### PR TITLE
Fix Problem 32: Clarify user preference for two-step process

### DIFF
--- a/data/tau2/domains/airline/tasks.json
+++ b/data/tau2/domains/airline/tasks.json
@@ -2039,7 +2039,7 @@
         "user_scenario": {
             "persona": null,
             "instructions": {
-                "task_instructions": "If the agent says your ticket is a basic economy one, you are willing to upgrade to economy in order to make the change.\n\nYou are willing to pay up to $100 for the change.\n\nYou don't want to buy a new ticket.",
+                "task_instructions": "If the agent says your ticket is a basic economy one, you want them to first upgrade you to economy and confirm that change, then separately change the flights to nonstop. You want to see both steps completed individually so you can verify each change.\n\nYou are willing to pay up to $100 for the change.\n\nYou don't want to buy a new ticket.",
                 "domain": "airline",
                 "reason_for_call": "You want to change your upcoming flight from EWR on May 21 to a nonstop flight on the same day. \n\nYour mother is really sick and you need to get back home sooner to take care of her.",
                 "known_info": "You are Ivan Rossi.\nYour user id is ivan_rossi_8555.",


### PR DESCRIPTION
## Summary
Fixed Problem 32 where agents failed evaluation for using an efficient single-step approach instead of the expected two-step process.

## Problem
Agents were failing when they used a single `update_reservation_flights` call to both:
1. Upgrade cabin from basic economy to economy 
2. Change flights to nonstop

This achieved the same result more efficiently but failed database state checks because the expected payment history assumed a two-step process.

## Root Cause
The user instructions didn't clearly indicate they wanted a two-step process, so efficient agents naturally used a single API call.

## Solution
Updated user instructions to explicitly request step-by-step changes:
- User now asks to "first upgrade you to economy and confirm that change"
- Then "separately change the flights to nonstop"  
- Added justification: "You want to see both steps completed individually so you can verify each change"

## Impact
This change:
- Makes the two-step process **user-driven** rather than arbitrary
- Maintains realism (stressed passenger wanting confirmation during emergency)
- Preserves evaluation framework without changes
- Ensures agents follow the expected workflow for proper database state matching

The evaluation now tests agents' ability to follow explicit user preferences for sequential operations, not just their understanding of efficient API usage.

🤖 Generated with [Claude Code](https://claude.ai/code)