### PR TITLE
feat: add Gemini 3 Pro thought signature support

### DIFF
--- a/src/tau2/utils/llm_utils.py
+++ b/src/tau2/utils/llm_utils.py
@@ -157,13 +157,16 @@ def to_litellm_messages(messages: list[Message]) -> list[dict]:
                     }
                     for tc in message.tool_calls
                 ]
-            litellm_messages.append(
-                {
-                    "role": "assistant",
-                    "content": message.content,
-                    "tool_calls": tool_calls,
-                }
-            )
+            if message.raw_data:
+                litellm_messages.append(message.raw_data["message"])
+            else:
+                litellm_messages.append(
+                    {
+                        "role": "assistant",
+                        "content": message.content,
+                        "tool_calls": tool_calls,
+                    }
+                )
         elif isinstance(message, ToolMessage):
             litellm_messages.append(
                 {


### PR DESCRIPTION
**Add Gemini 3 Pro thought signature support**

Gemini 3 Pro enforces stricter validation on thought signatures for multi-turn function calling. This PR adds support for preserving and returning thought signatures to maintain reasoning context across conversation turns.

Without this fix, requests to Gemini 3 Pro return a 400 error when required thought signatures are missing.

**References:**
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures
- https://docs.litellm.ai/docs/providers/gemini#thought-signatures