### PR TITLE
feat: add auto-discovery for community-contributed experimental domains

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,14 +240,47 @@ Brief description of the changes made.
 ## 🎯 Specific Contribution Guidelines
 
 ### Domain Contributions
-When contributing a new domain:
-- **Complete implementation**: Include all required components (tools, tasks, policy, tests)
-- **Documentation**: Comprehensive README with domain overview, API docs, and examples
-- **Test coverage**: Full test suite covering all domain functionality
-- **Data validation**: Ensure all domain data is properly validated
+
+There are two types of domain contributions:
+
+#### Core Domains (`src/tau2/domains/`)
+Core domains are part of the official τ²-bench benchmark and are maintained by Sierra. Core domain contributions:
+- Require thorough review and approval
+- Must include complete implementation (tools, tasks, policy, tests)
+- Are registered in the domain registry
+- Contribute to official benchmark results and leaderboard
+
+#### Community-Contributed Domains (`src/experiments/domains/`)
+Community domains are contributed by external developers and live in the experiments directory. They:
+- Are self-contained with their own data, tests, and documentation
+- Are auto-discovered and registered with an `experimental:` prefix (e.g., `experimental:airline_sapconcur`)
+- Can be used via CLI: `tau2 run --domain "experimental:<domain_name>" ...`
+- Can include the original contributor's code for reference
+- May be promoted to core domains after review and adoption
+
+**Structure for community domains:**
+```
+src/experiments/domains/<domain_name>/
+├── original/            # Original contributor's code (optional, for reference)
+├── domain/              # Clean tau2-compatible implementation
+│   ├── __init__.py
+│   ├── data_model.py    # Pydantic DB model
+│   ├── tools.py         # ToolKit implementation
+│   ├── environment.py   # get_environment() and get_tasks()
+│   └── tests/           # Unit tests
+├── data/                # Domain data (db.json, policy.md, tasks.json)
+└── README.md            # Documentation and attribution
+```
+
+**Requirements for community domains:**
+- **Attribution**: Proper credit to original contributors in README and source files
+- **Documentation**: Comprehensive README with usage instructions
+- **Self-contained data**: Include all data files within the domain directory
+- **Basic tests**: Include unit tests for core functionality
+- **Demo script**: Provide a demo.py for easy testing without registry integration
 
 ### Experimental Contributions
-For `src/experiments/` contributions:
+For other `src/experiments/` contributions (non-domain):
 - **Self-contained**: Keep experimental code isolated within the experiments directory
 - **Documentation**: Include detailed README explaining the experiment and usage
 - **Dependencies**: Manage dependencies carefully to avoid conflicts with core framework

--- a/src/experiments/README.md
+++ b/src/experiments/README.md
@@ -12,6 +12,63 @@ The `experiments/` folder is used for experimental features and research code th
 
 This directory is organized into subdirectories for different types of experimental components. Each subdirectory should contain its own README with specific documentation and usage instructions.
 
+```
+experiments/
+├── domains/              # Community-contributed domains
+├── hyperparam/           # Hyperparameter tuning experiments
+└── agentify_tau_bench/   # Agent framework experiments
+```
+
+### Community-Contributed Domains (`domains/`)
+
+The `domains/` subdirectory contains community-contributed tau2 domains that are not part of the core benchmark but follow tau2 domain conventions. These domains:
+
+- **Are self-contained**: Include their own data, tests, and documentation
+- **Follow tau2 conventions**: Implement `get_environment()`, `get_tasks()`, and proper tool structure
+- **Are auto-discovered**: Registered automatically with an `experimental:` prefix
+- **May include original code**: Can bundle the contributor's original code for reference
+
+#### Structure for Contributed Domains
+
+```
+domains/<domain_name>/
+├── original/            # Original contributor's code (optional, for reference)
+├── domain/              # Clean tau2-compatible implementation
+│   ├── __init__.py
+│   ├── data_model.py    # Pydantic DB model
+│   ├── tools.py         # ToolKit implementation
+│   ├── environment.py   # get_environment() and get_tasks()
+│   └── tests/           # Unit tests
+├── data/                # Domain data (db.json, policy.md, tasks.json)
+└── README.md            # Documentation and attribution
+```
+
+#### Using a Contributed Domain
+
+**Via CLI** (auto-discovered with `experimental:` prefix):
+```bash
+tau2 run --domain "experimental:<domain_name>" --agent-llm gpt-4o-mini --user-llm gpt-4o-mini
+```
+
+**Via Python** (direct import):
+```python
+from experiments.domains.<domain_name>.domain import (
+    get_environment,
+    get_tasks,
+)
+
+env = get_environment()
+tasks = get_tasks()
+```
+
+**Via Registry**:
+```python
+from tau2.registry import registry
+
+env_constructor = registry.get_env_constructor("experimental:<domain_name>")
+env = env_constructor()
+```
+
 ## Quick Start
 
 To contribute experimental code:

--- a/src/experiments/domains/__init__.py
+++ b/src/experiments/domains/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Sierra
+"""Community-contributed domains for tau2."""

--- a/src/tau2/registry.py
+++ b/src/tau2/registry.py
@@ -1,4 +1,6 @@
+import importlib
 import json
+from pathlib import Path
 from typing import Callable, Dict, Optional, Type
 
 from loguru import logger
@@ -247,5 +249,115 @@ try:
     logger.debug(
         f"Default components registered successfully. Registry info: {json.dumps(registry.get_info().model_dump(), indent=2)}"
     )
+
+    # Auto-discover experimental domains from experiments/domains/
+    def discover_experimental_domains(reg: Registry) -> None:
+        """
+        Auto-discover and register domains from experiments/domains/.
+
+        Scans the experiments/domains/ directory for valid domain implementations
+        and registers them automatically. A valid domain must have:
+        - A domain/ subdirectory with __init__.py
+        - get_environment and get_tasks functions exported from domain/__init__.py
+
+        If a domain exports ENVIRONMENT_VARIANTS dict, each variant is also
+        registered as a separate domain (e.g., experimental:domain_m01).
+
+        Failed registrations are logged as warnings but don't prevent other domains
+        from being registered.
+        """
+        # Path to experiments/domains/ relative to this file
+        experiments_domains_dir = (
+            Path(__file__).parent.parent / "experiments" / "domains"
+        )
+
+        if not experiments_domains_dir.exists():
+            logger.debug(
+                "No experiments/domains/ directory found, skipping auto-discovery"
+            )
+            return
+
+        for domain_dir in experiments_domains_dir.iterdir():
+            if not domain_dir.is_dir():
+                continue
+            if domain_dir.name.startswith("_"):
+                continue  # Skip __pycache__ and similar
+
+            domain_init = domain_dir / "domain" / "__init__.py"
+            if not domain_init.exists():
+                continue  # Not a valid domain structure
+
+            folder_name = domain_dir.name
+            module_path = f"experiments.domains.{folder_name}.domain"
+            # Prefix with "experimental:" to clearly distinguish from core domains
+            registered_name = f"experimental:{folder_name}"
+
+            try:
+                module = importlib.import_module(module_path)
+
+                # Check for required functions
+                if not hasattr(module, "get_environment"):
+                    logger.warning(
+                        f"Experimental domain '{folder_name}' missing get_environment, skipping"
+                    )
+                    continue
+                if not hasattr(module, "get_tasks"):
+                    logger.warning(
+                        f"Experimental domain '{folder_name}' missing get_tasks, skipping"
+                    )
+                    continue
+
+                # Register the base domain with experimental: prefix
+                reg.register_domain(module.get_environment, registered_name)
+
+                # Register tasks (with optional task splits)
+                get_task_splits = getattr(module, "get_tasks_split", None)
+                reg.register_tasks(
+                    module.get_tasks,
+                    registered_name,
+                    get_task_splits=get_task_splits,
+                )
+
+                logger.info(f"Registered experimental domain: {registered_name}")
+
+                # Register environment variants if available
+                if hasattr(module, "ENVIRONMENT_VARIANTS"):
+                    variants = module.ENVIRONMENT_VARIANTS
+                    for variant_name, variant_factory in variants.items():
+                        if variant_name == "base":
+                            continue  # Already registered as the main domain
+                        variant_registered_name = (
+                            f"{registered_name}:{variant_name}"
+                        )
+                        try:
+                            reg.register_domain(
+                                variant_factory, variant_registered_name
+                            )
+                            # Variants share the same tasks as the base domain
+                            reg.register_tasks(
+                                module.get_tasks,
+                                variant_registered_name,
+                                get_task_splits=get_task_splits,
+                            )
+                            logger.info(
+                                f"Registered experimental domain variant: {variant_registered_name}"
+                            )
+                        except Exception as ve:
+                            logger.warning(
+                                f"Failed to register variant '{variant_registered_name}': {ve}"
+                            )
+
+            except Exception as e:
+                logger.warning(
+                    f"Failed to register experimental domain '{folder_name}': {e}"
+                )
+
+    # Run auto-discovery
+    discover_experimental_domains(registry)
+
+    logger.debug(
+        f"Final registry info (including experimental): {json.dumps(registry.get_info().model_dump(), indent=2)}"
+    )
+
 except Exception as e:
     logger.error(f"Error initializing registry: {str(e)}")


### PR DESCRIPTION
Allow users to add custom domains by placing them in experiments/domains/. The registry now scans this directory at startup and auto-registers any valid domain with an "experimental:" prefix, making them available via CLI, Python imports, and the registry API. Updated CONTRIBUTING.md and experiments/README.md with documentation on the expected structure and usage patterns.