### PR TITLE
feat: make voice persona IDs configurable via env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,19 @@ DEEPGRAM_API_KEY=<your_key_here>
 
 # Required for banking_knowledge qwen_embeddings* retrieval configs (via OpenRouter)
 OPENROUTER_API_KEY=<your_key_here>
+
+# ── Voice Persona Overrides ────────────────────────────────────────────
+# The default voice IDs are Sierra-internal and won't work for external users.
+# Create your own voices in ElevenLabs and set the IDs here.
+# See docs/voice-personas.md for a step-by-step guide.
+#
+# Control personas (American accents, used in "control" complexity):
+# TAU2_VOICE_ID_MATT_DELANEY=<your_voice_id>
+# TAU2_VOICE_ID_LISA_BRENNER=<your_voice_id>
+#
+# Regular personas (diverse accents, used in "regular" complexity):
+# TAU2_VOICE_ID_MILDRED_KAPLAN=<your_voice_id>
+# TAU2_VOICE_ID_ARJUN_ROY=<your_voice_id>
+# TAU2_VOICE_ID_WEI_LIN=<your_voice_id>
+# TAU2_VOICE_ID_MAMADOU_DIALLO=<your_voice_id>
+# TAU2_VOICE_ID_PRIYA_PATIL=<your_voice_id>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,18 @@ If you're using voice features, add the following to your `.env` file:
 - `ELEVENLABS_API_KEY` — for voice synthesis
 - `DEEPGRAM_API_KEY` — for voice transcription
 
+### Voice Persona Setup (for voice-enabled features)
+
+The voice pipeline uses ElevenLabs voices for the user simulator. The default voice IDs are Sierra-internal and won't work for external users. You need to create your own voices and configure them via environment variables in your `.env` file:
+
+```bash
+TAU2_VOICE_ID_MATT_DELANEY=your_voice_id_here
+TAU2_VOICE_ID_LISA_BRENNER=your_voice_id_here
+# ... (one per persona)
+```
+
+See the [Voice Persona Setup Guide](voice-personas.md) for step-by-step instructions on creating matching voices using ElevenLabs Voice Design.
+
 ## Running Your First Evaluation
 
 ### Standard text-based evaluation (half-duplex)
@@ -196,4 +208,5 @@ make clean
 - [Communication Modes](../src/tau2/orchestrator/README.md) — half-duplex and full-duplex orchestration
 - [Knowledge Retrieval](../src/tau2/knowledge/README.md) — retrieval pipeline setup and configuration for banking_knowledge domain
 - [Voice (Full-Duplex)](../src/tau2/voice/README.md) — providers, speech complexity, and CLI options for voice evaluation
+- [Voice Persona Setup](voice-personas.md) — create custom ElevenLabs voices for the user simulator
 - [Gym/RL Interface](../src/tau2/gym/README.md) — Gymnasium-compatible environment for RL training

--- a/docs/leaderboard-submission.md
+++ b/docs/leaderboard-submission.md
@@ -389,6 +389,18 @@ The voice user simulator is a complex multi-component system — LLM, TTS (via E
 
 Because of this complexity, we recommend that you **open a PR and contact us** so we can coordinate running the evaluation.
 
+### Voice Persona Setup (for Local Development)
+
+The voice user simulator uses ElevenLabs TTS with specific voice personas. The default voice IDs in the codebase are Sierra-internal and **will not work** for external users. If you want to run voice evaluations locally for development or testing, you need to create your own voices first.
+
+See the [Voice Persona Setup Guide](voice-personas.md) for step-by-step instructions. The short version:
+
+1. Create voices in [ElevenLabs Voice Design](https://elevenlabs.io/app/voice-lab) using the prompts from `src/tau2/data_model/voice_personas.py`
+2. Set `TAU2_VOICE_ID_<PERSONA_NAME>` environment variables in your `.env` file
+3. For quick testing, create just the two control personas and use `--speech-complexity control`
+
+> **Note:** Your custom voices will sound different from Sierra's internal voices. Sierra runs all final/published evaluations with its own voices to ensure parity across leaderboard results.
+
 ### Existing Provider (Adapter Already Integrated)
 
 OpenAI, Gemini, and xAI already have audio-native adapters in `src/tau2/voice/audio_native/`. If you want results for one of these providers:
@@ -396,10 +408,42 @@ OpenAI, Gemini, and xAI already have audio-native adapters in `src/tau2/voice/au
 1. Open a PR with your `submission.json` and contact us — we can run the evaluation
 2. If you ran the evaluation yourself, include a link to your trajectory data in the PR description for verification
 
-The evaluation command (requires the full voice simulator stack):
+### How We Run Voice Evaluations
+
+For published leaderboard results, Sierra runs voice evaluations across all three core domains with the following commands:
 
 ```bash
-tau2 run --domain retail --audio-native --audio-native-provider openai --audio-native-model gpt-realtime-1.5 --num-tasks 1 --verbose-logs
+# Voice full-duplex evaluation (one per domain)
+tau2 run --domain retail --audio-native \
+    --audio-native-provider openai --audio-native-model gpt-4o-realtime-preview \
+    --speech-complexity regular --verbose-logs \
+    --save-to my_model_voice_retail
+
+tau2 run --domain airline --audio-native \
+    --audio-native-provider openai --audio-native-model gpt-4o-realtime-preview \
+    --speech-complexity regular --verbose-logs \
+    --save-to my_model_voice_airline
+
+tau2 run --domain telecom --audio-native \
+    --audio-native-provider openai --audio-native-model gpt-4o-realtime-preview \
+    --speech-complexity regular --verbose-logs \
+    --save-to my_model_voice_telecom
+```
+
+Replace `--audio-native-provider` and `--audio-native-model` with the provider and model being evaluated. Key flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--audio-native` | Enable voice full-duplex mode |
+| `--audio-native-provider` | Provider to evaluate (`openai`, `gemini`, `xai`) |
+| `--audio-native-model` | Specific model identifier |
+| `--speech-complexity regular` | Full realistic conditions (required for leaderboard) |
+| `--verbose-logs` | Save audio files and tick data for verification |
+
+For local development and testing, you can run a quick smoke test with fewer tasks:
+
+```bash
+tau2 run --domain retail --audio-native --speech-complexity control --num-tasks 1 --verbose-logs
 ```
 
 ### New Provider (No Adapter Yet)

--- a/docs/voice-personas.md
+++ b/docs/voice-personas.md
@@ -1,0 +1,115 @@
+# Voice Persona Setup
+
+The voice evaluation pipeline uses [ElevenLabs](https://elevenlabs.io/) to synthesize user simulator speech. Each voice persona has an associated ElevenLabs **voice ID** that determines how the simulated caller sounds.
+
+The default voice IDs in the codebase are Sierra's internal voices and **will not work** for external users. This guide walks you through creating your own voices and configuring the framework to use them.
+
+> **Note:** Sierra runs final evaluations with its own voices to ensure parity across published results. Your custom voices will sound different but are functionally equivalent for development and experimentation.
+
+## Prerequisites
+
+- An [ElevenLabs](https://elevenlabs.io/) account (free tier works for testing)
+- `ELEVENLABS_API_KEY` set in your `.env` file
+
+## Step 1: Create Voices with Voice Design
+
+ElevenLabs Voice Design lets you create voices from a text prompt — the same prompts used to define the personas in τ-bench.
+
+1. Go to [ElevenLabs Voice Library](https://elevenlabs.io/app/voice-lab) (or navigate to **Voices** in the ElevenLabs dashboard)
+2. Click **Add a voice** → **Voice Design** (the "voice from prompt" option)
+3. For each persona below, paste the corresponding prompt into the voice description field
+4. Generate and save the voice
+5. Copy the **Voice ID** from the voice details page (click the voice → look for the ID string)
+
+### Persona Prompts
+
+Use these prompts to create voices that match the built-in personas.
+
+#### Control Personas (American accents — used in `control` complexity)
+
+**Matt Delaney** — Middle-aged white man from the American Midwest, calm and respectful
+
+> You are a middle-aged white man from the American Midwest. You always behave as if you are speaking out loud in a real-time conversation with a customer service agent. You are calm, clear, and respectful — but also human. You sound like someone who's trying to be helpful and polite, even when you're slightly frustrated or in a hurry. You value efficiency but never sound robotic.
+
+**Lisa Brenner** — White woman in her late 40s from a suburban area, tense and impatient
+
+> You are a white woman in your late 40s from a suburban area. You always speak as if you are talking out loud to a customer service agent who is already wasting your time. You're not openly hostile (yet), but you are tense, impatient, and clearly annoyed. You act like this issue should have been resolved the first time, and the fact that you're following up is unacceptable.
+
+#### Regular Personas (diverse accents — used in `regular` complexity)
+
+**Mildred Kaplan** — Elderly white woman in her early 80s, needs help with technology
+
+> You are an elderly white woman in your early 80s calling customer service for help with something your grandson or neighbor usually does.
+
+**Arjun Roy** — Bengali man from Dhaka in his mid-30s, calm and direct
+
+> A Bengali man from Dhaka, Bangladesh in his mid-30s calling customer service about a billing issue. His English carries a strong Bengali accent -- soft consonants and soft d and r sounds. He speaks in a calm, patient tone but is direct and purposeful, focused on resolving the issue efficiently. His pacing is slow, distracted with a warm yet firm timbre. The speech sounds like it is coming from far away.
+
+**Wei Lin** — Chinese woman from Sichuan in her late 20s, upbeat and matter-of-fact
+
+> A Chinese woman in her late 20s from Sichuan, calling customer service about a credit card billing issue. She speaks English with a thick Sichuan Mandarin accent. She sounds upbeat, matter-of-fact, and distracted. Her tone is firm but polite, with fast pacing and smooth timbre. ok audio quality.
+
+**Mamadou Diallo** — Senegalese man in his mid-30s, hurried with French accent
+
+> A Senegalese man who's first language is french in his mid-30s calling customer service about a billing issue. He speaks English with a strong French accent. His tone is hurried, slightly annoyed, and matter-of-fact, as if he's been transferred between agents and just wants the problem fixed.
+
+**Priya Patil** — Maharashtrian woman in her early 30s, hurried and focused
+
+> A woman in her early 30s from Maharashtra, India, calling customer support from her mobile phone. She speaks Indian English with a strong Maharashtrian accent — noticeable regional intonation and rhythm. Her tone is slightly annoyed and hurried, matter-of-fact, and focused on getting the issue resolved quickly. Her voice has medium pitch, firm delivery, short sentences, and faint background room tone typical of a phone call.
+
+## Step 2: Configure Voice IDs
+
+Once you've created the voices, set environment variables in your `.env` file. The framework picks these up automatically — no code changes needed.
+
+```bash
+# Control personas
+TAU2_VOICE_ID_MATT_DELANEY=your_matt_voice_id
+TAU2_VOICE_ID_LISA_BRENNER=your_lisa_voice_id
+
+# Regular personas
+TAU2_VOICE_ID_MILDRED_KAPLAN=your_mildred_voice_id
+TAU2_VOICE_ID_ARJUN_ROY=your_arjun_voice_id
+TAU2_VOICE_ID_WEI_LIN=your_wei_voice_id
+TAU2_VOICE_ID_MAMADOU_DIALLO=your_mamadou_voice_id
+TAU2_VOICE_ID_PRIYA_PATIL=your_priya_voice_id
+```
+
+The environment variable pattern is `TAU2_VOICE_ID_<PERSONA_NAME_UPPER>`. If a variable is not set, the framework falls back to the built-in default (which only works for Sierra-internal use).
+
+### Minimal setup
+
+You don't need to create all 7 voices. For quick testing, create just the two **control** personas (Matt Delaney and Lisa Brenner) and run with `--speech-complexity control`:
+
+```bash
+tau2 run --domain retail --audio-native --speech-complexity control --num-tasks 1
+```
+
+## Step 3: Verify
+
+Test that your voices work with the synthesis CLI:
+
+```bash
+python src/tau2/voice/synthesis/cli.py synthesize "Hello, I'd like to check on my order." --play
+```
+
+Or run a quick voice simulation:
+
+```bash
+tau2 run --domain retail --audio-native --speech-complexity control \
+    --num-tasks 1 --verbose-logs
+```
+
+Check the generated audio in the output directory to confirm the voices sound correct.
+
+## How It Works
+
+The voice ID resolution follows this priority:
+
+1. **Environment variable** `TAU2_VOICE_ID_<NAME>` (if set)
+2. **Built-in default** in `src/tau2/data_model/voice_personas.py`
+
+The persona definitions (name, prompt, complexity level) remain the same regardless of which voice ID is used. Only the ElevenLabs voice that renders the speech changes.
+
+## Regenerating Pre-sampled Voice Configs
+
+If you use pre-sampled voice configurations (`tasks_voice.json` files in domain data directories), note that these files store persona *names*, not voice IDs. The voice ID is resolved at synthesis time from the persona name. So your custom voice IDs will be picked up automatically without regenerating these files.

--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 from tau2.config import DEFAULT_AUDIO_NATIVE_MODELS, DEFAULT_LLM_USER, DEFAULT_SEED
 
-
 DEFAULT_DOMAINS = ["airline", "retail"]
 DEFAULT_COMPLEXITIES = ["control", "regular"]
 
@@ -33,19 +32,30 @@ def build_command(
     max_concurrency: int = 8,
 ) -> list[str]:
     cmd = [
-        "uv", "run", "tau2", "run",
-        "--domain", domain,
+        "uv",
+        "run",
+        "tau2",
+        "run",
+        "--domain",
+        domain,
         "--audio-native",
-        "--audio-native-provider", provider,
-        "--audio-native-model", model,
-        "--speech-complexity", complexity,
-        "--seed", str(seed),
-        "--user-llm", user_llm,
-        "--max-concurrency", str(max_concurrency),
+        "--audio-native-provider",
+        provider,
+        "--audio-native-model",
+        model,
+        "--speech-complexity",
+        complexity,
+        "--seed",
+        str(seed),
+        "--user-llm",
+        user_llm,
+        "--max-concurrency",
+        str(max_concurrency),
         "--verbose-logs",
         "--auto-review",
         "--auto-resume",
-        "--save-to", save_to,
+        "--save-to",
+        save_to,
     ]
     if num_tasks is not None:
         cmd.extend(["--num-tasks", str(num_tasks)])
@@ -117,7 +127,11 @@ def main():
 
         print(f"[{i}/{total}] {run_name}")
         cmd = build_command(
-            domain, provider, model, complexity, save_to,
+            domain,
+            provider,
+            model,
+            complexity,
+            save_to,
             num_tasks=args.num_tasks,
             seed=args.seed,
             user_llm=args.user_llm,

--- a/src/tau2/data_model/voice_personas.py
+++ b/src/tau2/data_model/voice_personas.py
@@ -1,11 +1,40 @@
 # Copyright Sierra
-"""Voice persona definitions for user simulation."""
+"""Voice persona definitions for user simulation.
 
+Each persona ships with a default ElevenLabs ``voice_id`` used for TTS.
+These defaults are Sierra's internal voices and **will not work** for
+external users. To run voice evaluations you need to create your own
+voices and tell the framework about them.
+
+Quick override
+--------------
+Set an environment variable for any persona to replace its voice ID at
+runtime (no code changes needed)::
+
+    # Pattern: TAU2_VOICE_ID_<PERSONA_NAME_UPPER>
+    export TAU2_VOICE_ID_MATT_DELANEY=your_voice_id_here
+    export TAU2_VOICE_ID_LISA_BRENNER=your_voice_id_here
+
+See ``docs/voice-personas.md`` for a step-by-step guide to creating
+matching voices with the ElevenLabs Voice Design tool.
+"""
+
+import os
 from typing import Literal, Optional
 
 from pydantic import BaseModel
 
 PersonaComplexity = Literal["control", "regular"]
+
+
+def _resolve_voice_id(persona_name: str, default_id: str) -> str:
+    """Resolve voice ID from env variable, falling back to the default.
+
+    Env variable pattern: ``TAU2_VOICE_ID_<PERSONA_NAME_UPPER>``
+    e.g. ``TAU2_VOICE_ID_MATT_DELANEY`` for the ``matt_delaney`` persona.
+    """
+    env_key = f"TAU2_VOICE_ID_{persona_name.upper()}"
+    return os.environ.get(env_key, default_id)
 
 
 class VoicePersona(BaseModel):
@@ -20,7 +49,7 @@ class VoicePersona(BaseModel):
 
 
 MATT_DELANEY = VoicePersona(
-    elevenlabs_voice_id="EZfwTIuZL0WWIVnjSgTF",
+    elevenlabs_voice_id=_resolve_voice_id("matt_delaney", "EZfwTIuZL0WWIVnjSgTF"),
     name="matt_delaney",
     display_name="Matt Delaney",
     short_description="Middle-aged white man from the American Midwest, calm and respectful",
@@ -40,7 +69,7 @@ You rarely use formal or stiff language ("considerable," "retrieve," "representa
 )
 
 LISA_BRENNER = VoicePersona(
-    elevenlabs_voice_id="avQFHuQU7IjJf0u5MMBq",
+    elevenlabs_voice_id=_resolve_voice_id("lisa_brenner", "avQFHuQU7IjJf0u5MMBq"),
     name="lisa_brenner",
     display_name="Lisa Brenner",
     short_description="White woman in her late 40s from a suburban area, tense and impatient",
@@ -62,7 +91,7 @@ You never sound relaxed. You never use slow, reflective speech. You never thank 
 )
 
 MILDRED_KAPLAN = VoicePersona(
-    elevenlabs_voice_id="oNqrZRHHLWtHYsVNkRqe",
+    elevenlabs_voice_id=_resolve_voice_id("mildred_kaplan", "oNqrZRHHLWtHYsVNkRqe"),
     name="mildred_kaplan",
     display_name="Mildred Kaplan",
     short_description="Elderly white woman in her early 80s, needs help with technology",
@@ -71,7 +100,7 @@ MILDRED_KAPLAN = VoicePersona(
 )
 
 ARJUN_ROY = VoicePersona(
-    elevenlabs_voice_id="m1hMce9ingsjyIjkshRv",
+    elevenlabs_voice_id=_resolve_voice_id("arjun_roy", "m1hMce9ingsjyIjkshRv"),
     name="arjun_roy",
     display_name="Arjun Roy",
     short_description="Bengali man from Dhaka in his mid-30s, calm and direct",
@@ -80,7 +109,7 @@ ARJUN_ROY = VoicePersona(
 )
 
 WEI_LIN = VoicePersona(
-    elevenlabs_voice_id="GQ2S7ULnVjrOALFRfnsh",
+    elevenlabs_voice_id=_resolve_voice_id("wei_lin", "GQ2S7ULnVjrOALFRfnsh"),
     name="wei_lin",
     display_name="Wei Lin",
     short_description="Chinese woman from Sichuan in her late 20s, upbeat and matter-of-fact",
@@ -89,7 +118,7 @@ WEI_LIN = VoicePersona(
 )
 
 MAMADOU_DIALLO = VoicePersona(
-    elevenlabs_voice_id="ET3963lBcRmodt3ZaTBS",
+    elevenlabs_voice_id=_resolve_voice_id("mamadou_diallo", "ET3963lBcRmodt3ZaTBS"),
     name="mamadou_diallo",
     display_name="Mamadou Diallo",
     short_description="Senegalese man in his mid-30s, hurried with French accent",
@@ -98,7 +127,7 @@ MAMADOU_DIALLO = VoicePersona(
 )
 
 PRIYA_PATIL = VoicePersona(
-    elevenlabs_voice_id="mnHhNJntmsPxJsZvYVM7",
+    elevenlabs_voice_id=_resolve_voice_id("priya_patil", "mnHhNJntmsPxJsZvYVM7"),
     name="priya_patil",
     display_name="Priya Patil",
     short_description="Maharashtrian woman in her early 30s, hurried and focused",

--- a/src/tau2/voice/README.md
+++ b/src/tau2/voice/README.md
@@ -109,6 +109,23 @@ The voice module has two main components:
 
 - **`utils/`** — Audio format conversion, WAV I/O, and shared helpers.
 
+## Voice Persona Setup
+
+The user simulator uses ElevenLabs voices defined in `src/tau2/data_model/voice_personas.py`. The default voice IDs are Sierra-internal and **will not work** for external users.
+
+To run voice evaluations, create your own voices in ElevenLabs and configure them via environment variables:
+
+```bash
+# In your .env file:
+TAU2_VOICE_ID_MATT_DELANEY=your_voice_id_here
+TAU2_VOICE_ID_LISA_BRENNER=your_voice_id_here
+# ... (one per persona)
+```
+
+For a minimal setup, create just the two control personas and use `--speech-complexity control`.
+
+See the [Voice Persona Setup Guide](../../docs/voice-personas.md) for step-by-step instructions on creating matching voices with ElevenLabs Voice Design.
+
 ## Environment Variables
 
 | Variable | Used by |
@@ -118,3 +135,4 @@ The voice module has two main components:
 | `XAI_API_KEY` | xAI Grok Voice provider |
 | `ELEVENLABS_API_KEY` | User simulator TTS (synthesis) |
 | `DEEPGRAM_API_KEY` | Transcription (Deepgram nova-2, nova-3) |
+| `TAU2_VOICE_ID_*` | Custom voice ID overrides (see [Voice Persona Setup](../../docs/voice-personas.md)) |


### PR DESCRIPTION
## Summary

- Voice persona ElevenLabs voice IDs can now be overridden via `TAU2_VOICE_ID_<NAME>` environment variables (e.g. `TAU2_VOICE_ID_MATT_DELANEY=...`), so external users can run voice evaluations without modifying source code
- Adds `docs/voice-personas.md` with step-by-step instructions for creating custom voices using ElevenLabs Voice Design, including the exact prompts to use for each persona
- Updates `docs/leaderboard-submission.md` with full voice evaluation commands (mirroring the existing text eval section) and a voice persona setup section for local development
- Updates `docs/getting-started.md`, `src/tau2/voice/README.md`, and `.env.example` to reference the new setup guide

## Motivation

The default ElevenLabs voice IDs are Sierra-internal and don't work for external users. Previously, the only way to use custom voices was to edit `voice_personas.py` directly. There was no documentation explaining this limitation or how to set up custom voices.

## Test plan

- [x] Verified default fallback works (returns hardcoded ID when env var is not set)
- [x] Verified env override works (`TAU2_VOICE_ID_MATT_DELANEY=test_id` correctly replaces the default)
- [x] All 176 core tests pass (`make test`)
- [x] Ruff lint and format pass (`make check-all`)

Made with [Cursor](https://cursor.com)