### PR TITLE
Fix Problem 35: Correct user DOB to match profile

### DIFF
--- a/data/tau2/domains/airline/tasks.json
+++ b/data/tau2/domains/airline/tasks.json
@@ -2279,7 +2279,7 @@
                             {
                                 "first_name": "Aarav",
                                 "last_name": "Ahmed",
-                                "dob": "1985-04-04"
+                                "dob": "1981-05-26"
                             }
                         ],
                         "payment_methods": [


### PR DESCRIPTION
## Summary
Fixed Problem 35 where the expected date of birth didn't match the user's actual profile.

## Problem
The evaluation expected DOB "1985-04-04" for user aarav_ahmed_6699, but the user's actual DOB in the database is "1981-05-26".

## Changes
- Updated the expected DOB in the booking action (line 2282) from "1985-04-04" to "1981-05-26"

## Impact
This ensures the evaluation checks for the correct date of birth that matches the user's profile, allowing agents to pass when they correctly use the user's information from the database.

🤖 Generated with [Claude Code](https://claude.ai/code)