### PR TITLE
Fix Problem 15: Clarify ambiguous 'cheapest economy flight' terminology

### DIFF
--- a/data/tau2/domains/airline/tasks.json
+++ b/data/tau2/domains/airline/tasks.json
@@ -863,7 +863,7 @@
     {
         "id": "15",
         "description": {
-            "purpose": "Test finding cheapest economy flight on the next day. Multiple airports to consider. Testing understanding that policy forbids changing origin or destination of a reservation.",
+            "purpose": "Test finding cheapest Economy cabin class flight (not Basic Economy) on the next day. Multiple airports to consider. Testing understanding that policy forbids changing origin or destination of a reservation.",
             "relevant_policies": null,
             "notes": null
         },
@@ -872,7 +872,7 @@
             "instructions": {
                 "task_instructions": "Since you live in Princeton, so EWR and PHL are equally convenient for you and you want to consider both.\n\nYou are happy with original payment for refund.",
                 "domain": "airline",
-                "reason_for_call": "For your upcoming trip from ATL to PHL, you want to change for the cheapest economy flight and for the day after the original reservation.",
+                "reason_for_call": "For your upcoming trip from ATL to PHL, you want to change to the cheapest flight in Economy cabin class (not Basic Economy) for the day after the original reservation.",
                 "known_info": "Your name is Aarav Garcia.\n\nYour user id is aarav_garcia_1177.",
                 "unknown_info": null
             }
@@ -912,7 +912,7 @@
     {
         "id": "16",
         "description": {
-            "purpose": "Test finding cheapest economy flight on the next day.",
+            "purpose": "Test finding cheapest Economy cabin class flight (not Basic Economy) on the next day.",
             "relevant_policies": null,
             "notes": null
         },
@@ -921,7 +921,7 @@
             "instructions": {
                 "task_instructions": "You are happy with original payment for refund.",
                 "domain": "airline",
-                "reason_for_call": "For your upcoming trip from ATL to PHL, you want to change for the cheapest economy flight and for the day after the original reservation.",
+                "reason_for_call": "For your upcoming trip from ATL to PHL, you want to change to the cheapest flight in Economy cabin class (not Basic Economy) for the day after the original reservation.",
                 "known_info": "Your name is Aarav Garcia.\n\nYour user id is aarav_garcia_1177.",
                 "unknown_info": null
             }


### PR DESCRIPTION
## Summary
Fixed Problem 15 where ambiguous terminology caused agents to reasonably choose Basic Economy instead of the expected Economy cabin class.

## Problem
The user request asked for "the cheapest economy flight" which is ambiguous:
- Could mean the cheapest flight overall → Basic Economy at $124 (ATL→DFW→EWR)
- Could mean the cheapest flight in Economy cabin class → Economy at $207 (ATL→LGA→PHL)

Well-functioning agents reasonably interpret "cheapest economy" as the lowest cost option and choose Basic Economy, causing them to fail the evaluation.

## Solution
Clarified the user request to explicitly specify Economy cabin class:
- Changed: "cheapest economy flight"
- To: "cheapest flight in Economy cabin class (not Basic Economy)"

## Analysis
Available options on May 24:
- **ATL→DFW→EWR**: Basic Economy $124, Economy $243
- **ATL→ORD→PHL**: Basic Economy $140, Economy $216  
- **ATL→LGA→PHL**: Basic Economy $141, Economy $207 (expected answer)

The evaluation expects Economy class at $207, but agents choosing Basic Economy at $124 are making a reasonable interpretation of "cheapest economy flight."

## Changes
- Updated `reason_for_call` in both Problem 15 and 16 (identical scenarios)
- Updated `purpose` descriptions to explicitly mention "Economy cabin class (not Basic Economy)"

## Policy Reference
From the airline policy: "basic economy is its own class, completely distinct from economy"

This distinction needs to be explicit in user requests to avoid ambiguity.

## Impact
Agents will now understand they should search specifically for Economy cabin class, not just the overall cheapest option.

🤖 Generated with [Claude Code](https://claude.ai/code)