### PR TITLE
[AgentBeats] Configure issue template chooser YAML

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Sierra admin
+    url: https://github.com/sierra-research/tau2-bench/issues
+    about: Please check existing issues before submitting


### PR DESCRIPTION
Configure issue template chooser via YAML to require use of specific contributing guidelines.