### PR TITLE
feat: Add Distyl ButtonAgent and GPT-5.4 banking_knowledge submissions

### DIFF
--- a/web/leaderboard/public/submissions/distyl-buttonagent_distyl_2026-03-25/submission.json
+++ b/web/leaderboard/public/submissions/distyl-buttonagent_distyl_2026-03-25/submission.json
@@ -1,0 +1,50 @@
+{
+  "model_name": "Distyl ButtonAgent",
+  "model_organization": "Distyl AI",
+  "submitting_organization": "Distyl AI",
+  "submission_date": "2026-03-25",
+  "submission_type": "custom",
+  "contact_info": {
+    "email": "durga@distyl.ai",
+    "name": "Durga Sandeep Saluru"
+  },
+  "reasoning_effort": "high",
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "banking_knowledge": "distyl-buttonagent_banking_knowledge_4trials.json"
+  },
+  "results": {
+    "banking_knowledge": {
+      "pass_1": 31.19,
+      "pass_2": 21.47,
+      "pass_3": 16.19,
+      "pass_4": 13.40,
+      "cost": null,
+      "retrieval_config": "mixedbread"
+    }
+  },
+  "references": [
+    {
+      "title": "Mixedbread Semantic Search",
+      "url": "https://www.mixedbread.com/docs/stores/overview",
+      "type": "documentation"
+    },
+    {
+      "title": "Trajectory Data (Google Drive)",
+      "url": "https://drive.google.com/file/d/1fxCProuEbaqwRkmFapObYhjDUVx6ch6o/view?usp=sharing",
+      "type": "trajectories"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-03-25",
+    "tau2_bench_version": "0.2.1-dev",
+    "user_simulator": "gpt-5.2",
+    "notes": "Distyl ButtonAgent uses GPT-5.4 with high reasoning effort and a custom agentic retrieval pipeline powered by Mixedbread semantic search (mxbai-wholembed-v3). The 698 banking knowledge documents are indexed in a hosted Mixedbread vector store and retrieved dynamically during conversation. 4 trials. Seed: 300.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Full evaluation on all 97 banking_knowledge tasks with 4 trials each. No prompts were modified for the banking domain."
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/gpt-5-4_sierra_2026-03-25/submission.json
+++ b/web/leaderboard/public/submissions/gpt-5-4_sierra_2026-03-25/submission.json
@@ -1,0 +1,45 @@
+{
+  "model_name": "GPT-5.4",
+  "model_organization": "OpenAI",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-03-25",
+  "submission_type": "standard",
+  "contact_info": {
+    "email": "victor@sierra.ai, ben.s@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "is_new": true,
+  "reasoning_effort": "high",
+  "trajectories_available": true,
+  "trajectory_files": {
+    "banking_knowledge": "gpt-5.4_high_banking_knowledge_gpt-5.2_4trials.json"
+  },
+  "references": [
+    {
+      "title": "Trajectory Data (Google Drive)",
+      "url": "https://drive.google.com/file/d/1Um1lWa6IsfPgiW01E-5G4ikdtymDGcRt/view?usp=sharing",
+      "type": "trajectories"
+    }
+  ],
+  "results": {
+    "banking_knowledge": {
+      "pass_1": 31.19,
+      "pass_2": 22.68,
+      "pass_3": 19.07,
+      "pass_4": 16.49,
+      "cost": null,
+      "retrieval_config": "terminal"
+    }
+  },
+  "methodology": {
+    "evaluation_date": "2026-03-25",
+    "tau2_bench_version": "0.2.1-dev",
+    "user_simulator": "gpt-5.2",
+    "notes": "Evaluated using GPT-5.4 with reasoning_effort: high. User simulator: gpt-5.2 with reasoning_effort: low. 4 trials. Seed: 300. Banking domain evaluated with terminal-based agentic search retrieval (terminal_use). Only banking_knowledge domain evaluated.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Full evaluation on all 97 banking_knowledge tasks with 4 trials each. Standard tau-bench scaffold."
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -7,7 +7,9 @@
     "glm-5-think_sierra_2026-03-02",
     "qwen3.5-397b-a17b-think_sierra_2026-03-02",
     "gemini-3-flash_sierra_2026-03-02",
-    "gemini-3-pro_sierra_2026-03-02"
+    "gemini-3-pro_sierra_2026-03-02",
+    "distyl-buttonagent_distyl_2026-03-25",
+    "gpt-5-4_sierra_2026-03-25"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",

--- a/web/leaderboard/src/components/Leaderboard.css
+++ b/web/leaderboard/src/components/Leaderboard.css
@@ -784,6 +784,10 @@
   margin-left: 6px;
   white-space: nowrap;
   vertical-align: middle;
+  /* Default styling for unrecognized retrieval configs */
+  color: #6b21a8;
+  background: #faf5ff;
+  border: 1px solid #d8b4fe;
 }
 
 .retrieval-terminal {


### PR DESCRIPTION
## Summary

Adds two new banking_knowledge leaderboard submissions and a small CSS fix.

### Distyl ButtonAgent (from PR #194)

- **Model**: Distyl ButtonAgent (GPT-5.4, reasoning_effort=high)
- **Organization**: Distyl AI
- **Domain**: banking_knowledge (97 tasks, 4 trials)
- **Pass^1**: **31.19%** | **Pass^2**: 21.47% | **Pass^3**: 16.19% | **Pass^4**: 13.40%
- **Retrieval**: Mixedbread semantic search (mxbai-wholembed-v3)
- **User Simulator**: gpt-5.2
- **Trajectory**: [Google Drive](https://drive.google.com/file/d/1fxCProuEbaqwRkmFapObYhjDUVx6ch6o/view?usp=sharing)

Methodology: Distyl ButtonAgent combines GPT-5.4 with high reasoning effort and a custom agentic retrieval pipeline using Mixedbread semantic search. The 698 banking knowledge documents are indexed in a hosted Mixedbread vector store and retrieved dynamically during each conversation via the KB_search tool.

- No banking-specific prompt modifications
- Full evaluation on all 97 banking_knowledge tasks, 4 trials each
- Seed: 300

### GPT-5.4 baseline (Sierra)

Added as a fair comparison baseline since the leaderboard did not yet have a GPT-5.4 entry.

- **Model**: GPT-5.4 (reasoning_effort=high)
- **Organization**: OpenAI (submitted by Sierra)
- **Domain**: banking_knowledge (97 tasks, 4 trials)
- **Pass^1**: **31.19%** | **Pass^2**: 22.68% | **Pass^3**: 19.07% | **Pass^4**: 16.49%
- **Retrieval**: terminal (terminal_use)
- **User Simulator**: gpt-5.2
- **Trajectory**: [Google Drive](https://drive.google.com/file/d/1Um1lWa6IsfPgiW01E-5G4ikdtymDGcRt/view?usp=sharing)

### CSS fix

Adds default color styling to `.retrieval-badge` so unrecognized retrieval configs (e.g. `mixedbread`) still render with a colored pill badge instead of appearing unstyled.

cc: @durga-sandeep