### PR TITLE
leaderboard: add gemini-3.1-flash-live-preview voice submission

### DIFF
--- a/tests/test_voice/test_audio_native/testdata/generate_test_audio.py
+++ b/tests/test_voice/test_audio_native/testdata/generate_test_audio.py
@@ -97,9 +97,7 @@ def generate_test_audio():
             ulaw_path = os.path.join(OUTPUT_DIR, f"{filename}.ulaw")
             audio = AudioData(
                 data=raw_pcm,
-                format=AudioFormat(
-                    encoding=AudioEncoding.PCM_S16LE, sample_rate=16000
-                ),
+                format=AudioFormat(encoding=AudioEncoding.PCM_S16LE, sample_rate=16000),
             )
             audio = resample_audio(audio, 8000)
             audio = convert_to_ulaw(audio)

--- a/web/leaderboard/public/submissions/gemini-3-1-flash-live-preview-thinking-high_google_2026-04-02/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-1-flash-live-preview-thinking-high_google_2026-04-02/submission.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "gemini-3.1-flash-live-preview",
+  "model_name": "gemini-3.1-flash-live-preview-thinking-high",
   "model_organization": "Google",
   "submitting_organization": "Sierra",
   "submission_date": "2026-04-02",
@@ -33,7 +33,8 @@
     "user_simulator": "v1.0",
     "verification": {
       "modified_prompts": false,
-      "omitted_questions": false
+      "omitted_questions": false,
+      "details": "Ran with thinking = HIGH."
     }
   },
   "voice_config": {

--- a/web/leaderboard/public/submissions/gemini-3-1-flash-live-preview_google_2026-04-02/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-1-flash-live-preview_google_2026-04-02/submission.json
@@ -1,0 +1,46 @@
+{
+  "model_name": "gemini-3.1-flash-live-preview",
+  "model_organization": "Google",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-04-02",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "keshav@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 45.614035087719294
+    },
+    "airline": {
+      "pass_1": 64.0
+    },
+    "telecom": {
+      "pass_1": 21.929824561403507
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_regular",
+    "retail": "retail_regular",
+    "telecom": "telecom_regular"
+  },
+  "methodology": {
+    "evaluation_date": "2026-04-02",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "v1.0",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "gemini",
+    "model": "gemini-3.1-flash-live-preview",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 600.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  }
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -15,7 +15,7 @@
     "gpt-realtime-1.5_sierra_2026-03-03",
     "gemini-live-2.5-flash_sierra_2026-03-03",
     "xai-realtime_sierra_2026-03-03",
-    "gemini-3-1-flash-live-preview_google_2026-04-02"
+    "gemini-3-1-flash-live-preview-thinking-high_google_2026-04-02"
 
   ],
   "legacy_submissions": [

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -14,7 +14,9 @@
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",
     "gemini-live-2.5-flash_sierra_2026-03-03",
-    "xai-realtime_sierra_2026-03-03"
+    "xai-realtime_sierra_2026-03-03",
+    "gemini-3-1-flash-live-preview_google_2026-04-02"
+
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",


### PR DESCRIPTION
## Summary
- Add new voice leaderboard submission for **gemini-3.1-flash-live-preview** (Google, 2026-04-02) with results for airline, retail, and telecom domains
- Update submissions manifest to include the new entry

## Test plan
- [ ] Verify the leaderboard renders the new submission correctly
- [ ] Confirm trajectory links resolve for both new and updated submissions

Made with [Cursor](https://cursor.com)