### PR TITLE
updated evaluator so that nl assertions are not run by default

### DIFF
--- a/src/tau2/evaluator/evaluator.py
+++ b/src/tau2/evaluator/evaluator.py
@@ -11,10 +11,11 @@ from tau2.registry import registry
 
 class EvaluationType(str, Enum):
     ENV = "env"
-    NL_ASSERTIONS = "nl_assertions"
     COMMUNICATE = "communicate"
     ACTION = "action"
     ALL = "all"
+    NL_ASSERTIONS = "nl_assertions"  # WIP
+    ALL_WITH_NL_ASSERTIONS = "all_with_nl_assertions"  # WIP
 
 
 def evaluate_simulation(
@@ -64,7 +65,7 @@ def evaluate_simulation(
             task=task,
             full_trajectory=simulation.messages,
         )
-    elif evaluation_type == EvaluationType.ALL:
+    elif evaluation_type in {EvaluationType.ALL, EvaluationType.ALL_WITH_NL_ASSERTIONS}:
         env_reward_info = EnvironmentEvaluator.calculate_reward(
             environment_constructor=registry.get_env_constructor(domain),
             task=task,
@@ -79,10 +80,12 @@ def evaluate_simulation(
             task=task,
             full_trajectory=simulation.messages,
         )
-        nl_reward_info = NLAssertionsEvaluator.calculate_reward(
-            task=task,
-            full_trajectory=simulation.messages,
-        )
+        nl_reward_info = None
+        if evaluation_type == EvaluationType.ALL_WITH_NL_ASSERTIONS:
+            nl_reward_info = NLAssertionsEvaluator.calculate_reward(
+                task=task,
+                full_trajectory=simulation.messages,
+            )
 
         ## Combine all the rewards.
         reward = 1.0
@@ -102,6 +105,10 @@ def evaluate_simulation(
                 reward_breakdown.update(action_reward_info.reward_breakdown)
             reward *= action_reward_info.reward
         if task_reward_basis & nl_bases:
+            if evaluation_type != EvaluationType.ALL_WITH_NL_ASSERTIONS:
+                raise ValueError(
+                    "NL assertions are part of the reward basis, but they are not being evaluated."
+                )
             if nl_reward_info.reward_breakdown is not None:
                 reward_breakdown.update(nl_reward_info.reward_breakdown)
             reward *= nl_reward_info.reward
@@ -115,13 +122,15 @@ def evaluate_simulation(
             db_check=env_reward_info.db_check,
             env_assertions=env_reward_info.env_assertions,
             action_checks=action_reward_info.action_checks,
-            nl_assertions=nl_reward_info.nl_assertions,
+            nl_assertions=nl_reward_info.nl_assertions
+            if nl_reward_info is not None
+            else None,
             communicate_checks=communicate_reward_info.communicate_checks,
             reward_basis=task.evaluation_criteria.reward_basis,
             reward_breakdown=reward_breakdown,
             info={
                 "env": env_reward_info.info,
-                "nl": nl_reward_info.info,
+                "nl": nl_reward_info.info if nl_reward_info is not None else None,
                 "communicate": communicate_reward_info.info,
                 "action": action_reward_info.info,
             },


### PR DESCRIPTION
NL Assertions were introduced to provide extra checks on the agent's behavior but are not used in the final calculation of the reward. By default they are not run anymore to avoid creating confusion and extra cost.