### PR TITLE
Fix cli dict parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,26 @@ source .venv/bin/activate
 3. Install tau2
 
 ```bash
-pip install .
+pip install -e .
 ```
 
 This will enable you to run the `tau2` command.
+
+**Note:** If you use `pip install .` (without `-e`), you'll need to set the `TAU2_DATA_DIR` environment variable to point to your data directory:
+
+```bash
+export TAU2_DATA_DIR=/path/to/your/tau2-bench/data
+```
+
+**Check your data directory setup:**
+
+After installation, you can verify that your data directory is correctly configured by running:
+
+```bash
+tau2 check-data
+```
+
+This command will check if the data directory exists and print instructions if it is missing.
 
 To remove all the generated files and the virtual environment, run:
 ```bash
@@ -122,6 +138,12 @@ tau2 domain <domain>
 Visit http://127.0.0.1:8004/redoc to see the domain policy and API documentation.
 
 ![domain_viewer1](figs/domain_viewer.png)
+
+### Check data configuration
+```bash
+tau2 check-data
+```
+This command checks if your data directory is properly configured and all required files are present.
 
 ## Experiments
 

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -192,6 +192,12 @@ def main():
     start_parser = subparsers.add_parser("start", help="Start all servers")
     start_parser.set_defaults(func=lambda args: run_start_servers())
 
+    # Check data command
+    check_data_parser = subparsers.add_parser(
+        "check-data", help="Check if data directory is properly configured"
+    )
+    check_data_parser.set_defaults(func=lambda args: run_check_data())
+
     args = parser.parse_args()
     if not hasattr(args, "func"):
         parser.print_help()
@@ -220,6 +226,12 @@ def run_start_servers():
     from tau2.scripts.start_servers import main as start_main
 
     start_main()
+
+
+def run_check_data():
+    from tau2.scripts.check_data import main as check_data_main
+
+    check_data_main()
 
 
 if __name__ == "__main__":

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 
 from tau2.config import (
     DEFAULT_AGENT_IMPLEMENTATION,
@@ -49,9 +50,9 @@ def add_run_args(parser):
     )
     parser.add_argument(
         "--agent-llm-args",
-        type=dict,
+        type=json.loads,
         default={"temperature": DEFAULT_LLM_TEMPERATURE_AGENT},
-        help=f"The arguments to pass to the LLM for the agent. Default is temperature={DEFAULT_LLM_TEMPERATURE_AGENT}.",
+        help=f"The arguments to pass to the LLM for the agent. Default is '{\"temperature\": {DEFAULT_LLM_TEMPERATURE_AGENT}}'.",
     )
     parser.add_argument(
         "--user",
@@ -68,9 +69,9 @@ def add_run_args(parser):
     )
     parser.add_argument(
         "--user-llm-args",
-        type=dict,
+        type=json.loads,
         default={"temperature": DEFAULT_LLM_TEMPERATURE_USER},
-        help=f"The arguments to pass to the LLM for the user. Default is temperature={DEFAULT_LLM_TEMPERATURE_USER}.",
+        help=f"The arguments to pass to the LLM for the user. Default is '{\"temperature\": {DEFAULT_LLM_TEMPERATURE_USER}}'.",
     )
     parser.add_argument(
         "--task-set-name",

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -52,7 +52,7 @@ def add_run_args(parser):
         "--agent-llm-args",
         type=json.loads,
         default={"temperature": DEFAULT_LLM_TEMPERATURE_AGENT},
-        help=f"The arguments to pass to the LLM for the agent. Default is '{\"temperature\": {DEFAULT_LLM_TEMPERATURE_AGENT}}'.",
+        help=f"The arguments to pass to the LLM for the agent. Default is '{{\"temperature\": {DEFAULT_LLM_TEMPERATURE_AGENT}}}'.",
     )
     parser.add_argument(
         "--user",
@@ -71,7 +71,7 @@ def add_run_args(parser):
         "--user-llm-args",
         type=json.loads,
         default={"temperature": DEFAULT_LLM_TEMPERATURE_USER},
-        help=f"The arguments to pass to the LLM for the user. Default is '{\"temperature\": {DEFAULT_LLM_TEMPERATURE_USER}}'.",
+        help=f"The arguments to pass to the LLM for the user. Default is '{{\"temperature\": {DEFAULT_LLM_TEMPERATURE_USER}}}'.",
     )
     parser.add_argument(
         "--task-set-name",

--- a/src/tau2/registry.py
+++ b/src/tau2/registry.py
@@ -7,29 +7,29 @@ from pydantic import BaseModel
 from tau2.agent.base import BaseAgent
 from tau2.agent.llm_agent import LLMAgent, LLMGTAgent, LLMSoloAgent
 from tau2.data_model.tasks import Task
-from tau2.domains.airline.environment import (
-    get_environment as airline_domain_get_environment,
-)
-from tau2.domains.airline.environment import get_tasks as airline_domain_get_tasks
-from tau2.domains.mock.environment import get_environment as mock_domain_get_environment
+from tau2.domains.airline.environment import \
+    get_environment as airline_domain_get_environment
+from tau2.domains.airline.environment import \
+    get_tasks as airline_domain_get_tasks
+from tau2.domains.mock.environment import \
+    get_environment as mock_domain_get_environment
 from tau2.domains.mock.environment import get_tasks as mock_domain_get_tasks
-from tau2.domains.retail.environment import (
-    get_environment as retail_domain_get_environment,
-)
-from tau2.domains.retail.environment import get_tasks as retail_domain_get_tasks
-from tau2.domains.telecom.environment import (
-    get_environment_manual_policy as telecom_domain_get_environment_manual_policy,
-)
-from tau2.domains.telecom.environment import (
-    get_environment_workflow_policy as telecom_domain_get_environment_workflow_policy,
-)
-from tau2.domains.telecom.environment import get_tasks as telecom_domain_get_tasks
-from tau2.domains.telecom.environment import (
-    get_tasks_full as telecom_domain_get_tasks_full,
-)
-from tau2.domains.telecom.environment import (
-    get_tasks_small as telecom_domain_get_tasks_small,
-)
+from tau2.domains.retail.environment import \
+    get_environment as retail_domain_get_environment
+from tau2.domains.retail.environment import \
+    get_tasks as retail_domain_get_tasks
+from tau2.domains.telecom.environment import \
+    get_environment_manual_policy as \
+    telecom_domain_get_environment_manual_policy
+from tau2.domains.telecom.environment import \
+    get_environment_workflow_policy as \
+    telecom_domain_get_environment_workflow_policy
+from tau2.domains.telecom.environment import \
+    get_tasks as telecom_domain_get_tasks
+from tau2.domains.telecom.environment import \
+    get_tasks_full as telecom_domain_get_tasks_full
+from tau2.domains.telecom.environment import \
+    get_tasks_small as telecom_domain_get_tasks_small
 from tau2.environment.environment import Environment
 from tau2.user.base import BaseUser
 from tau2.user.user_simulator import DummyUser, UserSimulator
@@ -171,7 +171,7 @@ class Registry:
 # Create a global registry instance
 try:
     registry = Registry()
-    logger.info("Registering default components...")
+    logger.debug("Registering default components...")
     registry.register_user(UserSimulator, "user_simulator")
     registry.register_user(DummyUser, "dummy_user")
     registry.register_agent(LLMAgent, "llm_agent")
@@ -191,8 +191,6 @@ try:
     registry.register_tasks(telecom_domain_get_tasks_small, "telecom_small")
     registry.register_tasks(telecom_domain_get_tasks, "telecom")
     registry.register_tasks(telecom_domain_get_tasks, "telecom-workflow")
-    logger.info(
-        f"Default components registered successfully. Registry info: {json.dumps(registry.get_info().model_dump(), indent=2)}"
-    )
+    logger.debug(f"Default components registered successfully. Registry info: {json.dumps(registry.get_info().model_dump(), indent=2)}")
 except Exception as e:
     logger.error(f"Error initializing registry: {str(e)}")

--- a/src/tau2/scripts/check_data.py
+++ b/src/tau2/scripts/check_data.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+Script to check if the tau2 data directory is properly configured.
+"""
+
+import sys
+from pathlib import Path
+
+from tau2.utils.utils import DATA_DIR
+
+
+def main():
+    """Main function to check data directory."""
+    print("tau2 Data Directory Checker")
+    print("=" * 40)
+
+    print(f"Data directory: {DATA_DIR}")
+
+    if DATA_DIR.exists():
+        print("✅ Data directory exists")
+        print("You can now run tau2 commands.")
+    else:
+        print("❌ Data directory does not exist!")
+        print("\nTo fix this, you can:")
+        print("1. Set the TAU2_DATA_DIR environment variable:")
+        print("   export TAU2_DATA_DIR=/path/to/your/tau2-bench/data")
+        print("2. Or ensure the data directory exists in the expected location")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tau2/utils/utils.py
+++ b/src/tau2/utils/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -12,8 +13,26 @@ res = load_dotenv()
 if not res:
     logger.warning("No .env file found")
 
-SOURCE_DIR = Path(__file__).parents[3]
-DATA_DIR = SOURCE_DIR / "data"
+# Try to get data directory from environment variable first
+DATA_DIR_ENV = os.getenv("TAU2_DATA_DIR")
+
+if DATA_DIR_ENV:
+    # Use environment variable if set
+    DATA_DIR = Path(DATA_DIR_ENV)
+    logger.info(f"Using data directory from environment: {DATA_DIR}")
+else:
+    # Fallback to source directory (for development)
+    SOURCE_DIR = Path(__file__).parents[3]
+    DATA_DIR = SOURCE_DIR / "data"
+    logger.info(f"Using data directory from source: {DATA_DIR}")
+
+# Check if data directory exists and is accessible
+if not DATA_DIR.exists():
+    logger.warning(f"Data directory does not exist: {DATA_DIR}")
+    logger.warning(
+        "Set TAU2_DATA_DIR environment variable to point to your data directory"
+    )
+    logger.warning("Or ensure the data directory exists in the expected location")
 
 
 def get_dict_hash(obj: dict) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_data_dir_environment_variable():
+    """Test that DATA_DIR can be set via environment variable."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_data_dir = Path(temp_dir) / "custom_data"
+        temp_data_dir.mkdir()
+
+        with patch.dict(os.environ, {"TAU2_DATA_DIR": str(temp_data_dir)}):
+            # Re-import to get the new DATA_DIR value
+            import importlib
+
+            import tau2.utils.utils
+
+            importlib.reload(tau2.utils.utils)
+
+            assert tau2.utils.utils.DATA_DIR == temp_data_dir
+
+
+def test_data_dir_fallback_to_source():
+    """Test that DATA_DIR falls back to source directory when env var is not set."""
+    # Clear environment variable
+    with patch.dict(os.environ, {}, clear=True):
+        # Re-import to get the fallback DATA_DIR value
+        import importlib
+
+        import tau2.utils.utils
+
+        importlib.reload(tau2.utils.utils)
+
+        # Check that DATA_DIR points to the source directory
+        # Calculate expected path from utils.py location
+        utils_file = Path(tau2.utils.utils.__file__)
+        expected_source_dir = utils_file.parents[3] / "data"
+        assert tau2.utils.utils.DATA_DIR == expected_source_dir


### PR DESCRIPTION
There is no way for `dict` to parse a CLI string into a dictionary, so `type=dict` is simply non-functional. This change fixes that by allowing users to pass JSON strings at the CLI to configure LLMs. 

I am using this to pass `api_key` and `api_base` for self-hosted LLMs on an OpenAI API-like endpoint.

Partially resolves https://github.com/sierra-research/tau2-bench/issues/11