### PR TITLE
feat: warn on non-official voice IDs and persist voice_id in results

### DIFF
--- a/src/tau2/data_model/voice.py
+++ b/src/tau2/data_model/voice.py
@@ -14,7 +14,7 @@ from tau2.data_model.audio_effects import (
     SpeechEffectsConfig,
 )
 from tau2.data_model.persona import PersonaConfig
-from tau2.data_model.voice_personas import DEFAULT_PERSONA_NAME
+from tau2.data_model.voice_personas import DEFAULT_PERSONA_NAME, get_elevenlabs_voice_id
 from tau2.voice_config import (
     BURST_NOISE_EVENTS_PER_MINUTE,
     DEFAULT_TRANSCRIPTION_MODEL,
@@ -166,6 +166,10 @@ class SpeechEnvironment(BaseModel):
 
     voice_seed: int = Field(default=DEFAULT_SEED)
     persona_name: str = Field(default=DEFAULT_PERSONA_NAME)
+    voice_id: Optional[str] = Field(
+        default=None,
+        description="The TTS voice ID actually used for synthesis.",
+    )
     background_noise_file: Optional[str] = Field(default=None)
     burst_noise_files: list[str] = Field(
         default_factory=list,
@@ -270,6 +274,7 @@ class SampledVoiceConfig(BaseModel):
         return SpeechEnvironment(
             voice_seed=seed,
             persona_name=self.persona_name,
+            voice_id=get_elevenlabs_voice_id(self.persona_name),
             background_noise_file=self.background_noise_file,
             burst_noise_files=self.burst_noise_files,
             environment=self.environment,

--- a/src/tau2/data_model/voice_personas.py
+++ b/src/tau2/data_model/voice_personas.py
@@ -19,12 +19,17 @@ See ``docs/voice-personas.md`` for a step-by-step guide to creating
 matching voices with the ElevenLabs Voice Design tool.
 """
 
+import logging
 import os
 from typing import Literal, Optional
 
 from pydantic import BaseModel
 
+logger = logging.getLogger(__name__)
+
 PersonaComplexity = Literal["control", "regular"]
+
+_overridden_personas: list[str] = []
 
 
 def _resolve_voice_id(persona_name: str, default_id: str) -> str:
@@ -34,7 +39,18 @@ def _resolve_voice_id(persona_name: str, default_id: str) -> str:
     e.g. ``TAU2_VOICE_ID_MATT_DELANEY`` for the ``matt_delaney`` persona.
     """
     env_key = f"TAU2_VOICE_ID_{persona_name.upper()}"
-    return os.environ.get(env_key, default_id)
+    voice_id = os.environ.get(env_key)
+    if voice_id is not None:
+        _overridden_personas.append(persona_name)
+        logger.warning(
+            "Using NON-OFFICIAL voice ID for persona '%s' "
+            "(from env var %s). Evaluation results may not be "
+            "comparable to the official leaderboard.",
+            persona_name,
+            env_key,
+        )
+        return voice_id
+    return default_id
 
 
 class VoicePersona(BaseModel):
@@ -138,6 +154,33 @@ ALL_PERSONA_NAMES: list[str] = list(ALL_PERSONAS.keys())
 CONTROL_PERSONA_NAMES: list[str] = [p.name for p in CONTROL_PERSONAS]
 REGULAR_PERSONA_NAMES: list[str] = [p.name for p in REGULAR_PERSONAS]
 DEFAULT_PERSONA_NAME = "matt_delaney"
+
+
+def get_voice_id_overrides() -> list[str]:
+    """Return the list of persona names using non-official voice IDs."""
+    return list(_overridden_personas)
+
+
+def warn_if_non_official_voices() -> None:
+    """Log a prominent warning if any voice IDs were overridden.
+
+    Call this at startup (e.g. in the CLI or runner) to surface the
+    override summary early in the log output.
+    """
+    if _overridden_personas:
+        names = ", ".join(_overridden_personas)
+        logger.warning(
+            "\n"
+            "============================================================\n"
+            "  NON-OFFICIAL VOICE IDs IN USE\n"
+            "  The following personas use voice IDs from environment\n"
+            "  variables instead of the official τ-bench defaults:\n"
+            "    %s\n"
+            "  Results produced with non-official voices are NOT\n"
+            "  comparable to the official leaderboard.\n"
+            "============================================================",
+            names,
+        )
 
 
 def get_elevenlabs_voice_id(persona_name: str) -> str:

--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -35,6 +35,7 @@ from tau2.data_model.simulation import (
 )
 from tau2.data_model.tasks import Task
 from tau2.data_model.voice import SynthesisConfig, VoiceSettings
+from tau2.data_model.voice_personas import warn_if_non_official_voices
 from tau2.evaluator.evaluator import EvaluationType
 from tau2.evaluator.reviewer import check_hallucination, format_hallucination_feedback
 from tau2.metrics.agent_metrics import compute_metrics
@@ -858,6 +859,9 @@ def run_domain(config: RunConfig) -> Results:
     """
     config.validate()
     ConsoleDisplay.display_run_config(config)
+
+    if isinstance(config, VoiceRunConfig):
+        warn_if_non_official_voices()
 
     # Load tasks
     task_set_name = config.task_set_name or config.domain


### PR DESCRIPTION
## Summary
- Log a per-persona warning and a run-level banner when voice IDs are overridden via `TAU2_VOICE_ID_*` environment variables, making it clear that evaluation results are not comparable to the official leaderboard.
- Add a `voice_id` field to `SpeechEnvironment` so the actual TTS voice ID used for synthesis is recorded in saved simulation results (backward-compatible, defaults to `None` for old data).
- Call `warn_if_non_official_voices()` at the start of voice runs in `run_domain()`.

## Test plan
- [x] `make test` passes (175/176, 1 pre-existing flaky test unrelated to this change)
- [x] `make check-all` passes (pre-commit hook verified on commit)
- [x] Verify warning appears when running with `TAU2_VOICE_ID_*` env vars set
- [ ] Verify `voice_id` field is populated in saved `SpeechEnvironment` for new voice runs
- [ ] Verify old results without `voice_id` still deserialize correctly (`default=None`)


Made with [Cursor](https://cursor.com)