### PR TITLE
fix: update leaderboard submission validation and clarify submission types

### DIFF
--- a/src/tau2/scripts/leaderboard/prepare_submission.py
+++ b/src/tau2/scripts/leaderboard/prepare_submission.py
@@ -46,7 +46,7 @@ def check_and_load_submission_data(
     # Check that trajectory files directory exists
     trajectory_files_dir = Path(submission_dir) / TRAJECTORY_FILES_DIR_NAME
     if not trajectory_files_dir.exists():
-        return False, f"Trajectory files directory {trajectory_files_dir} not found"
+        return False, f"Trajectory files directory {trajectory_files_dir} not found", None
 
     # Get trajectory files
     trajectory_files = expand_paths([trajectory_files_dir], extension=".json")
@@ -159,12 +159,12 @@ def get_metrics(
         # Compute metrics for this trajectory file
         metrics = compute_metrics(results)
         domain_metrics[domain] = metrics
-        # Create DomainResults object
+        # Create DomainResults object (multiply by 100 to convert to percentage)
         domain_results[domain] = DomainResults(
-            pass_1=metrics.pass_hat_ks.get(1),
-            pass_2=metrics.pass_hat_ks.get(2),
-            pass_3=metrics.pass_hat_ks.get(3),
-            pass_4=metrics.pass_hat_ks.get(4),
+            pass_1=metrics.pass_hat_ks.get(1) * 100,
+            pass_2=metrics.pass_hat_ks.get(2) * 100,
+            pass_3=metrics.pass_hat_ks.get(3) * 100,
+            pass_4=metrics.pass_hat_ks.get(4) * 100,
             cost=metrics.avg_agent_cost,
         )
 
@@ -356,7 +356,13 @@ def prepare_submission(
     user_simulator = Prompt.ask(
         "Enter user simulator model", default=default_user_simulator
     )
-    organization = Prompt.ask("Enter organization name", default="My-Organization")
+    model_organization = Prompt.ask(
+        "Enter model organization (who developed the model)", default="My-Organization"
+    )
+    submitting_organization = Prompt.ask(
+        "Enter submitting organization (who ran the evaluation)",
+        default=model_organization,
+    )
     email = Prompt.ask("Enter contact email")
 
     # Optional information
@@ -401,7 +407,8 @@ def prepare_submission(
 
     submission = Submission(
         model_name=model_name,
-        organization=organization,
+        model_organization=model_organization,
+        submitting_organization=submitting_organization,
         submission_date=date.today(),
         contact_info=contact_info,
         results=results_obj,

--- a/src/tau2/scripts/leaderboard/submission.py
+++ b/src/tau2/scripts/leaderboard/submission.py
@@ -1,12 +1,40 @@
 """Pydantic models for tau2-bench leaderboard submissions."""
 
 from datetime import date
-from typing import Optional
+from enum import Enum
+from typing import Literal, Optional
 
 from pydantic import Field
 
 from tau2.data_model.simulation import Results as TrajectoryResults
 from tau2.utils.pydantic_utils import BaseModelNoExtra
+
+
+class SubmissionType(str, Enum):
+    """Type of submission."""
+
+    STANDARD = "standard"
+    CUSTOM = "custom"
+
+
+class ReferenceType(str, Enum):
+    """Type of reference."""
+
+    PAPER = "paper"
+    BLOG_POST = "blog_post"
+    DOCUMENTATION = "documentation"
+    MODEL_CARD = "model_card"
+    GITHUB = "github"
+    HUGGINGFACE = "huggingface"
+    OTHER = "other"
+
+
+class Reference(BaseModelNoExtra):
+    """Reference to a paper, blog post, or other resource."""
+
+    title: str = Field(..., description="Title or description of the reference")
+    url: str = Field(..., description="URL to the reference")
+    type: Optional[ReferenceType] = Field(None, description="Type of reference")
 
 
 class ContactInfo(BaseModelNoExtra):
@@ -60,6 +88,21 @@ class Results(BaseModelNoExtra):
             raise ValueError(f"Invalid domain: {domain}")
 
 
+class Verification(BaseModelNoExtra):
+    """Verification details for result authenticity."""
+
+    modified_prompts: bool = Field(
+        ...,
+        description="Whether any modifications were made to user simulator or agent prompts",
+    )
+    omitted_questions: bool = Field(
+        ..., description="Whether any questions/tasks were omitted from the evaluation"
+    )
+    details: Optional[str] = Field(
+        None, description="Additional verification details or explanations"
+    )
+
+
 class Methodology(BaseModelNoExtra):
     """Information about how the evaluation was conducted."""
 
@@ -76,14 +119,21 @@ class Methodology(BaseModelNoExtra):
     notes: Optional[str] = Field(
         None, description="Additional notes about the evaluation methodology"
     )
+    verification: Optional[Verification] = Field(
+        None, description="Verification details for result authenticity"
+    )
 
 
 class Submission(BaseModelNoExtra):
     """Tau2-Bench Leaderboard Submission model."""
 
     model_name: str = Field(..., description="Name of the model being evaluated")
-    organization: str = Field(
+    model_organization: str = Field(
         ..., description="Organization or company that developed the model"
+    )
+    submitting_organization: str = Field(
+        ...,
+        description="Organization that actually ran the evaluation and submitted the results",
     )
     submission_date: date = Field(..., description="Date of submission")
     contact_info: ContactInfo = Field(..., description="Contact information")
@@ -91,6 +141,17 @@ class Submission(BaseModelNoExtra):
     is_new: bool = Field(
         False,
         description="Whether this model should be highlighted as new on the leaderboard",
+    )
+    submission_type: SubmissionType = Field(
+        SubmissionType.STANDARD,
+        description="Type of submission: 'standard' uses the default tau2-bench scaffold, 'custom' uses modified scaffolds",
+    )
+    trajectories_available: bool = Field(
+        False, description="Whether trajectory files are available for this submission"
+    )
+    references: Optional[list[Reference]] = Field(
+        None,
+        description="Links to papers, blog posts, documentation, or other resources about this model",
     )
     methodology: Optional[Methodology] = Field(
         None, description="Information about how the evaluation was conducted"
@@ -103,8 +164,10 @@ class Submission(BaseModelNoExtra):
             "examples": [
                 {
                     "model_name": "GPT-4.1",
-                    "organization": "OpenAI",
+                    "model_organization": "OpenAI",
+                    "submitting_organization": "OpenAI",
                     "submission_date": "2024-01-15",
+                    "submission_type": "standard",
                     "contact_info": {
                         "email": "researcher@openai.com",
                         "name": "Jane Doe",
@@ -132,11 +195,17 @@ class Submission(BaseModelNoExtra):
                         },
                     },
                     "is_new": True,
+                    "trajectories_available": True,
                     "methodology": {
                         "evaluation_date": "2024-01-10",
                         "tau2_bench_version": "1.0.0",
                         "user_simulator": "gpt-4.1",
                         "notes": "Evaluated using default configuration with 4 trials per task",
+                        "verification": {
+                            "modified_prompts": False,
+                            "omitted_questions": False,
+                            "details": "Standard evaluation with no modifications",
+                        },
                     },
                 }
             ]

--- a/web/leaderboard/SUBMISSION_GUIDE.md
+++ b/web/leaderboard/SUBMISSION_GUIDE.md
@@ -7,18 +7,29 @@ This repository supports community submissions to the leaderboard through pull r
 The leaderboard distinguishes between two types of submissions:
 
 ### Standard Submissions (Default)
-Standard submissions use the **default τ-bench scaffold**:
-- A base LLM as the agent
+Standard submissions evaluate a **general-purpose LLM** using the **default τ-bench scaffold**:
+- A general-purpose LLM as the agent (not specifically trained for this benchmark)
 - The standard tool set provided by τ-bench
 - Default prompts and evaluation protocol
+- No modifications to the evaluation setup
 
-If you're running τ-bench as documented without modifications, your submission is **standard**. You don't need to specify `submission_type` in your JSON (it defaults to `"standard"`).
+If you're evaluating an off-the-shelf LLM using τ-bench as documented without modifications, your submission is **standard**. You don't need to specify `submission_type` in your JSON (it defaults to `"standard"`).
 
 ### Custom Submissions
-Custom submissions use **modified scaffolds or approaches**, such as:
+Custom submissions include **any approach that differs from the standard evaluation**, such as:
+
+**Modified Scaffolds:**
 - Multi-model routers or model ensembles
 - Additional tools beyond the standard τ-bench tool set
 - Modified agent orchestration or control flow
+- Modified prompts or system instructions
+
+**Domain-Specific Training:**
+- Models trained or fine-tuned specifically on τ-bench domains (airline, retail, telecom customer service)
+- Models trained using τ-bench tasks, reward signals, or evaluation data
+- Models where training data significantly overlaps with τ-bench evaluation scenarios
+
+**Other Modifications:**
 - Any other modifications to the default evaluation setup
 
 **⚠️ Requirements for Custom Submissions:**
@@ -29,16 +40,18 @@ Custom submissions **must** include detailed methodology documentation:
 
 2. **Provide comprehensive `methodology.notes`** explaining:
    - What modifications were made to the standard scaffold
+   - If domain-trained: describe the training approach, data sources, and any overlap with τ-bench domains or tasks
    - Why these modifications were made
    - How the custom system works at a high level
 
 3. **Link to your implementation** in the `references` array:
    - Include a GitHub link to your code/fork
+   - Link to the paper describing your training methodology (if applicable)
    - Provide documentation or a blog post if available
 
 4. **Set `methodology.verification.modified_prompts` to `true`** if you modified any prompts
 
-Example methodology section for a custom submission:
+**Example 1:** Custom scaffold with modified prompts
 ```json
 {
   "submission_type": "custom",
@@ -58,6 +71,36 @@ Example methodology section for a custom submission:
       "title": "Our Custom Agent Implementation",
       "url": "https://github.com/example/custom-tau-agent",
       "type": "github"
+    }
+  ]
+}
+```
+
+**Example 2:** Domain-trained model
+```json
+{
+  "submission_type": "custom",
+  "methodology": {
+    "evaluation_date": "2025-01-15",
+    "tau2_bench_version": "0.2.0",
+    "user_simulator": "gpt-4o",
+    "notes": "This model was post-trained using RL on customer service scenarios including airline and retail domains. Training data was synthetically generated based on similar task distributions. The model uses the standard τ-bench scaffold without prompt modifications.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard evaluation protocol. Model was trained on data overlapping with τ-bench domains."
+    }
+  },
+  "references": [
+    {
+      "title": "Our Training Methodology Paper",
+      "url": "https://arxiv.org/abs/xxxx.xxxxx",
+      "type": "paper"
+    },
+    {
+      "title": "Model Weights on HuggingFace",
+      "url": "https://huggingface.co/example/our-agent-model",
+      "type": "huggingface"
     }
   ]
 }


### PR DESCRIPTION
Submission model changes:
- Sync Pydantic model with schema.json (add model_organization, submitting_organization, submission_type, trajectories_available, references, and Verification fields)
- Make contact_info.email required per schema.json
- Make verification.modified_prompts and omitted_questions required when verification is present

Validation fixes:
- Fix missing return value in check_and_load_submission_data
- Fix percentage scaling in get_metrics (multiply by 100)

SUBMISSION_GUIDE updates:
- Clarify standard submissions are for general-purpose LLMs only
- Add "Domain-Specific Training" as custom submission category for models trained on τ-bench domains (airline, retail, telecom)
- Add example for domain-trained model submissions