### PR TITLE
feat(registry): register retell_chat agent from cs_eval

### DIFF
--- a/src/tau2/registry.py
+++ b/src/tau2/registry.py
@@ -347,6 +347,13 @@ try:
     registry.register_domain(knowledge_domain_get_environment, "banking_knowledge")
     registry.register_tasks(knowledge_domain_get_tasks, "banking_knowledge")
 
+    # External agent registration (cs_eval)
+    try:
+        from cs_eval.agents.retell_chat_tau_agent import create_retell_chat_agent
+        registry.register_agent_factory(create_retell_chat_agent, "retell_chat")
+    except ImportError:
+        logger.debug("cs_eval not installed, skipping retell_chat registration")
+
     logger.debug(
         f"Default components registered successfully. Registry info: {json.dumps(registry.get_info().model_dump(), indent=2)}"
     )


### PR DESCRIPTION
## Summary

- Registers a `retell_chat` agent factory from the `cs_eval` package into the tau2 registry
- Import is fully optional — guarded with `try/except ImportError` so tau2 works normally when `cs_eval` is not installed
- Enables running Retell-hosted chat agents against tau2 benchmarks via the standard tau2 runner without modifying tau2 internals

## Test plan

- [ ] Verify tau2 runs normally without `cs_eval` installed (import guard fires, no error)
- [ ] Verify `retell_chat` agent is available in the registry when `cs_eval` is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)