### PR TITLE
Fix Problem 23: Clarify description about multiple bookings requirement

### DIFF
--- a/data/tau2/domains/airline/tasks.json
+++ b/data/tau2/domains/airline/tasks.json
@@ -1432,7 +1432,7 @@
     {
         "id": "23",
         "description": {
-            "purpose": "Complex transaction where multiple bookings need to be made with payment efficiently split across them to minimize charges to a Mastercard.",
+            "purpose": "Complex transaction testing understanding of one-certificate-per-reservation policy. Multiple bookings must be made to use three certificates, with payment efficiently split across them to minimize charges to a Mastercard.",
             "relevant_policies": null,
             "notes": null
         },


### PR DESCRIPTION
## Summary
Updated Problem 23's description to be clearer about why multiple bookings are required in this scenario.

## Context
Problem 23 is working correctly - it tests whether agents understand the one-certificate-per-reservation policy. However, the description could be clearer about WHY multiple bookings are needed.

## Change
Updated the purpose description to explicitly mention the policy constraint:
- **Before**: "Complex transaction where multiple bookings need to be made with payment efficiently split across them to minimize charges to a Mastercard."
- **After**: "Complex transaction testing understanding of one-certificate-per-reservation policy. Multiple bookings must be made to use three certificates, with payment efficiently split across them to minimize charges to a Mastercard."

## Why This Helps
The clarified description helps developers and evaluators understand that:
1. The multiple bookings are not arbitrary
2. They are specifically required due to the one-certificate-per-reservation policy
3. The scenario tests policy understanding, not just transaction complexity

## Policy Reference
From `/data/tau2/domains/airline/policy.md`:
> Each reservation can use at most one travel certificate, at most one credit card, and at most three gift cards.

Since the user has three certificates to use, three separate bookings are required.

🤖 Generated with [Claude Code](https://claude.ai/code)