### PR TITLE
Fix temporal impossibility in airline evaluation tasks

### DIFF
--- a/data/tau2/domains/airline/db.json
+++ b/data/tau2/domains/airline/db.json
@@ -164945,28 +164945,28 @@
                     "origin": "ORD",
                     "destination": "DEN",
                     "flight_number": "HAT238",
-                    "date": "2024-05-14",
+                    "date": "2024-05-20",
                     "price": 96
                 },
                 {
                     "origin": "DEN",
                     "destination": "LAS",
                     "flight_number": "HAT290",
-                    "date": "2024-05-14",
+                    "date": "2024-05-20",
                     "price": 64
                 },
                 {
                     "origin": "LAS",
                     "destination": "IAH",
                     "flight_number": "HAT266",
-                    "date": "2024-05-16",
+                    "date": "2024-05-22",
                     "price": 70
                 },
                 {
                     "origin": "IAH",
                     "destination": "ORD",
                     "flight_number": "HAT044",
-                    "date": "2024-05-16",
+                    "date": "2024-05-22",
                     "price": 76
                 }
             ],
@@ -185088,14 +185088,14 @@
                     "origin": "MCO",
                     "destination": "PHX",
                     "flight_number": "HAT214",
-                    "date": "2024-05-13",
+                    "date": "2024-05-20",
                     "price": 1377
                 },
                 {
                     "origin": "PHX",
                     "destination": "SEA",
                     "flight_number": "HAT045",
-                    "date": "2024-05-14",
+                    "date": "2024-05-21",
                     "price": 1712
                 }
             ],

--- a/data/tau2/domains/airline/tasks.json
+++ b/data/tau2/domains/airline/tasks.json
@@ -555,7 +555,7 @@
             "nl_assertions": [
                 "Check that Agent does not cancel IFOYYZ. Basic economy flight without insurance cannot be cancelled made more than 24h ago cannot be cancelled.",
                 "Check that Agent cancelled NQNU5R.",
-                "Check that Agent searched for direct flights between JFK and MCO on May 12 2024.",
+                "Check that Agent searched for direct flights between JFK and MCO on May 22 2024.",
                 "Reservation M20IZO is not modified by Agent."
             ]
         },


### PR DESCRIPTION
## Summary
Fixed issues where evaluations expected agents to cancel or modify reservations with already-flown flights, which violates airline policy.

## Problem
The airline policy states: "If any portion of the flight has already been flown, the agent cannot help and transfer is needed."

However, with the current time hardcoded at `2024-05-15 15:00:00`, several problems expected actions on flights that had already occurred:
- **Problem 9**: Expected cancellation of NQNU5R (flights on May 13-14) 
- **Problem 36**: Expected changes to EUJUY6 (flights on May 14 and 16)
- **Problem 37**: Expected cancellation of NQNU5R (flights on May 13-14)

## Changes
- Updated NQNU5R reservation flights from May 13-14 to May 20-21 (affects Problems 9 & 37)
- Updated EUJUY6 reservation flights from May 14/16 to May 20/22 (affects Problem 36)
- Fixed assertion typo in Problem 9 (May 12 → May 22 to match the action check date)

## Impact
These changes ensure evaluations don't expect policy violations while preserving the original test intent. Agents can now correctly perform the expected actions without violating the temporal constraints.

🤖 Generated with [Claude Code](https://claude.ai/code)