### PR TITLE
web: remove need for hard refresh

### DIFF
--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -15,6 +15,8 @@ const getBenchmarkFromHash = () => {
 const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
   || `${import.meta.env.BASE_URL}submissions`
 
+const NO_CACHE = { cache: 'no-cache' }
+
 const Leaderboard = () => {
   // Benchmark selector: 'text' (τ-bench) or 'voice' (τ-voice)
   const [benchmark, setBenchmark] = useState(() => {
@@ -91,7 +93,7 @@ const Leaderboard = () => {
       setLoadError(null)
       
       // Load the manifest file to get list of submissions from new directory structure
-      const manifestResponse = await fetch(`${SUBMISSIONS_BASE}/manifest.json`)
+      const manifestResponse = await fetch(`${SUBMISSIONS_BASE}/manifest.json`, NO_CACHE)
       if (!manifestResponse.ok) {
         throw new Error('Failed to load submissions manifest')
       }
@@ -107,7 +109,7 @@ const Leaderboard = () => {
       // Helper to load a submission directory
       const loadSubmission = async (submissionDir, isLegacy, modality = 'text') => {
         try {
-          const response = await fetch(`${SUBMISSIONS_BASE}/${submissionDir}/submission.json`)
+          const response = await fetch(`${SUBMISSIONS_BASE}/${submissionDir}/submission.json`, NO_CACHE)
           if (!response.ok) {
             console.warn(`Failed to load ${submissionDir}: ${response.status}`)
             return

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -6,6 +6,8 @@ const MEDAL_EMOJI = ['🥇', '🥈', '🥉']
 const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
   || `${import.meta.env.BASE_URL}submissions`
 
+const NO_CACHE = { cache: 'no-cache' }
+
 function LeaderboardPreview({ onViewFullLeaderboard }) {
   const [textTop3, setTextTop3] = useState([])
   const [voiceTop3, setVoiceTop3] = useState([])
@@ -17,7 +19,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
 
   const loadPreviewData = async () => {
     try {
-      const manifestResponse = await fetch(`${SUBMISSIONS_BASE}/manifest.json`)
+      const manifestResponse = await fetch(`${SUBMISSIONS_BASE}/manifest.json`, NO_CACHE)
       if (!manifestResponse.ok) return
       const manifest = await manifestResponse.json()
 
@@ -28,7 +30,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
       const textModels = []
       for (const dir of textDirs) {
         try {
-          const res = await fetch(`${SUBMISSIONS_BASE}/${dir}/submission.json`)
+          const res = await fetch(`${SUBMISSIONS_BASE}/${dir}/submission.json`, NO_CACHE)
           if (!res.ok) continue
           const sub = await res.json()
 
@@ -60,7 +62,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
       const voiceDomains = ['airline', 'retail', 'telecom']
       for (const dir of voiceDirs) {
         try {
-          const res = await fetch(`${SUBMISSIONS_BASE}/${dir}/submission.json`)
+          const res = await fetch(`${SUBMISSIONS_BASE}/${dir}/submission.json`, NO_CACHE)
           if (!res.ok) continue
           const sub = await res.json()
 

--- a/web/leaderboard/src/components/TrajectoryVisualizer.jsx
+++ b/web/leaderboard/src/components/TrajectoryVisualizer.jsx
@@ -5,6 +5,8 @@ import './TrajectoryVisualizer.css'
 const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
   || `${import.meta.env.BASE_URL}submissions`
 
+const NO_CACHE = { cache: 'no-cache' }
+
 const S3_BUCKET = 'sierra-tau-bench-public'
 const S3_SUBMISSIONS_PREFIX = 'submissions'
 
@@ -131,7 +133,7 @@ const TrajectoryVisualizer = () => {
     const loadSubmissions = async () => {
       try {
         setSubmissionsLoading(true)
-        const res = await fetch(`${SUBMISSIONS_BASE}/manifest.json`)
+        const res = await fetch(`${SUBMISSIONS_BASE}/manifest.json`, NO_CACHE)
         if (!res.ok) throw new Error('Failed to load manifest')
         const manifest = await res.json()
         const textDirs = manifest.submissions || []
@@ -141,7 +143,7 @@ const TrajectoryVisualizer = () => {
 
         const loadDir = async (dir, modality) => {
           try {
-            const r = await fetch(`${SUBMISSIONS_BASE}/${dir}/submission.json`)
+            const r = await fetch(`${SUBMISSIONS_BASE}/${dir}/submission.json`, NO_CACHE)
             if (!r.ok) return
             const sub = await r.json()
             if (sub.trajectories_available && sub.trajectory_files) {
@@ -232,7 +234,7 @@ const TrajectoryVisualizer = () => {
         const url = sub.modality === 'voice'
           ? `${SUBMISSIONS_BASE}/${sub.dir}/trajectories/${fileName}/results.json`
           : `${SUBMISSIONS_BASE}/${sub.dir}/trajectories/${fileName}`
-        const res = await fetch(url)
+        const res = await fetch(url, NO_CACHE)
         if (!res.ok) throw new Error(`Failed to load trajectory: ${res.statusText}`)
         const data = await res.json()
 

--- a/web/leaderboard/src/components/VoiceViewer.jsx
+++ b/web/leaderboard/src/components/VoiceViewer.jsx
@@ -6,6 +6,8 @@ import './VoiceViewer.css'
 const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
   || `${import.meta.env.BASE_URL}submissions`
 
+const NO_CACHE = { cache: 'no-cache' }
+
 /**
  * Voice trajectory viewer component.
  *
@@ -38,7 +40,7 @@ const VoiceViewer = ({
         setError(null)
 
         const url = `${SUBMISSIONS_BASE}/${submissionDir}/trajectories/${trajectoryDir}/simulations/${simulationId}.json`
-        const res = await fetch(url)
+        const res = await fetch(url, NO_CACHE)
         if (!res.ok) {
           throw new Error(
             res.status === 404


### PR DESCRIPTION
web: add no-cache to submission data fetches to prevent stale browser cache

Adds { cache: 'no-cache' } to all fetch calls for manifest.json, submission.json, and trajectory data so the browser always revalidates with the server instead of serving stale cached responses.

Made-with: Cursor