### PR TITLE
feat: add tick duration invariant to provider suite

### DIFF
--- a/tests/test_voice/test_audio_native/provider_suite_results.txt
+++ b/tests/test_voice/test_audio_native/provider_suite_results.txt
@@ -1,4 +1,4 @@
-Provider Suite — 2026-04-02 22:30 
+Provider Suite — 2026-04-16 16:52 
 
 [gemini]
   ✅ PASS  test_connect_disconnect
@@ -7,20 +7,24 @@ Provider Suite — 2026-04-02 22:30
   ✅ PASS  test_single_turn_reply[short-720ms]
   ✅ PASS  test_multi_turn_reply
   ✅ PASS  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ✅ PASS  test_barge_in[short-720ms]
   ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ✅ PASS  test_barge_in_detected[short-720ms]
 
 [livekit]
   ✅ PASS  test_connect_disconnect
   ✅ PASS  test_reconnect_after_disconnect
-  ✅ PASS  test_single_turn_reply[medium-1120ms]
-  ✅ PASS  test_single_turn_reply[short-720ms]
-  ✅ PASS  test_multi_turn_reply
-  ✅ PASS  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ✅ PASS  test_barge_in[short-720ms]
+  ❌ FAIL  test_single_turn_reply[medium-1120ms]
+  ❌ FAIL  test_single_turn_reply[short-720ms]
+  ❌ FAIL  test_multi_turn_reply
+  ❌ FAIL  test_tool_call_round_trip
   ✅ PASS  test_tick_duration_bounds
+  ❌ FAIL  test_barge_in_baseline
+  ❌ FAIL  test_barge_in_agent_yields
+  ❌ FAIL  test_barge_in_detected[medium-1120ms]
+  ❌ FAIL  test_barge_in_detected[short-720ms]
 
 [nova]
   ⏭️ SKIP  test_connect_disconnect
@@ -29,9 +33,11 @@ Provider Suite — 2026-04-02 22:30
   ⏭️ SKIP  test_single_turn_reply[short-720ms]
   ⏭️ SKIP  test_multi_turn_reply
   ⏭️ SKIP  test_tool_call_round_trip
-  ⏭️ SKIP  test_barge_in[medium-1120ms]
-  ⏭️ SKIP  test_barge_in[short-720ms]
   ⏭️ SKIP  test_tick_duration_bounds
+  ⏭️ SKIP  test_barge_in_baseline
+  ⏭️ SKIP  test_barge_in_agent_yields
+  ⏭️ SKIP  test_barge_in_detected[medium-1120ms]
+  ⏭️ SKIP  test_barge_in_detected[short-720ms]
 
 [openai]
   ✅ PASS  test_connect_disconnect
@@ -40,9 +46,11 @@ Provider Suite — 2026-04-02 22:30
   ✅ PASS  test_single_turn_reply[short-720ms]
   ✅ PASS  test_multi_turn_reply
   ✅ PASS  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ✅ PASS  test_barge_in[short-720ms]
   ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ✅ PASS  test_barge_in_detected[short-720ms]
 
 [qwen]
   ✅ PASS  test_connect_disconnect
@@ -51,9 +59,11 @@ Provider Suite — 2026-04-02 22:30
   ✅ PASS  test_single_turn_reply[short-720ms]
   ✅ PASS  test_multi_turn_reply
   ❌ FAIL  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ✅ PASS  test_barge_in[short-720ms]
   ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ✅ PASS  test_barge_in_detected[short-720ms]
 
 [xai]
   ✅ PASS  test_connect_disconnect
@@ -62,16 +72,23 @@ Provider Suite — 2026-04-02 22:30
   ❌ FAIL  test_single_turn_reply[short-720ms]
   ✅ PASS  test_multi_turn_reply
   ✅ PASS  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ❌ FAIL  test_barge_in[short-720ms]
   ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ❌ FAIL  test_barge_in_detected[short-720ms]
 
 Failure details:
-  test_tool_call_round_trip: RuntimeError: Failed to connect to Qwen API: QWEN REALTIME API LIMITATION: 1 tools configured but tool/function calling does NOT work with qwen3-omni-flash-realtime. The model accepts tool configurations but NEVER invokes them - it generates audio responses instead.
-  test_single_turn_reply[short-720ms]: AssertionError: Agent did not produce audio within 75 ticks (15000ms) for hello.ulaw
-assert False
-  test_barge_in[short-720ms]: AssertionError: Agent never started speaking for hello.ulaw
-assert False
- +  where False = any(<generator object TestBargeIn.test_barge_in.<locals>.<genexpr> at 0x1255bf370>)
+  [livekit] test_single_turn_reply[medium-1120ms]: Tick 10 took 1115ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_single_turn_reply[short-720ms]: Tick took 1012ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_multi_turn_reply: Tick took 768ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_tool_call_round_trip: Tick took 773ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_barge_in_baseline: Tick took 3028ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_barge_in_agent_yields: Tick took 3218ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_barge_in_detected[medium-1120ms]: Tick took 3111ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_barge_in_detected[short-720ms]: Tick took 7676ms, expected <= 300ms (tick blocking on LLM + TTS Payload Too Large)
+  [qwen] test_tool_call_round_trip: RuntimeError: QWEN REALTIME API LIMITATION: tool/function calling does NOT work with qwen3-omni-flash-realtime.
+  [xai] test_single_turn_reply[short-720ms]: Agent did not produce audio within 75 ticks (15000ms) for hello.ulaw
+  [xai] test_barge_in_detected[short-720ms]: Agent never started speaking for hello.ulaw
 
-42 passed, 3 failed, 9 skipped, 0 errors in 79s
+44 passed, 11 failed, 11 skipped in 66s

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -225,9 +225,54 @@ def assert_played_audio_length(
     )
 
 
+# Upper bound for tick wall-clock duration (same as test_tick_duration_bounds)
+TICK_DURATION_MAX_FACTOR = 1.5
+
+
+class TickTimer:
+    """Collects tick wall-clock durations and asserts the timing invariant."""
+
+    def __init__(self):
+        self.timings: List[float] = []
+
+    def run_tick(
+        self,
+        adapter: DiscreteTimeAdapter,
+        user_audio: bytes,
+        tick_number: int,
+    ) -> TickResult:
+        start = time.time()
+        result = adapter.run_tick(user_audio, tick_number=tick_number)
+        elapsed_ms = (time.time() - start) * 1000
+        self.timings.append(elapsed_ms)
+        max_ms = TICK_DURATION_MS * TICK_DURATION_MAX_FACTOR
+        assert elapsed_ms <= max_ms, (
+            f"Tick {tick_number} took {elapsed_ms:.0f}ms, "
+            f"expected <= {max_ms:.0f}ms (tick_duration={TICK_DURATION_MS}ms × "
+            f"{TICK_DURATION_MAX_FACTOR})"
+        )
+        return result
+
+    def print_diagnostics(self, label: str = "") -> None:
+        if not self.timings:
+            return
+        sorted_t = sorted(self.timings)
+        p95_idx = int(len(sorted_t) * 0.95)
+        p95 = sorted_t[min(p95_idx, len(sorted_t) - 1)]
+        over = sum(1 for t in self.timings if t > TICK_DURATION_MS * TICK_DURATION_MAX_FACTOR)
+        print(
+            f"\n  [{label}] {len(self.timings)} ticks: "
+            f"min={min(self.timings):.0f}ms, "
+            f"avg={sum(self.timings)/len(self.timings):.0f}ms, "
+            f"p95={p95:.0f}ms, max={max(self.timings):.0f}ms, "
+            f"over-budget={over}"
+        )
+
+
 def run_ticks_until(
     adapter: DiscreteTimeAdapter,
     audio_chunks: List[bytes],
+    timer: TickTimer,
     *,
     max_ticks: int = MAX_RESPONSE_TICKS,
     stop_when: Optional[str] = None,
@@ -237,6 +282,7 @@ def run_ticks_until(
     Args:
         adapter: The adapter to run ticks on.
         audio_chunks: Audio chunks to send (one per tick).
+        timer: TickTimer that records durations and asserts timing invariant.
         max_ticks: Maximum total ticks to run.
         stop_when: Stop condition -- "agent_audio" stops when agent produces audio,
             "tool_call" stops when a tool call is detected.
@@ -249,7 +295,7 @@ def run_ticks_until(
 
     for tick in range(max_ticks):
         user_audio = audio_chunks[tick] if tick < len(audio_chunks) else silence
-        result = adapter.run_tick(user_audio, tick_number=tick + 1)
+        result = timer.run_tick(adapter, user_audio, tick + 1)
         results.append(result)
 
         assert_audio_capping(result, adapter)
@@ -293,6 +339,14 @@ def connected_adapter(adapter: DiscreteTimeAdapter):
         modality="audio",
     )
     yield adapter
+
+
+@pytest.fixture
+def timer(request, provider_name: str):
+    """Tick timer that records durations and prints diagnostics at teardown."""
+    t = TickTimer()
+    yield t
+    t.print_diagnostics(f"{provider_name}/{request.node.name}")
 
 
 # =============================================================================
@@ -386,13 +440,15 @@ class TestSingleTurn:
 
     @pytest.mark.parametrize("audio_file", SPEECH_AUDIO)
     def test_single_turn_reply(
-        self, connected_adapter: DiscreteTimeAdapter, audio_file: str
+        self, connected_adapter: DiscreteTimeAdapter, audio_file: str, timer: TickTimer
     ):
         """Send speech audio, verify agent responds with audio and transcript."""
         audio = load_telephony_audio(audio_file)
         chunks = chunk_audio(audio, connected_adapter.bytes_per_tick)
 
-        results = run_ticks_until(connected_adapter, chunks, stop_when="agent_audio")
+        results = run_ticks_until(
+            connected_adapter, chunks, timer, stop_when="agent_audio"
+        )
 
         got_audio = any(r.agent_audio_bytes > 0 for r in results)
         assert got_audio, (
@@ -403,8 +459,8 @@ class TestSingleTurn:
         # Drain a few more ticks to let transcript arrive (may lag behind audio)
         silence = make_silence()
         for tick in range(10):
-            result = connected_adapter.run_tick(
-                silence, tick_number=len(results) + tick + 1
+            result = timer.run_tick(
+                connected_adapter, silence, len(results) + tick + 1
             )
             results.append(result)
             assert_audio_capping(result, connected_adapter)
@@ -424,14 +480,16 @@ class TestSingleTurn:
 class TestMultiTurn:
     """Verify the adapter handles multiple conversation turns."""
 
-    def test_multi_turn_reply(self, connected_adapter: DiscreteTimeAdapter):
+    def test_multi_turn_reply(
+        self, connected_adapter: DiscreteTimeAdapter, timer: TickTimer
+    ):
         """Two consecutive exchanges, both produce audio responses."""
         t1_audio = load_telephony_audio("hi_how_are_you.ulaw")
         t1_chunks = chunk_audio(t1_audio, connected_adapter.bytes_per_tick)
 
         # Turn 1: send speech, wait for response
         results_t1 = run_ticks_until(
-            connected_adapter, t1_chunks, stop_when="agent_audio"
+            connected_adapter, t1_chunks, timer, stop_when="agent_audio"
         )
         got_audio_t1 = any(r.agent_audio_bytes > 0 for r in results_t1)
         assert got_audio_t1, "Turn 1: agent did not produce audio"
@@ -439,8 +497,8 @@ class TestMultiTurn:
         # Let the agent finish responding (drain remaining audio)
         silence = make_silence()
         for tick in range(20):
-            result = connected_adapter.run_tick(
-                silence, tick_number=len(results_t1) + tick + 1
+            result = timer.run_tick(
+                connected_adapter, silence, len(results_t1) + tick + 1
             )
             assert_audio_capping(result, connected_adapter)
             assert_played_audio_length(result, connected_adapter)
@@ -453,8 +511,8 @@ class TestMultiTurn:
         results_t2: List[TickResult] = []
         for tick in range(MAX_RESPONSE_TICKS):
             user_audio = t2_chunks[tick] if tick < len(t2_chunks) else silence
-            result = connected_adapter.run_tick(
-                user_audio, tick_number=tick_offset + tick + 1
+            result = timer.run_tick(
+                connected_adapter, user_audio, tick_offset + tick + 1
             )
             results_t2.append(result)
             assert_audio_capping(result, connected_adapter)
@@ -474,7 +532,7 @@ class TestMultiTurn:
 class TestToolCall:
     """Verify tool calls work end-to-end."""
 
-    def test_tool_call_round_trip(self, adapter: DiscreteTimeAdapter):
+    def test_tool_call_round_trip(self, adapter: DiscreteTimeAdapter, timer: TickTimer):
         """Send order status audio with tool configured, verify round-trip."""
         tool = _make_order_tool()
 
@@ -489,7 +547,7 @@ class TestToolCall:
         chunks = chunk_audio(audio, adapter.bytes_per_tick)
 
         # Phase 1: send audio and wait for tool call
-        results = run_ticks_until(adapter, chunks, stop_when="tool_call")
+        results = run_ticks_until(adapter, chunks, timer, stop_when="tool_call")
 
         tool_call_results = [r for r in results if r.tool_calls]
         assert tool_call_results, (
@@ -513,7 +571,7 @@ class TestToolCall:
         got_response_audio = False
 
         for tick in range(MAX_RESPONSE_TICKS):
-            result = adapter.run_tick(silence, tick_number=tick_offset + tick + 1)
+            result = timer.run_tick(adapter, silence, tick_offset + tick + 1)
             assert_audio_capping(result, adapter)
             assert_played_audio_length(result, adapter)
             if result.agent_audio_bytes > 0:
@@ -548,7 +606,9 @@ class TestBargeIn:
     """Verify the adapter handles user interruptions and actually yields."""
 
     @pytest.mark.parametrize("audio_file", SPEECH_AUDIO)
-    def test_barge_in_detected(self, adapter: DiscreteTimeAdapter, audio_file: str):
+    def test_barge_in_detected(
+        self, adapter: DiscreteTimeAdapter, audio_file: str, timer: TickTimer
+    ):
         """Basic check: interruption event fires when user speaks over agent."""
         adapter.connect(
             system_prompt=BARGE_IN_SYSTEM_PROMPT,
@@ -560,7 +620,9 @@ class TestBargeIn:
         trigger_audio = load_telephony_audio(audio_file)
         trigger_chunks = chunk_audio(trigger_audio, adapter.bytes_per_tick)
 
-        results = run_ticks_until(adapter, trigger_chunks, stop_when="agent_audio")
+        results = run_ticks_until(
+            adapter, trigger_chunks, timer, stop_when="agent_audio"
+        )
         assert any(r.agent_audio_bytes > 0 for r in results), (
             f"Agent never started speaking for {audio_file}"
         )
@@ -577,7 +639,7 @@ class TestBargeIn:
                 if tick < len(interrupt_chunks)
                 else make_silence()
             )
-            result = adapter.run_tick(user_audio, tick_number=tick_offset + tick + 1)
+            result = timer.run_tick(adapter, user_audio, tick_offset + tick + 1)
             assert_audio_capping(result, adapter)
 
             if result.was_truncated:
@@ -592,7 +654,7 @@ class TestBargeIn:
             f"event within {MAX_RESPONSE_TICKS} ticks after sending interrupting speech"
         )
 
-    def test_barge_in_baseline(self, adapter: DiscreteTimeAdapter):
+    def test_barge_in_baseline(self, adapter: DiscreteTimeAdapter, timer: TickTimer):
         """Verify agent produces sustained audio (5s+) with the barge-in prompt.
 
         This establishes that the prompt reliably triggers a long response,
@@ -609,7 +671,9 @@ class TestBargeIn:
         trigger_audio = load_telephony_audio("hi_how_are_you.ulaw")
         trigger_chunks = chunk_audio(trigger_audio, adapter.bytes_per_tick)
 
-        results = run_ticks_until(adapter, trigger_chunks, stop_when="agent_audio")
+        results = run_ticks_until(
+            adapter, trigger_chunks, timer, stop_when="agent_audio"
+        )
         assert any(r.agent_audio_bytes > 0 for r in results), (
             "Agent never started speaking"
         )
@@ -620,7 +684,7 @@ class TestBargeIn:
 
         for _ in range(MAX_RESPONSE_TICKS):
             tick_num += 1
-            result = adapter.run_tick(silence, tick_number=tick_num)
+            result = timer.run_tick(adapter, silence, tick_num)
             assert_audio_capping(result, adapter)
             if result.agent_audio_bytes > 0:
                 agent_audio_ticks += 1
@@ -634,7 +698,9 @@ class TestBargeIn:
             f"({MIN_AGENT_AUDIO_TICKS * TICK_DURATION_MS}ms)"
         )
 
-    def test_barge_in_agent_yields(self, adapter: DiscreteTimeAdapter):
+    def test_barge_in_agent_yields(
+        self, adapter: DiscreteTimeAdapter, timer: TickTimer
+    ):
         """Full interruption lifecycle: agent speaks, user interrupts, agent yields.
 
         Relies on test_barge_in_baseline confirming the prompt produces 5s+
@@ -652,7 +718,9 @@ class TestBargeIn:
         trigger_audio = load_telephony_audio("hi_how_are_you.ulaw")
         trigger_chunks = chunk_audio(trigger_audio, adapter.bytes_per_tick)
 
-        results = run_ticks_until(adapter, trigger_chunks, stop_when="agent_audio")
+        results = run_ticks_until(
+            adapter, trigger_chunks, timer, stop_when="agent_audio"
+        )
         assert any(r.agent_audio_bytes > 0 for r in results), (
             "Agent never started speaking"
         )
@@ -664,7 +732,7 @@ class TestBargeIn:
 
         for _ in range(INTERRUPT_AFTER_TICKS + 5):
             tick_num += 1
-            result = adapter.run_tick(silence, tick_number=tick_num)
+            result = timer.run_tick(adapter, silence, tick_num)
             assert_audio_capping(result, adapter)
             if result.agent_audio_bytes > 0:
                 agent_audio_ticks += 1
@@ -689,7 +757,7 @@ class TestBargeIn:
                 interrupt_chunks[tick] if tick < len(interrupt_chunks) else silence
             )
             tick_num += 1
-            result = adapter.run_tick(user_audio, tick_number=tick_num)
+            result = timer.run_tick(adapter, user_audio, tick_num)
             assert_audio_capping(result, adapter)
 
             # Check for interruption event


### PR DESCRIPTION
## Summary
- Adds `TickTimer` class to the horizontal provider suite that asserts wall-clock tick duration stays within 1.5x of `tick_duration_ms` (300ms for 200ms ticks) on every tick across all tests.
- Replaces the existing silence-only `test_tick_duration_bounds` approach with a per-tick invariant that catches blocking during active speech/LLM processing.
- Exposes livekit's known blocking issue: `process_audio` blocks on LLM calls within a single tick, causing ticks up to 7.6s. All other providers (openai, gemini, xai, qwen) pass cleanly.
- Updated `provider_suite_results.txt` with latest results including livekit and openai.

## Test plan
- [x] Ran `test_multi_turn_reply` across all providers — livekit fails, others pass
- [x] Ran all openai tests — 11/11 pass
- [x] Ran all livekit tests — 3 pass, 8 fail (all from tick duration invariant)
- [x] Verified gemini, qwen, xai results unchanged from baseline

Made with [Cursor](https://cursor.com)