### PR TITLE
feat: redesign leaderboard landing page with preview tables and dropdowns

### DIFF
--- a/web/leaderboard/src/App.css
+++ b/web/leaderboard/src/App.css
@@ -323,7 +323,6 @@ body {
   padding: 0 24px;
   display: flex;
   justify-content: center;
-  min-height: 85vh;
 }
 
 .hero-content-vertical {
@@ -332,7 +331,8 @@ body {
   align-items: center;
   text-align: center;
   width: 100%;
-  gap: 48px;
+  max-width: 860px;
+  gap: 32px;
 }
 
 .hero-title-section {
@@ -426,7 +426,6 @@ body {
   display: flex;
   flex-direction: row;
   gap: 16px;
-  margin-bottom: 40px;
   justify-content: center;
 }
 
@@ -469,6 +468,154 @@ body {
   border-color: #065f46;
   color: #065f46;
   transform: translateY(-1px);
+}
+
+/* Hero Papers Dropdown */
+.hero-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.hero-dropdown .btn-secondary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hero-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-8px);
+  margin-top: 8px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  min-width: 180px;
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.2s ease;
+  z-index: 1000;
+}
+
+.hero-dropdown-menu.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.hero-dropdown-menu > a {
+  display: block;
+  padding: 12px 16px;
+  color: #4a5568;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.15s ease;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.hero-dropdown-menu > a:last-child {
+  border-bottom: none;
+}
+
+.hero-dropdown-menu > a:hover {
+  background: #f8fafc;
+  color: #065f46;
+}
+
+.hero-dropdown-menu > a:first-child,
+.hero-dropdown-menu > .hero-submenu-item:first-child .hero-submenu-label {
+  border-radius: 8px 8px 0 0;
+}
+
+.hero-dropdown-menu > a:last-child,
+.hero-dropdown-menu > .hero-submenu-item:last-child .hero-submenu-label {
+  border-radius: 0 0 8px 8px;
+}
+
+/* Submenu (nested dropdown) */
+.hero-submenu-item {
+  position: relative;
+}
+
+.hero-submenu-label {
+  display: block;
+  padding: 12px 16px;
+  color: #4a5568;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: default;
+  transition: all 0.15s ease;
+  border-bottom: 1px solid #f1f5f9;
+  text-align: center;
+}
+
+.hero-submenu-item:hover .hero-submenu-label {
+  background: #f8fafc;
+  color: #065f46;
+}
+
+.submenu-arrow {
+  font-size: 12px;
+  color: #a0aec0;
+  transition: color 0.15s ease;
+}
+
+.hero-submenu-item:hover .submenu-arrow {
+  color: #065f46;
+}
+
+.hero-submenu {
+  position: absolute;
+  left: 100%;
+  top: 0;
+  margin-left: 4px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  min-width: 160px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-8px);
+  transition: all 0.2s ease;
+  z-index: 1001;
+}
+
+.hero-submenu-item:hover .hero-submenu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(0);
+}
+
+.hero-submenu a {
+  display: block;
+  padding: 12px 16px;
+  color: #4a5568;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.15s ease;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.hero-submenu a:last-child {
+  border-bottom: none;
+}
+
+.hero-submenu a:hover {
+  background: #f8fafc;
+  color: #065f46;
+}
+
+.hero-submenu a:first-child {
+  border-radius: 8px 8px 0 0;
+}
+
+.hero-submenu a:last-child {
+  border-radius: 0 0 8px 8px;
 }
 
 .hero-visual {
@@ -1116,6 +1263,41 @@ body {
   .btn-secondary {
     width: 100%;
     max-width: 280px;
+  }
+
+  .hero-dropdown {
+    width: 100%;
+    max-width: 280px;
+  }
+
+  .hero-dropdown .btn-secondary {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .hero-dropdown-menu {
+    left: 50%;
+    transform: translateX(-50%) translateY(-8px);
+  }
+
+  .hero-dropdown-menu.open {
+    transform: translateX(-50%) translateY(0);
+  }
+
+  .hero-submenu {
+    position: static;
+    margin-left: 0;
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+    background: #f8fafc;
+  }
+
+  .hero-submenu a {
+    padding-left: 32px;
   }
   
   .nav-links {

--- a/web/leaderboard/src/App.jsx
+++ b/web/leaderboard/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import TrajectoryVisualizer from './components/TrajectoryVisualizer'
 import Leaderboard from './components/Leaderboard'
+import LeaderboardPreview from './components/LeaderboardPreview'
 
 function App() {
   
@@ -27,6 +28,8 @@ function App() {
   const [currentView, setCurrentView] = useState(getInitialView())
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [blogDropdownOpen, setBlogDropdownOpen] = useState(false)
+  const [papersDropdownOpen, setPapersDropdownOpen] = useState(false)
+  const [heroBlogDropdownOpen, setHeroBlogDropdownOpen] = useState(false)
 
   // Handle navigation with URL updates
   const navigateTo = (view) => {
@@ -153,39 +156,53 @@ function App() {
                     <span className="bench-text">-bench</span>
                   </h1>
                 </div>
-                
-                <div className="hero-image-section">
-                  <img src={`${import.meta.env.BASE_URL}traj.png`} alt="Sample τ-bench Trajectories" className="trajectory-image" />
-                </div>
-                
-                <div className="hero-description-section">
-                  <p className="hero-description">
-                    Benchmarking AI agents in collaborative real-world scenarios. 
-                    τ-bench challenges agents to coordinate, guide, and assist users 
-                    in achieving shared objectives across complex enterprise domains.
-                  </p>
-                  <div className="hero-actions">
-                    <div className="button-row">
-                      <a href="https://github.com/sierra-research/tau2-bench" target="_blank" rel="noopener noreferrer">
-                        <button className="btn-primary">View on GitHub</button>
-                      </a>
-                      <button onClick={() => navigateTo('leaderboard')} className="btn-secondary">
-                        View Leaderboard
+
+                <p className="hero-description">
+                  Benchmarking AI agents in collaborative real-world scenarios. 
+                  τ-bench challenges agents to coordinate, guide, and assist users 
+                  in achieving shared objectives across complex enterprise domains.
+                </p>
+
+                <div className="hero-actions">
+                  <div className="button-row">
+                    <a href="https://github.com/sierra-research/tau2-bench" target="_blank" rel="noopener noreferrer">
+                      <button className="btn-primary">View on GitHub</button>
+                    </a>
+                    <a href="https://github.com/sierra-research/tau2-bench/blob/main/docs/leaderboard-submission.md" target="_blank" rel="noopener noreferrer">
+                      <button className="btn-secondary">Submit Results</button>
+                    </a>
+                  </div>
+                  <div className="button-row">
+                    <div className="hero-dropdown" onMouseEnter={() => setPapersDropdownOpen(true)} onMouseLeave={() => setPapersDropdownOpen(false)}>
+                      <button className="btn-secondary">
+                        Read Papers <span className="dropdown-arrow">▾</span>
                       </button>
-                      <a href="https://github.com/sierra-research/tau2-bench/blob/main/docs/leaderboard-submission.md" target="_blank" rel="noopener noreferrer">
-                        <button className="btn-secondary">Submit Results</button>
-                      </a>
+                      <div className={`hero-dropdown-menu ${papersDropdownOpen ? 'open' : ''}`}>
+                        <div className="hero-submenu-item">
+                          <span className="hero-submenu-label">τ³-bench <span className="submenu-arrow">›</span></span>
+                          <div className="hero-submenu">
+                            <a href="https://arxiv.org/abs/2603.04370" target="_blank" rel="noopener noreferrer">τ-Knowledge</a>
+                            <a href="https://arxiv.org/abs/2603.13686" target="_blank" rel="noopener noreferrer">τ-Voice</a>
+                          </div>
+                        </div>
+                        <a href="https://arxiv.org/abs/2506.07982" target="_blank" rel="noopener noreferrer">τ²-bench</a>
+                        <a href="https://arxiv.org/abs/2406.12045" target="_blank" rel="noopener noreferrer">τ-bench</a>
+                      </div>
                     </div>
-                    <div className="button-row">
-                      <a href="https://arxiv.org/abs/2506.07982" target="_blank" rel="noopener noreferrer">
-                        <button className="btn-secondary">Read Paper</button>
-                      </a>
-                      <a href="https://sierra.ai/uk/blog/benchmarking-ai-agents" target="_blank" rel="noopener noreferrer">
-                        <button className="btn-secondary">Read Blog Post</button>
-                      </a>
+                    <div className="hero-dropdown" onMouseEnter={() => setHeroBlogDropdownOpen(true)} onMouseLeave={() => setHeroBlogDropdownOpen(false)}>
+                      <button className="btn-secondary">
+                        Blog Posts <span className="dropdown-arrow">▾</span>
+                      </button>
+                      <div className={`hero-dropdown-menu ${heroBlogDropdownOpen ? 'open' : ''}`}>
+                        <a href="https://sierra.ai/blog/bench-advancing-agent-benchmarking-to-knowledge-and-voice" target="_blank" rel="noopener noreferrer">τ³-bench</a>
+                        <a href="https://sierra.ai/blog/benchmarking-agents-in-collaborative-real-world-scenarios" target="_blank" rel="noopener noreferrer">τ²-bench</a>
+                        <a href="https://sierra.ai/blog/benchmarking-ai-agents" target="_blank" rel="noopener noreferrer">τ-bench</a>
+                      </div>
                     </div>
                   </div>
                 </div>
+
+                <LeaderboardPreview onViewFullLeaderboard={() => navigateTo('leaderboard')} />
               </div>
             </div>
           </section>

--- a/web/leaderboard/src/components/LeaderboardPreview.css
+++ b/web/leaderboard/src/components/LeaderboardPreview.css
@@ -1,0 +1,179 @@
+.leaderboard-preview {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.preview-loading {
+  color: #a0aec0;
+  font-size: 14px;
+  padding: 32px;
+}
+
+.preview-tables {
+  display: flex;
+  gap: 24px;
+  width: 100%;
+}
+
+.preview-table-wrapper {
+  flex: 1;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.preview-table-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #4a5568;
+  padding: 14px 16px;
+  margin: 0;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+}
+
+.preview-mode-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.preview-mode-badge.text {
+  background: #ebf8ff;
+  color: #2b6cb0;
+}
+
+.preview-mode-badge.voice {
+  background: #faf5ff;
+  color: #6b46c1;
+}
+
+.preview-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.preview-table thead th {
+  font-size: 11px;
+  font-weight: 600;
+  color: #a0aec0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 8px 16px;
+  text-align: left;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.preview-rank-col {
+  width: 40px;
+  text-align: center !important;
+}
+
+.preview-score-col {
+  width: 80px;
+  text-align: right !important;
+}
+
+.preview-row {
+  transition: background 0.15s ease;
+}
+
+.preview-row:hover {
+  background: #f8fafc;
+}
+
+.preview-row:not(:last-child) td {
+  border-bottom: 1px solid #f7fafc;
+}
+
+.preview-rank {
+  text-align: center;
+  padding: 10px 16px;
+  font-size: 16px;
+}
+
+.preview-model {
+  padding: 10px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.preview-model-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #2d3748;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+}
+
+.preview-model-org {
+  font-size: 11px;
+  color: #a0aec0;
+  font-weight: 500;
+}
+
+.preview-score {
+  padding: 10px 16px;
+  text-align: right;
+  font-size: 15px;
+  font-weight: 700;
+  color: #065f46;
+  font-variant-numeric: tabular-nums;
+}
+
+.preview-more {
+  padding: 10px 16px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 500;
+  color: #a0aec0;
+  border-top: 1px dashed #e2e8f0;
+  background: linear-gradient(to bottom, #fafbfc, #f7fafc);
+}
+
+.preview-cta {
+  background: none;
+  border: 2px solid #e2e8f0;
+  color: #065f46;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 10px 24px;
+  border-radius: 8px;
+  transition: all 0.15s ease;
+}
+
+.preview-cta:hover {
+  background: #f0fdf4;
+  border-color: #065f46;
+  color: #047857;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 768px) {
+  .preview-tables {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .leaderboard-preview {
+    padding: 0 8px;
+  }
+}

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -1,0 +1,166 @@
+import { useState, useEffect } from 'react'
+import './LeaderboardPreview.css'
+
+const MEDAL_EMOJI = ['🥇', '🥈', '🥉']
+
+function LeaderboardPreview({ onViewFullLeaderboard }) {
+  const [textTop3, setTextTop3] = useState([])
+  const [voiceTop3, setVoiceTop3] = useState([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    loadPreviewData()
+  }, [])
+
+  const loadPreviewData = async () => {
+    try {
+      const manifestResponse = await fetch(`${import.meta.env.BASE_URL}submissions/manifest.json`)
+      if (!manifestResponse.ok) return
+      const manifest = await manifestResponse.json()
+
+      const textDirs = [...(manifest.submissions || []), ...(manifest.legacy_submissions || [])]
+      const voiceDirs = manifest.voice_submissions || []
+
+      // Load text submissions and compute overall pass^1
+      const textModels = []
+      for (const dir of textDirs) {
+        try {
+          const res = await fetch(`${import.meta.env.BASE_URL}submissions/${dir}/submission.json`)
+          if (!res.ok) continue
+          const sub = await res.json()
+
+          // Only include standard submissions
+          if (sub.submission_type && sub.submission_type !== 'standard') continue
+
+          const r = sub.results
+          const airline = r.airline?.pass_1
+          const retail = r.retail?.pass_1
+          const telecom = r.telecom?.pass_1
+          const banking = r.banking_knowledge?.pass_1
+
+          if (airline != null && retail != null && telecom != null && banking != null) {
+            const overall = (airline + retail + telecom + banking) / 4
+            textModels.push({
+              name: sub.model_name,
+              org: sub.model_organization,
+              overall: overall,
+            })
+          }
+        } catch { /* skip */ }
+      }
+
+      textModels.sort((a, b) => b.overall - a.overall)
+      setTextTop3(textModels.slice(0, 3))
+
+      // Load voice submissions and compute overall pass^1
+      const voiceModels = []
+      const voiceDomains = ['airline', 'retail', 'telecom']
+      for (const dir of voiceDirs) {
+        try {
+          const res = await fetch(`${import.meta.env.BASE_URL}submissions/${dir}/submission.json`)
+          if (!res.ok) continue
+          const sub = await res.json()
+
+          if (sub.submission_type && sub.submission_type !== 'standard') continue
+
+          const r = sub.results
+          const values = voiceDomains
+            .map(d => r[d]?.pass_1)
+            .filter(v => v != null)
+
+          if (values.length > 0) {
+            const overall = values.reduce((s, v) => s + v, 0) / values.length
+            voiceModels.push({
+              name: sub.model_name,
+              org: sub.model_organization,
+              overall: overall,
+            })
+          }
+        } catch { /* skip */ }
+      }
+
+      voiceModels.sort((a, b) => b.overall - a.overall)
+      setVoiceTop3(voiceModels.slice(0, 3))
+    } catch (err) {
+      console.warn('Failed to load leaderboard preview:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="leaderboard-preview">
+        <div className="preview-loading">Loading leaderboard...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="leaderboard-preview">
+      <div className="preview-tables">
+        <div className="preview-table-wrapper">
+          <h3 className="preview-table-title">
+            <span className="preview-mode-badge text">Text</span>
+            Overall
+          </h3>
+          <table className="preview-table">
+            <thead>
+              <tr>
+                <th className="preview-rank-col">#</th>
+                <th className="preview-model-col">Model</th>
+                <th className="preview-score-col">Pass^1</th>
+              </tr>
+            </thead>
+            <tbody>
+              {textTop3.map((model, i) => (
+                <tr key={i} className="preview-row">
+                  <td className="preview-rank">{MEDAL_EMOJI[i]}</td>
+                  <td className="preview-model">
+                    <span className="preview-model-name">{model.name}</span>
+                    <span className="preview-model-org">{model.org}</span>
+                  </td>
+                  <td className="preview-score">{model.overall.toFixed(1)}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="preview-more">⋯</div>
+        </div>
+        <div className="preview-table-wrapper">
+          <h3 className="preview-table-title">
+            <span className="preview-mode-badge voice">Voice</span>
+            Overall
+          </h3>
+          <table className="preview-table">
+            <thead>
+              <tr>
+                <th className="preview-rank-col">#</th>
+                <th className="preview-model-col">Model</th>
+                <th className="preview-score-col">Pass^1</th>
+              </tr>
+            </thead>
+            <tbody>
+              {voiceTop3.map((model, i) => (
+                <tr key={i} className="preview-row">
+                  <td className="preview-rank">{MEDAL_EMOJI[i]}</td>
+                  <td className="preview-model">
+                    <span className="preview-model-name">{model.name}</span>
+                    <span className="preview-model-org">{model.org}</span>
+                  </td>
+                  <td className="preview-score">{model.overall.toFixed(1)}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="preview-more">⋯</div>
+        </div>
+      </div>
+      <button className="preview-cta" onClick={onViewFullLeaderboard}>
+        View Full Leaderboard →
+      </button>
+    </div>
+  )
+}
+
+export default LeaderboardPreview


### PR DESCRIPTION
## Summary

Redesigns the leaderboard landing page for a cleaner, more informative experience.

## Changes

### Papers & Blog Posts Dropdowns
- **Read Papers dropdown** — lists all 4 τ-bench papers with a τ³-bench submenu expanding to τ-Knowledge and τ-Voice
- **Blog Posts dropdown** — lists all 3 blog posts (τ³-bench, τ²-bench, τ-bench)
- Updated blog post link to new τ³-bench URL

### Leaderboard Preview
- New `LeaderboardPreview` component showing top 3 models for both **Text** and **Voice** overall Pass^1 scores
- Loads data from the same `manifest.json` / `submission.json` files as the full leaderboard
- Subtle `⋯` hint at the bottom of each table + "View Full Leaderboard →" CTA

### Hero Layout Reorganization (Option B)
- Reordered hero: **title → description → action buttons → leaderboard preview**
- Removed the trajectory image — the preview tables are now the visual anchor
- Tightened spacing and removed `min-height: 85vh` for a more compact layout

### Responsive
- All new components (dropdowns, submenus, preview tables) stack properly on mobile
- Model names truncate with ellipsis if too long

## Files Changed
- `web/leaderboard/src/App.jsx` — restructured hero, added dropdowns
- `web/leaderboard/src/App.css` — dropdown styles, layout adjustments
- `web/leaderboard/src/components/LeaderboardPreview.jsx` — new component
- `web/leaderboard/src/components/LeaderboardPreview.css` — new styles