### PR TITLE
Fix Problem 14: Correct cost calculations in description and assertions

### DIFF
--- a/data/tau2/domains/airline/tasks.json
+++ b/data/tau2/domains/airline/tasks.json
@@ -755,7 +755,7 @@
     {
         "id": "14",
         "description": {
-            "purpose": "Test the capacity of the agent to look for the cheapest flights with constraints on dates, cities and cabin. \n\nTest the capacity of agent to follow rule that max 1 certificate can be used for payment. \n\n\nTest capacity of agents to reason about money amounts.\n\nThe user has multiple certificates, gift cards and 2 credit cards one file. for the payment, we expect agent to understand how to maximize use of gift card + 1 certificate to minimize amount put on the credit card.\n\nThe total cost of the new flight will be $871. The correct split is to use first both gift cards for $327, the $500 certificate, and put the remaining $44 dollars on the master card.",
+            "purpose": "Test the capacity of the agent to look for the cheapest flights with constraints on dates, cities and cabin. \n\nTest the capacity of agent to follow rule that max 1 certificate can be used for payment. \n\n\nTest capacity of agents to reason about money amounts.\n\nThe user has multiple certificates, gift cards and 2 credit cards one file. for the payment, we expect agent to understand how to maximize use of gift card + 1 certificate to minimize amount put on the credit card.\n\nThe total cost of the new flight will be $2613. The correct split is to use first both gift cards for $327, the $500 certificate, and put the remaining $1786 dollars on the master card.",
             "relevant_policies": null,
             "notes": null
         },
@@ -848,14 +848,14 @@
             "communicate_info": [
                 "327",
                 "1000",
-                "44"
+                "1786"
             ],
             "nl_assertions": [
                 "Agent communicates that total gift card balance is $327.",
                 "Agent communicates that total certificate balance if $1000.",
                 "Agent should cancel reservation K1NW8N.",
                 "Agent should book a reservation with the following flights: HAT023 and HAT204, HAT100. No insurance. No baggage. Departure on 2024-05-26, return on 2024-05-28.",
-                "Agent communicated that the $44 will be charged to the mastercard."
+                "Agent communicated that the $1786 will be charged to the mastercard."
             ]
         },
         "annotations": null


### PR DESCRIPTION
## Summary
Fixed incorrect cost information in Problem 14's description that didn't match the mathematically correct expected actions.

## Problem
The problem description contained inconsistent cost calculations:
- Claimed total cost would be **$871** 
- Claimed mastercard charge would be **$44**
- But expected actions showed **$1786** mastercard charge (which is correct)

## Root Cause
The description showed **per-passenger costs** ($871) but the booking is for **3 passengers**:
- Actual total: $871 × 3 = $2613
- This created confusion between the description and expected actions

## Changes
Updated problem description and assertions to match the mathematically correct amounts:
- **Total cost**: $871 → $2613 (for 3 passengers)
- **Mastercard charge**: $44 → $1786 
- **communicate_info**: "44" → "1786"
- **NL assertion**: "$44" → "$1786"

## Math Verification
- Business class cost: $871 per passenger × 3 passengers = $2613 total
- Available payment: $500 (max 1 certificate per policy) + $327 (gift cards) = $827
- Mastercard charge: $2613 - $827 = **$1786** ✓

## Impact
The expected actions were already mathematically correct and policy-compliant. This fix makes the problem description internally consistent and removes confusion for evaluators.

🤖 Generated with [Claude Code](https://claude.ai/code)