### PR TITLE
fix: allow DummyUser to be instantiated without arguments

### DIFF
--- a/src/tau2/user/user_simulator.py
+++ b/src/tau2/user/user_simulator.py
@@ -269,6 +269,9 @@ class UserSimulator(
 class DummyUser(UserSimulator):
     """A dummy user to run a agent solo simulation."""
 
+    def __init__(self):
+        super().__init__(llm="dummy")
+
     def get_init_state(
         self, message_history: Optional[list[Message]] = None
     ) -> UserState:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -26,11 +26,7 @@ def user_simulator() -> UserSimulator:
 
 @pytest.fixture
 def dummy_user() -> DummyUser:
-    return DummyUser(
-        instructions="You are a dummy user.",
-        llm="gpt-3.5-turbo",
-        llm_args={"temperature": 0.0},
-    )
+    return DummyUser()
 
 
 @pytest.fixture

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tau2.data_model.message import AssistantMessage, UserMessage
-from tau2.user.user_simulator import UserSimulator
+from tau2.user.user_simulator import DummyUser, UserSimulator
 
 
 @pytest.fixture
@@ -57,3 +57,10 @@ def test_user_simulator_set_state(
             ),
         ]
     )
+
+
+def test_dummy_user_no_args():
+    """DummyUser must be instantiable without arguments (solo-mode gym path)."""
+    dummy = DummyUser()
+    state = dummy.get_init_state()
+    assert state.messages == []


### PR DESCRIPTION
Fixes #199

## Summary
- Add a no-arg __init__ to DummyUser so it can be used in solo-mode gym path
- Update test fixtures to match
