### PR TITLE
feat: add voice user simulator versioning (v1.0)

### DIFF
--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -70,6 +70,13 @@ DEFAULT_TEXT_STREAMING_CONFIG = {
     "chunk_size": DEFAULT_TEXT_STREAMING_CHUNK_SIZE,
 }
 
+# VOICE USER SIMULATOR VERSION
+# Bump this when any component of the voice user simulator changes
+# (LLM, TTS, decision models, presets, system prompts, effects pipeline).
+# Each version is anchored to a git tag: voice-user-sim-<version>
+VOICE_USER_SIMULATOR_VERSION = "v1.0"
+VOICE_USER_SIMULATOR_DECISION_MODEL = "gpt-4.1"
+
 # AUDIO NATIVE (Full-duplex voice using DiscreteTimeAudioNativeAgent)
 # Agent and user implementations for audio-native mode
 DEFAULT_AUDIO_NATIVE_AGENT_IMPLEMENTATION = "discrete_time_audio_native_agent"

--- a/src/tau2/scripts/leaderboard/data_models.py
+++ b/src/tau2/scripts/leaderboard/data_models.py
@@ -147,7 +147,8 @@ class Methodology(BaseModelStrict):
     )
     user_simulator: Optional[str] = Field(
         None,
-        description="Model used for user simulation during evaluation",
+        description="For text: model name (e.g. 'gpt-4.1-2025-04-14'). "
+        "For voice: version identifier (e.g. 'v1.0') anchored to git tag voice-user-sim-<version>.",
     )
     notes: Optional[str] = Field(
         None, description="Additional notes about the evaluation methodology"

--- a/src/tau2/user/user_simulator_streaming.py
+++ b/src/tau2/user/user_simulator_streaming.py
@@ -17,6 +17,7 @@ from tau2.agent.base.streaming import (
     merge_homogeneous_chunks,
 )
 from tau2.agent.base.voice import VoiceMixin, VoiceState
+from tau2.config import VOICE_USER_SIMULATOR_DECISION_MODEL
 from tau2.data_model.audio import (
     PCM_SAMPLE_RATE,
     AudioData,
@@ -286,10 +287,9 @@ def user_interruption_policy(
     # Create messages for LLM call
     decision_messages = [UserMessage(role="user", content=interruption_prompt)]
 
-    # Call LLM to make decision using gpt-4.1
     try:
         response = generate(
-            model="gpt-4.1",
+            model=VOICE_USER_SIMULATOR_DECISION_MODEL,
             messages=decision_messages,
             call_name="interruption_decision",
         )
@@ -355,10 +355,9 @@ def user_backchannel_policy(
     # Create messages for LLM call
     decision_messages = [UserMessage(role="user", content=decision_prompt)]
 
-    # Call LLM to make decision using gpt-4.1
     try:
         response = generate(
-            model="gpt-4.1",
+            model=VOICE_USER_SIMULATOR_DECISION_MODEL,
             messages=decision_messages,
             call_name="backchannel_decision",
         )

--- a/web/leaderboard/public/submissions/gemini-live-2.5-flash_sierra_2026-03-03/submission.json
+++ b/web/leaderboard/public/submissions/gemini-live-2.5-flash_sierra_2026-03-03/submission.json
@@ -32,7 +32,7 @@
   "methodology": {
     "evaluation_date": "2026-03-03",
     "tau2_bench_version": "1.0.0",
-    "user_simulator": "gpt-4.1-2025-04-14",
+    "user_simulator": "v1.0",
     "notes": "Full-duplex audio-native evaluation using regular speech complexity (realistic audio conditions). 1 trial per task.",
     "verification": {
       "modified_prompts": false,

--- a/web/leaderboard/public/submissions/gpt-realtime-1.5_sierra_2026-03-03/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-1.5_sierra_2026-03-03/submission.json
@@ -32,7 +32,7 @@
   "methodology": {
     "evaluation_date": "2026-03-03",
     "tau2_bench_version": "1.0.0",
-    "user_simulator": "gpt-4.1-2025-04-14",
+    "user_simulator": "v1.0",
     "notes": "Full-duplex audio-native evaluation using regular speech complexity (realistic audio conditions). 1 trial per task.",
     "verification": {
       "modified_prompts": false,

--- a/web/leaderboard/public/submissions/schema.json
+++ b/web/leaderboard/public/submissions/schema.json
@@ -163,7 +163,7 @@
         },
         "user_simulator": {
           "type": ["string", "null"],
-          "description": "Model used for user simulation during evaluation, or null if unknown"
+          "description": "For text submissions: model name (e.g. 'gpt-4.1-2025-04-14'). For voice submissions: version identifier (e.g. 'v1.0') anchored to git tag voice-user-sim-<version>. Null if unknown."
         },
         "notes": {
           "type": "string",

--- a/web/leaderboard/public/submissions/xai-realtime_sierra_2026-03-03/submission.json
+++ b/web/leaderboard/public/submissions/xai-realtime_sierra_2026-03-03/submission.json
@@ -32,7 +32,7 @@
   "methodology": {
     "evaluation_date": "2026-03-03",
     "tau2_bench_version": "1.0.0",
-    "user_simulator": "gpt-4.1-2025-04-14",
+    "user_simulator": "v1.0",
     "notes": "Full-duplex audio-native evaluation using regular speech complexity (realistic audio conditions). 1 trial per task.",
     "verification": {
       "modified_prompts": false,

--- a/web/leaderboard/src/components/Leaderboard.css
+++ b/web/leaderboard/src/components/Leaderboard.css
@@ -1269,6 +1269,15 @@
   line-height: 1.2;
 }
 
+a.user-sim-version-link {
+  color: #3182ce;
+  text-decoration: none;
+}
+
+a.user-sim-version-link:hover {
+  text-decoration: underline;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .submissions-notice {

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -780,7 +780,17 @@ const Leaderboard = () => {
                      {/* User Simulator */}
                      <td className="user-sim-info">
                        {model.data.userSimulator ? (
-                         <span className="user-sim-name">{model.data.userSimulator}</span>
+                         isVoice && model.data.userSimulator.startsWith('v') ? (
+                           <a
+                             href={`https://github.com/sierra-research/tau2-bench/tree/voice-user-sim-${model.data.userSimulator}`}
+                             target="_blank"
+                             rel="noopener noreferrer"
+                             className="user-sim-name user-sim-version-link"
+                             title="View voice user simulator source at this version"
+                           >{model.data.userSimulator}</a>
+                         ) : (
+                           <span className="user-sim-name">{model.data.userSimulator}</span>
+                         )
                        ) : (
                          <span className="no-data">—</span>
                        )}
@@ -988,7 +998,17 @@ const Leaderboard = () => {
                     <>
                       <tr className="sd-section-header"><td colSpan="2">METHODOLOGY</td></tr>
                       {selectedSubmission.methodology.user_simulator && (
-                        <tr><td>User Simulator</td><td>{selectedSubmission.methodology.user_simulator}</td></tr>
+                        <tr><td>User Simulator</td><td>
+                          {selectedSubmission.modality === 'voice' && selectedSubmission.methodology.user_simulator.startsWith('v') ? (
+                            <a
+                              href={`https://github.com/sierra-research/tau2-bench/tree/voice-user-sim-${selectedSubmission.methodology.user_simulator}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >{selectedSubmission.methodology.user_simulator}</a>
+                          ) : (
+                            selectedSubmission.methodology.user_simulator
+                          )}
+                        </td></tr>
                       )}
                       {selectedSubmission.methodology.evaluation_date && (
                         <tr><td>Evaluation Date</td><td>{selectedSubmission.methodology.evaluation_date}</td></tr>


### PR DESCRIPTION
## Summary

- Introduces proper versioning for the voice user simulator, which is a multi-component system (LLM, TTS, effects pipeline, decision models) previously identified only by its LLM name
- Adds `VOICE_USER_SIMULATOR_VERSION` and `VOICE_USER_SIMULATOR_DECISION_MODEL` constants to `config.py`, extracts the hardcoded `"gpt-4.1"` decision model string in `user_simulator_streaming.py`
- Updates all 3 voice `submission.json` files to use `"v1.0"` instead of `"gpt-4.1-2025-04-14"`, and the leaderboard UI now renders voice user sim versions as clickable links to the corresponding git tag (`voice-user-sim-v1.0`)

## How versioning works

Each voice user simulator version is anchored to a git tag (`voice-user-sim-<version>`). The tag points to the commit whose code defines that version's full configuration — LLM, TTS provider/model, speech complexity presets, effects pipeline, system prompts, and decision models. Anyone can `git checkout voice-user-sim-v1.0` to see exactly what v1.0 means.

## Test plan

- [ ] Verify voice leaderboard renders "v1.0" in the User Sim column
- [ ] Verify "v1.0" links to `https://github.com/sierra-research/tau2-bench/tree/voice-user-sim-v1.0`
- [ ] Verify the detail modal also shows the linked version
- [ ] Verify text leaderboard still shows LLM names (unchanged)

Made with [Cursor](https://cursor.com)