### PR TITLE
feat: migrate OpenAI provider to GA Realtime API

### DIFF
--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -18,6 +18,11 @@ from tau2.config import DEFAULT_AUDIO_NATIVE_MODELS, DEFAULT_LLM_USER, DEFAULT_S
 DEFAULT_DOMAINS = ["airline", "retail"]
 DEFAULT_COMPLEXITIES = ["control", "regular"]
 
+# Virtual providers that map to a real provider + cascaded config
+VIRTUAL_PROVIDERS = {
+    "livekit-thinking": ("livekit", "openai-thinking"),
+}
+
 
 def build_command(
     domain: str,
@@ -26,6 +31,7 @@ def build_command(
     complexity: str,
     save_to: str,
     *,
+    cascaded_config: str | None = None,
     num_tasks: int | None = None,
     seed: int = DEFAULT_SEED,
     user_llm: str = DEFAULT_LLM_USER,
@@ -57,6 +63,8 @@ def build_command(
         "--save-to",
         save_to,
     ]
+    if cascaded_config is not None:
+        cmd.extend(["--cascaded-config", cascaded_config])
     if num_tasks is not None:
         cmd.extend(["--num-tasks", str(num_tasks)])
     return cmd
@@ -70,7 +78,7 @@ def main():
         "--providers",
         type=str,
         required=True,
-        help="Comma-separated providers (e.g. openai,gemini,xai,livekit)",
+        help="Comma-separated providers (e.g. openai,gemini,xai,livekit,livekit-thinking)",
     )
     parser.add_argument(
         "--domains",
@@ -100,29 +108,35 @@ def main():
     domains = [d.strip() for d in args.domains.split(",")]
     complexities = [c.strip() for c in args.complexities.split(",")]
 
-    # Resolve provider -> model, supporting "provider:model" override
-    provider_models = []
+    # Resolve provider -> (real_provider, model, cascaded_config, display_name)
+    provider_entries = []
     for p in providers:
-        if ":" in p:
+        if p in VIRTUAL_PROVIDERS:
+            real_provider, cascaded = VIRTUAL_PROVIDERS[p]
+            model = DEFAULT_AUDIO_NATIVE_MODELS[real_provider]
+            provider_entries.append((real_provider, model, cascaded, p))
+        elif ":" in p:
             prov, model = p.split(":", 1)
+            provider_entries.append((prov, model, None, p))
         else:
-            prov, model = p, DEFAULT_AUDIO_NATIVE_MODELS[p]
-        provider_models.append((prov, model))
+            provider_entries.append((p, DEFAULT_AUDIO_NATIVE_MODELS[p], None, p))
 
     base_dir = Path(args.save_to).resolve()
 
     combos = [
-        (domain, prov, model, complexity)
+        (domain, prov, model, cascaded, display, complexity)
         for domain in domains
-        for prov, model in provider_models
+        for prov, model, cascaded, display in provider_entries
         for complexity in complexities
     ]
     total = len(combos)
 
     print(f"Running {total} combinations -> {base_dir}\n")
 
-    for i, (domain, provider, model, complexity) in enumerate(combos, 1):
-        run_name = f"{domain}_{complexity}_{provider}_{model}"
+    for i, (domain, provider, model, cascaded, display, complexity) in enumerate(
+        combos, 1
+    ):
+        run_name = f"{domain}_{complexity}_{display}_{model}"
         save_to = str(base_dir / run_name)
 
         print(f"[{i}/{total}] {run_name}")
@@ -132,6 +146,7 @@ def main():
             model,
             complexity,
             save_to,
+            cascaded_config=cascaded,
             num_tasks=args.num_tasks,
             seed=args.seed,
             user_llm=args.user_llm,

--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -2,69 +2,109 @@
 """
 Run audio-native evaluations across providers and speech complexities.
 
+Provider syntax: "provider", "provider:model", or "provider:model:reasoning"
+  - openai                           (default model, no reasoning)
+  - openai:gpt-realtime-1.5          (specific model)
+  - openai:gpt-realtime-1.5:high     (model + reasoning effort)
+  - livekit                           (default cascaded config)
+  - livekit::openai-thinking          (default model + cascaded config)
+
 Usage:
-    python -m experiments.tau_voice.run_multiple --providers openai,gemini,xai --save-to data/exp/my_run
-    python -m experiments.tau_voice.run_multiple --providers openai --save-to data/exp/my_run --num-tasks 5
-    python -m experiments.tau_voice.run_multiple --providers openai,gemini --save-to data/exp/my_run --domains airline --complexities control
+    python -m experiments.tau_voice.run_multiple --providers openai,gemini --save-to data/exp/my_run
+    python -m experiments.tau_voice.run_multiple --providers openai:gpt-realtime-1.5:high --save-to data/exp/run --num-tasks 5
+    python -m experiments.tau_voice.run_multiple --providers livekit,livekit::openai-thinking --save-to data/exp/run
 """
 
 import argparse
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 from tau2.config import DEFAULT_AUDIO_NATIVE_MODELS, DEFAULT_LLM_USER, DEFAULT_SEED
 
 DEFAULT_DOMAINS = ["airline", "retail"]
 DEFAULT_COMPLEXITIES = ["control", "regular"]
 
-# Virtual providers that map to a real provider + cascaded config
-VIRTUAL_PROVIDERS = {
-    "livekit-thinking": ("livekit", "openai-thinking"),
-}
+
+@dataclass
+class ProviderSpec:
+    provider: str
+    model: str
+    reasoning_effort: Optional[str] = None
+    cascaded_config: Optional[str] = None
+    display_name: str = ""
+
+    def __post_init__(self):
+        if not self.display_name:
+            self.display_name = self.provider
+
+
+def parse_provider(spec: str) -> ProviderSpec:
+    """Parse provider spec: 'provider', 'provider:model', or 'provider:model:qualifier'.
+
+    For livekit, the third field is a cascaded config name (e.g. 'openai-thinking').
+    For all other providers, the third field is reasoning effort (e.g. 'high').
+    """
+    parts = spec.split(":")
+    provider = parts[0]
+    model = DEFAULT_AUDIO_NATIVE_MODELS.get(provider, "dummy")
+
+    if len(parts) == 1:
+        return ProviderSpec(provider=provider, model=model, display_name=spec)
+    elif len(parts) == 2:
+        if parts[1]:
+            model = parts[1]
+        return ProviderSpec(provider=provider, model=model, display_name=spec)
+    elif len(parts) == 3:
+        if parts[1]:
+            model = parts[1]
+        qualifier = parts[2]
+        if provider == "livekit":
+            return ProviderSpec(
+                provider=provider, model=model,
+                cascaded_config=qualifier, display_name=spec,
+            )
+        else:
+            return ProviderSpec(
+                provider=provider, model=model,
+                reasoning_effort=qualifier, display_name=spec,
+            )
+    else:
+        raise ValueError(f"Invalid provider spec: {spec}")
 
 
 def build_command(
     domain: str,
-    provider: str,
-    model: str,
+    spec: ProviderSpec,
     complexity: str,
     save_to: str,
     *,
-    cascaded_config: str | None = None,
     num_tasks: int | None = None,
     seed: int = DEFAULT_SEED,
     user_llm: str = DEFAULT_LLM_USER,
     max_concurrency: int = 8,
 ) -> list[str]:
     cmd = [
-        "uv",
-        "run",
-        "tau2",
-        "run",
-        "--domain",
-        domain,
+        "uv", "run", "tau2", "run",
+        "--domain", domain,
         "--audio-native",
-        "--audio-native-provider",
-        provider,
-        "--audio-native-model",
-        model,
-        "--speech-complexity",
-        complexity,
-        "--seed",
-        str(seed),
-        "--user-llm",
-        user_llm,
-        "--max-concurrency",
-        str(max_concurrency),
+        "--audio-native-provider", spec.provider,
+        "--audio-native-model", spec.model,
+        "--speech-complexity", complexity,
+        "--seed", str(seed),
+        "--user-llm", user_llm,
+        "--max-concurrency", str(max_concurrency),
         "--verbose-logs",
         "--auto-review",
         "--auto-resume",
-        "--save-to",
-        save_to,
+        "--save-to", save_to,
     ]
-    if cascaded_config is not None:
-        cmd.extend(["--cascaded-config", cascaded_config])
+    if spec.reasoning_effort is not None:
+        cmd.extend(["--reasoning-effort", spec.reasoning_effort])
+    if spec.cascaded_config is not None:
+        cmd.extend(["--cascaded-config", spec.cascaded_config])
     if num_tasks is not None:
         cmd.extend(["--num-tasks", str(num_tasks)])
     return cmd
@@ -78,7 +118,7 @@ def main():
         "--providers",
         type=str,
         required=True,
-        help="Comma-separated providers (e.g. openai,gemini,xai,livekit,livekit-thinking)",
+        help="Comma-separated provider specs (e.g. openai,openai:model:high,livekit::openai-thinking)",
     )
     parser.add_argument(
         "--domains",
@@ -104,49 +144,29 @@ def main():
     )
     args = parser.parse_args()
 
-    providers = [p.strip() for p in args.providers.split(",")]
+    specs = [parse_provider(p.strip()) for p in args.providers.split(",")]
     domains = [d.strip() for d in args.domains.split(",")]
     complexities = [c.strip() for c in args.complexities.split(",")]
-
-    # Resolve provider -> (real_provider, model, cascaded_config, display_name)
-    provider_entries = []
-    for p in providers:
-        if p in VIRTUAL_PROVIDERS:
-            real_provider, cascaded = VIRTUAL_PROVIDERS[p]
-            model = DEFAULT_AUDIO_NATIVE_MODELS[real_provider]
-            provider_entries.append((real_provider, model, cascaded, p))
-        elif ":" in p:
-            prov, model = p.split(":", 1)
-            provider_entries.append((prov, model, None, p))
-        else:
-            provider_entries.append((p, DEFAULT_AUDIO_NATIVE_MODELS[p], None, p))
 
     base_dir = Path(args.save_to).resolve()
 
     combos = [
-        (domain, prov, model, cascaded, display, complexity)
+        (domain, spec, complexity)
         for domain in domains
-        for prov, model, cascaded, display in provider_entries
+        for spec in specs
         for complexity in complexities
     ]
     total = len(combos)
 
     print(f"Running {total} combinations -> {base_dir}\n")
 
-    for i, (domain, provider, model, cascaded, display, complexity) in enumerate(
-        combos, 1
-    ):
-        run_name = f"{domain}_{complexity}_{display}_{model}"
+    for i, (domain, spec, complexity) in enumerate(combos, 1):
+        run_name = f"{domain}_{complexity}_{spec.display_name}".replace(":", "_")
         save_to = str(base_dir / run_name)
 
         print(f"[{i}/{total}] {run_name}")
         cmd = build_command(
-            domain,
-            provider,
-            model,
-            complexity,
-            save_to,
-            cascaded_config=cascaded,
+            domain, spec, complexity, save_to,
             num_tasks=args.num_tasks,
             seed=args.seed,
             user_llm=args.user_llm,

--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -206,6 +206,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         audio_format: Optional[AudioFormat] = None,
         provider: AudioNativeProvider = DEFAULT_AUDIO_NATIVE_PROVIDER,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         max_inactive_seconds: float = DEFAULT_AUDIO_NATIVE_MAX_INACTIVE_SECONDS,
         use_xml_prompt: bool = False,
         cascaded_config: Optional["CascadedConfig"] = None,
@@ -250,6 +251,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         self.provider = provider
         self.use_xml_prompt = use_xml_prompt
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self.max_inactive_seconds = max_inactive_seconds
         self.cascaded_config = cascaded_config
 
@@ -362,6 +364,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
                 tick_duration_ms=self.tick_duration_ms,
                 send_audio_instant=self.send_audio_instant,
                 model=self.model,
+                reasoning_effort=self.reasoning_effort,
                 audio_format=self.audio_format,
                 cascaded_config=self.cascaded_config,
             )
@@ -810,6 +813,7 @@ def create_discrete_time_audio_native_agent(tools, domain_policy, **kwargs):
             send_audio_instant=audio_native_config.send_audio_instant,
             provider=audio_native_config.provider,
             model=audio_native_config.model,
+            reasoning_effort=audio_native_config.reasoning_effort,
             use_xml_prompt=audio_native_config.use_xml_prompt,
             cascaded_config=getattr(audio_native_config, "cascaded_config", None),
             audio_taps_dir=audio_taps_dir,

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -247,7 +247,7 @@ def add_run_args(parser):
         type=str,
         default=None,
         help="Cascaded config preset name for livekit provider. "
-        "Available presets: 'default', 'openai-thinking', 'openai-thinking-high'. "
+        "Available presets: 'default', 'openai-thinking'. "
         "See tau2.voice.audio_native.livekit.config for details.",
     )
     parser.add_argument(

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -257,6 +257,13 @@ def add_run_args(parser):
         help="Audio native model to use. If not specified, uses the default model for the selected provider.",
     )
     parser.add_argument(
+        "--reasoning-effort",
+        type=str,
+        choices=["minimal", "low", "medium", "high"],
+        default=None,
+        help="Reasoning effort for thinking models. Only applies to providers that support it (e.g. OpenAI).",
+    )
+    parser.add_argument(
         "--tick-duration",
         type=float,
         default=DEFAULT_TICK_DURATION_SECONDS,
@@ -595,6 +602,7 @@ def main():
                 provider=args.audio_native_provider,
                 model=audio_native_model,
                 cascaded_config_name=args.cascaded_config,
+                reasoning_effort=args.reasoning_effort,
                 # Timing
                 tick_duration_seconds=args.tick_duration,
                 max_steps_seconds=args.max_steps_seconds,

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -102,7 +102,7 @@ DEFAULT_AUDIO_NATIVE_PROVIDER = (
     "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
-DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable, 20 minutes max
+DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable
 DEFAULT_SEND_AUDIO_INSTANT = False  # overridable
 
 # Turn-taking thresholds (overridable, in seconds, converted to ticks at runtime)
@@ -201,7 +201,7 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
 }
 
 DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
-    "openai": "high",
+    "openai": None,
     "gemini": "high",
     "xai": None,
     "nova": None,

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -102,7 +102,7 @@ DEFAULT_AUDIO_NATIVE_PROVIDER = (
     "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
-DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable, 20 minutes max
+DEFAULT_MAX_STEPS_SECONDS = 120  # overridable
 DEFAULT_SEND_AUDIO_INSTANT = False  # overridable
 
 # Turn-taking thresholds (overridable, in seconds, converted to ticks at runtime)
@@ -156,7 +156,6 @@ DEFAULT_WHISPER_MODEL = "whisper-1"  # fixed
 DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-live-preview"  # overridable
 _LEGACY_GEMINI_MODEL = "gemini-live-2.5-flash-native-audio"
 DEFAULT_GEMINI_VOICE = "Zephyr"  # overridable
-DEFAULT_GEMINI_THINKING_LEVEL = "high"  # overridable: minimal, low, medium, high
 DEFAULT_GEMINI_PROACTIVE_AUDIO = True  # fixed
 DEFAULT_GEMINI_LOCATION = "us-central1"  # fixed
 DEFAULT_GEMINI_INPUT_SAMPLE_RATE = 16000  # fixed, API-defined
@@ -199,6 +198,15 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
     "nova": DEFAULT_NOVA_MODEL,
     "qwen": DEFAULT_QWEN_MODEL,
     "livekit": "dummy",
+}
+
+DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
+    "openai": "high",
+    "gemini": "high",
+    "xai": None,
+    "nova": None,
+    "qwen": None,
+    "livekit": None,
 }
 
 AUDIO_NATIVE_PROVIDER_TYPES = {

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -102,7 +102,7 @@ DEFAULT_AUDIO_NATIVE_PROVIDER = (
     "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
-DEFAULT_MAX_STEPS_SECONDS = 120  # overridable
+DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable, 20 minutes max
 DEFAULT_SEND_AUDIO_INSTANT = False  # overridable
 
 # Turn-taking thresholds (overridable, in seconds, converted to ticks at runtime)

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -84,6 +84,10 @@ class AudioNativeConfig(BaseModel):
         default=DEFAULT_AUDIO_NATIVE_MODELS[DEFAULT_AUDIO_NATIVE_PROVIDER],
         description="Audio native model to use",
     )
+    reasoning_effort: Optional[str] = Field(
+        default=None,
+        description="Reasoning effort for thinking models: 'minimal', 'low', 'medium', 'high'. If None, not sent.",
+    )
 
     # Timing configuration
     tick_duration_seconds: float = Field(

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from tau2.config import (
     DEFAULT_AUDIO_NATIVE_MODELS,
+    DEFAULT_AUDIO_NATIVE_REASONING_EFFORT,
     DEFAULT_AUDIO_NATIVE_VOIP_PACKET_INTERVAL_MS,
     DEFAULT_SEND_AUDIO_INSTANT,
     TELEPHONY_ULAW_SILENCE,
@@ -359,6 +360,10 @@ def create_adapter(
     Raises:
         ValueError: If the provider is unknown.
     """
+    # --- Resolve reasoning_effort default ---
+    if reasoning_effort is None:
+        reasoning_effort = DEFAULT_AUDIO_NATIVE_REASONING_EFFORT.get(provider)
+
     # --- Resolve model default ---
     if model is None:
         if provider == "livekit":
@@ -400,6 +405,7 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
         )
     elif provider == "xai":
         from tau2.voice.audio_native.xai.discrete_time_adapter import (

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -415,6 +415,7 @@ def create_adapter(
         adapter = DiscreteTimeXAIAdapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
+            reasoning_effort=reasoning_effort,
         )
     elif provider == "nova":
         from tau2.voice.audio_native.nova.discrete_time_adapter import (
@@ -425,6 +426,7 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
         )
     elif provider == "qwen":
         from tau2.voice.audio_native.qwen.discrete_time_adapter import (
@@ -435,6 +437,7 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
         )
     elif provider == "livekit":
         from tau2.voice.audio_native.livekit.config import CascadedConfig

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -333,6 +333,7 @@ def create_adapter(
     tick_duration_ms: int,
     send_audio_instant: bool = DEFAULT_SEND_AUDIO_INSTANT,
     model: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     audio_format: Optional[AudioFormat] = None,
     cascaded_config: Any = None,
 ) -> Tuple[DiscreteTimeAdapter, str]:
@@ -387,6 +388,7 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
             audio_format=audio_format,
         )
     elif provider == "gemini":

--- a/src/tau2/voice/audio_native/gemini/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/gemini/discrete_time_adapter.py
@@ -96,6 +96,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
         tick_duration_ms: int,
         send_audio_instant: bool = True,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[GeminiLiveProvider] = None,
         max_resumptions: int = 3,
         resume_only_on_timeout: bool = True,
@@ -132,6 +133,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
             raise ValueError("model and provider cannot be provided together")
 
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self._max_resumptions = max_resumptions
         self._resume_only_on_timeout = resume_only_on_timeout
 
@@ -158,6 +160,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
         if self._provider is None:
             self._provider = GeminiLiveProvider(
                 model=self.model,
+                reasoning_effort=self.reasoning_effort,
                 max_resumptions=self._max_resumptions,
                 resume_only_on_timeout=self._resume_only_on_timeout,
             )

--- a/src/tau2/voice/audio_native/gemini/provider.py
+++ b/src/tau2/voice/audio_native/gemini/provider.py
@@ -19,7 +19,6 @@ from tau2.config import (
     DEFAULT_GEMINI_MODEL,
     DEFAULT_GEMINI_OUTPUT_SAMPLE_RATE,
     DEFAULT_GEMINI_PROACTIVE_AUDIO,
-    DEFAULT_GEMINI_THINKING_LEVEL,
     DEFAULT_GEMINI_VOICE,
 )
 from tau2.environment.tool import Tool
@@ -140,6 +139,7 @@ class GeminiLiveProvider:
         self,
         api_key: Optional[str] = None,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         project_id: Optional[str] = None,
         location: Optional[str] = None,
         use_raw_json_schema: bool = True,
@@ -275,6 +275,8 @@ class GeminiLiveProvider:
                 "  - GOOGLE_SERVICE_ACCOUNT_KEY (JSON content for Vertex AI)\n"
                 "  - GOOGLE_APPLICATION_CREDENTIALS (file path for Vertex AI)"
             )
+
+        self.reasoning_effort = reasoning_effort
 
         self._client = None
         self._session = None
@@ -480,10 +482,9 @@ class GeminiLiveProvider:
                     proactive_audio=True,
                 )
 
-            # Add thinking config if a thinking level is set
-            if DEFAULT_GEMINI_THINKING_LEVEL:
+            if self.reasoning_effort:
                 config_kwargs["thinking_config"] = types.ThinkingConfig(
-                    thinking_level=DEFAULT_GEMINI_THINKING_LEVEL.upper(),
+                    thinking_level=self.reasoning_effort.upper(),
                 )
 
             config = types.LiveConnectConfig(**config_kwargs)

--- a/src/tau2/voice/audio_native/livekit/config.py
+++ b/src/tau2/voice/audio_native/livekit/config.py
@@ -178,6 +178,8 @@ class CascadedConfig(BaseModel):
     stt: STTConfig = Field(default_factory=DeepgramSTTConfig)
     llm: LLMConfig = Field(default_factory=OpenAILLMConfig)
     tts: TTSConfig = Field(default_factory=DeepgramTTSConfig)
+    preamble: bool = False
+    preamble_text: str = "One moment please."
     log_prompts: bool = False
 
 
@@ -192,16 +194,11 @@ CASCADED_CONFIGS: Dict[str, CascadedConfig] = {
         llm=OpenAILLMConfig(model="gpt-4.1"),
         tts=DeepgramTTSConfig(model="aura-asteria-en"),
     ),
-    # OpenAI thinking: Uses OpenAI's thinking models for complex reasoning
+    # OpenAI thinking: Uses OpenAI's thinking models with high reasoning effort
     "openai-thinking": CascadedConfig(
-        stt=DeepgramSTTConfig(model="nova-3"),
-        llm=OpenAILLMConfig(model="gpt-5.2", reasoning_effort="medium"),
-        tts=DeepgramTTSConfig(model="aura-asteria-en"),
-    ),
-    # OpenAI thinking (high): Maximum reasoning effort
-    "openai-thinking-high": CascadedConfig(
         stt=DeepgramSTTConfig(model="nova-3"),
         llm=OpenAILLMConfig(model="gpt-5.2", reasoning_effort="high"),
         tts=DeepgramTTSConfig(model="aura-asteria-en"),
+        preamble=True,
     ),
 }

--- a/src/tau2/voice/audio_native/livekit/config.py
+++ b/src/tau2/voice/audio_native/livekit/config.py
@@ -70,7 +70,7 @@ class OpenAILLMConfig(BaseModel):
         model: Model name (e.g., "gpt-4.1", "o3-mini", "gpt-4.1-mini").
         temperature: Sampling temperature (0.0-2.0). Not used for thinking models.
         top_p: Nucleus sampling parameter.
-        reasoning_effort: For thinking models (o1, o3): "low", "medium", "high".
+        reasoning_effort: For thinking models (o1, o3): "minimal", "low", "medium", "high".
             Controls how much "thinking" the model does before responding.
         max_completion_tokens: Maximum tokens in the response.
         timeout_seconds: Request timeout in seconds.
@@ -81,7 +81,7 @@ class OpenAILLMConfig(BaseModel):
     model: str = "gpt-4.1"
     temperature: Optional[float] = None
     top_p: Optional[float] = None
-    reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
+    reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]] = None
     max_completion_tokens: Optional[int] = None
     timeout_seconds: Optional[float] = None
     parallel_tool_calls: Optional[bool] = None
@@ -199,6 +199,6 @@ CASCADED_CONFIGS: Dict[str, CascadedConfig] = {
         stt=DeepgramSTTConfig(model="nova-3"),
         llm=OpenAILLMConfig(model="gpt-5.2", reasoning_effort="high"),
         tts=DeepgramTTSConfig(model="aura-asteria-en"),
-        preamble=True,
+        # preamble=True,
     ),
 }

--- a/src/tau2/voice/audio_native/livekit/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/livekit/discrete_time_adapter.py
@@ -121,6 +121,10 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
         self._tick_count = 0
         self._pending_tool_results: List[Tuple[str, str, bool]] = []
 
+        # Event queue for non-blocking tick processing.
+        # Background tasks push events here; ticks drain within their time budget.
+        self._event_queue: asyncio.Queue[CascadedEvent] = asyncio.Queue()
+
         # Audio buffering for tick alignment
         # Excess audio from one tick is carried over to the next
         self._buffered_audio_chunks: List[Tuple[bytes, Optional[str]]] = []
@@ -301,6 +305,48 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
             logger.error(f"Error in run_tick (tick={tick_number}): {e}")
             raise
 
+    async def _drain_to_queue(self, async_gen) -> None:
+        """Consume an async generator and push its events to the event queue.
+
+        Runs as a background task so the tick doesn't block on slow operations
+        like LLM inference or TTS synthesis.
+        """
+        try:
+            async for event in async_gen:
+                await self._event_queue.put(event)
+        except Exception as e:
+            logger.error(f"Background pipeline error: {e}")
+            await self._event_queue.put(
+                CascadedEvent(
+                    type=CascadedEventType.ERROR,
+                    data={"error": str(e), "stage": "pipeline"},
+                )
+            )
+
+    async def _drain_event_queue(
+        self,
+        deadline: float,
+        events: List[CascadedEvent],
+        agent_audio_chunks: List[Tuple[bytes, Optional[str]]],
+        vad_events: List[str],
+        tool_calls: List[ToolCall],
+    ) -> None:
+        """Drain events from the queue until the tick deadline."""
+        loop = asyncio.get_running_loop()
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                event = await asyncio.wait_for(
+                    self._event_queue.get(),
+                    timeout=max(0.001, remaining),
+                )
+                events.append(event)
+                self._handle_event(event, agent_audio_chunks, vad_events, tool_calls)
+            except asyncio.TimeoutError:
+                break
+
     async def _async_run_tick(
         self,
         user_audio: bytes,
@@ -308,11 +354,12 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
     ) -> TickResult:
         """Async tick execution.
 
-        Collects events from the provider and maps them to TickResult.
-        Audio is capped at bytes_per_tick, with excess buffered for next tick.
-        Wall-clock time is enforced to be at least tick_duration_ms.
+        Spawns provider pipelines (process_audio, send_tool_result) as background
+        tasks that push events to a queue. The tick drains the queue within its
+        time budget, so slow LLM calls don't block the tick.
         """
         tick_start = asyncio.get_running_loop().time()
+        deadline = tick_start + (self.tick_duration_ms / 1000)
 
         events: List[CascadedEvent] = []
         tool_calls: List[ToolCall] = []
@@ -331,22 +378,29 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
             agent_audio_chunks.extend(self._buffered_audio_chunks)
             self._buffered_audio_chunks = []
 
-        # Send any pending tool results first
+        # Spawn pending tool results as background tasks
         for call_id, result, request_response in self._pending_tool_results:
-            async for event in self.provider.send_tool_result(
-                call_id, result, request_response=request_response
-            ):
-                events.append(event)
-                self._handle_event(event, agent_audio_chunks, vad_events, tool_calls)
+            asyncio.create_task(
+                self._drain_to_queue(
+                    self.provider.send_tool_result(
+                        call_id, result, request_response=request_response
+                    )
+                )
+            )
         self._pending_tool_results.clear()
 
         # Convert user audio from telephony (8kHz μ-law) to STT format (16kHz PCM16)
         stt_audio = self._audio_converter.convert_input(user_audio)
 
-        # Process user audio through provider
-        async for event in self.provider.process_audio(stt_audio):
-            events.append(event)
-            self._handle_event(event, agent_audio_chunks, vad_events, tool_calls)
+        # Spawn process_audio as a background task — events go to queue
+        asyncio.create_task(
+            self._drain_to_queue(self.provider.process_audio(stt_audio))
+        )
+
+        # Drain events from queue until tick deadline
+        await self._drain_event_queue(
+            deadline, events, agent_audio_chunks, vad_events, tool_calls
+        )
 
         # Cap audio at bytes_per_tick and buffer excess for next tick
         capped_chunks, buffered_chunks = self._cap_audio_chunks(

--- a/src/tau2/voice/audio_native/livekit/provider.py
+++ b/src/tau2/voice/audio_native/livekit/provider.py
@@ -767,6 +767,14 @@ class CascadedVoiceProvider:
 
         self._state = ProviderState.PROCESSING
 
+        if self.config.preamble:
+            yield CascadedEvent(
+                type=CascadedEventType.LLM_COMPLETED,
+                data={"text": self.config.preamble_text, "tool_calls": []},
+            )
+            async for tts_event in self._process_tts(self.config.preamble_text):
+                yield tts_event
+
         # Add user message to context
         self._context.add_user(user_text)
 

--- a/src/tau2/voice/audio_native/nova/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/nova/discrete_time_adapter.py
@@ -96,6 +96,7 @@ class DiscreteTimeNovaAdapter(DiscreteTimeAdapter):
         tick_duration_ms: int,
         send_audio_instant: bool = True,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[NovaSonicProvider] = None,
         voice: str = "tiffany",
     ):
@@ -106,9 +107,14 @@ class DiscreteTimeNovaAdapter(DiscreteTimeAdapter):
             send_audio_instant: If True, send audio in one call (discrete-time mode).
             model: Model to use. Defaults to None (provider default).
                 If provider is also provided, this is ignored.
+            reasoning_effort: Not supported by Nova. Must be None.
             provider: Optional provider instance. Created lazily if not provided.
             voice: Voice to use. Options: matthew, tiffany, amy. Default: tiffany.
         """
+        if reasoning_effort is not None:
+            raise ValueError(
+                f"Nova provider does not support reasoning_effort (got '{reasoning_effort}')"
+            )
         super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
 
         self._chunk_size = int(NOVA_BYTES_PER_SECOND * self._voip_interval_ms / 1000)

--- a/src/tau2/voice/audio_native/openai/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/openai/discrete_time_adapter.py
@@ -68,6 +68,7 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
         tick_duration_ms: int,
         send_audio_instant: bool = False,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[OpenAIRealtimeProvider] = None,
         audio_format: Optional[AudioFormat] = None,
     ):
@@ -85,6 +86,7 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
             raise ValueError("model and provider cannot be provided together")
 
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self._provider = provider
         self._owns_provider = provider is None
 
@@ -94,7 +96,10 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
     @property
     def provider(self) -> OpenAIRealtimeProvider:
         if self._provider is None:
-            self._provider = OpenAIRealtimeProvider(model=self.model)
+            self._provider = OpenAIRealtimeProvider(
+                model=self.model,
+                reasoning_effort=self.reasoning_effort,
+            )
         return self._provider
 
     @property

--- a/src/tau2/voice/audio_native/openai/events.py
+++ b/src/tau2/voice/audio_native/openai/events.py
@@ -26,7 +26,7 @@ class TextDoneEvent(BaseRealtimeEvent):
 
 
 class AudioDeltaEvent(BaseRealtimeEvent):
-    type: Literal["response.audio.delta"]
+    type: Literal["response.output_audio.delta"]
     delta: str = Field(
         default="", description="Base64-encoded audio delta", exclude=True
     )  # Exclude from serialization due to large size
@@ -35,19 +35,19 @@ class AudioDeltaEvent(BaseRealtimeEvent):
 
 
 class AudioDoneEvent(BaseRealtimeEvent):
-    type: Literal["response.audio.done"]
+    type: Literal["response.output_audio.done"]
     item_id: Optional[str] = None
 
 
 class AudioTranscriptDeltaEvent(BaseRealtimeEvent):
-    type: Literal["response.audio_transcript.delta"]
+    type: Literal["response.output_audio_transcript.delta"]
     delta: str
     response_id: Optional[str] = None
     item_id: Optional[str] = None
 
 
 class AudioTranscriptDoneEvent(BaseRealtimeEvent):
-    type: Literal["response.audio_transcript.done"]
+    type: Literal["response.output_audio_transcript.done"]
     transcript: str = ""
     item_id: Optional[str] = None
 
@@ -214,10 +214,10 @@ RealtimeEvent = Annotated[_KnownEvents, Field(discriminator="type")]
 _EVENT_TYPE_MAP: dict[str, type[BaseRealtimeEvent]] = {
     "response.text.delta": TextDeltaEvent,
     "response.text.done": TextDoneEvent,
-    "response.audio.delta": AudioDeltaEvent,
-    "response.audio.done": AudioDoneEvent,
-    "response.audio_transcript.delta": AudioTranscriptDeltaEvent,
-    "response.audio_transcript.done": AudioTranscriptDoneEvent,
+    "response.output_audio.delta": AudioDeltaEvent,
+    "response.output_audio.done": AudioDoneEvent,
+    "response.output_audio_transcript.delta": AudioTranscriptDeltaEvent,
+    "response.output_audio_transcript.done": AudioTranscriptDoneEvent,
     "response.function_call_arguments.delta": FunctionCallArgumentsDeltaEvent,
     "response.function_call_arguments.done": FunctionCallArgumentsDoneEvent,
     "response.output_item.added": OutputItemAddedEvent,

--- a/src/tau2/voice/audio_native/openai/provider.py
+++ b/src/tau2/voice/audio_native/openai/provider.py
@@ -31,7 +31,7 @@ from tau2.voice.audio_native.openai.events import (
     UnknownEvent,
     parse_realtime_event,
 )
-from tau2.voice.utils.openai_utils import audio_format_to_openai_string
+from tau2.voice.utils.openai_utils import audio_format_to_openai
 
 load_dotenv()
 
@@ -113,13 +113,20 @@ class OpenAIRealtimeProvider:
     BASE_URL = DEFAULT_OPENAI_REALTIME_BASE_URL
     DEFAULT_MODEL = DEFAULT_OPENAI_REALTIME_MODEL
 
-    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+    ):
         """Initialize the OpenAI Realtime provider.
 
         Args:
             api_key: OpenAI API key. If not provided, reads from OPENAI_API_KEY
                 environment variable.
             model: Model identifier to use. Defaults to DEFAULT_MODEL.
+            reasoning_effort: Reasoning effort for thinking models ("minimal",
+                "low", "medium", "high"). If None, not sent to the API.
 
         Raises:
             ValueError: If no API key is provided or found in environment.
@@ -129,6 +136,7 @@ class OpenAIRealtimeProvider:
             raise ValueError("OpenAI API key not provided. Set OPENAI_API_KEY env var.")
 
         self.model = model or self.DEFAULT_MODEL
+        self.reasoning_effort = reasoning_effort
         self.ws: Optional[websockets.WebSocketClientProtocol] = None
         self._current_vad_config: Optional[OpenAIVADConfig] = None
         self._audio_format: AudioFormat = TELEPHONY_AUDIO_FORMAT
@@ -170,10 +178,7 @@ class OpenAIRealtimeProvider:
             return
 
         url = f"{self.BASE_URL}?model={self.model}"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "OpenAI-Beta": "realtime=v1",
-        }
+        headers = {"Authorization": f"Bearer {self.api_key}"}
 
         self.ws = await websockets.connect(url, additional_headers=headers)
 
@@ -297,7 +302,7 @@ class OpenAIRealtimeProvider:
         if modality == "text":
             modalities = ["text"]
         elif modality == "audio":
-            modalities = ["text", "audio"]
+            modalities = ["audio"]
         elif modality == "audio_in_text_out":
             modalities = ["text"]
         else:
@@ -310,43 +315,39 @@ class OpenAIRealtimeProvider:
         # Store audio format for reference
         self._audio_format = audio_format
 
-        session_config = {
-            "type": "session.update",
-            "session": {
-                "instructions": system_prompt,
-                "modalities": modalities,
-                "tools": self._format_tools_for_api(tools),
-                "tool_choice": "auto",
-                "turn_detection": self._build_turn_detection_config(vad_config),
-            },
+        audio_fmt = audio_format_to_openai(audio_format)
+
+        session = {
+            "type": "realtime",
+            "instructions": system_prompt,
+            "output_modalities": modalities,
+            "tools": self._format_tools_for_api(tools),
+            "tool_choice": "auto",
         }
 
+        if self.reasoning_effort is not None:
+            session["reasoning"] = {"effort": self.reasoning_effort}
+
         if modality in ("audio", "audio_in_text_out"):
-            # Get OpenAI format string from AudioFormat
-            openai_format = audio_format_to_openai_string(audio_format)
-            input_config = {
-                "input_audio_format": openai_format,
-                "input_audio_transcription": {
-                    "model": DEFAULT_OPENAI_TRANSCRIPTION_MODEL,
-                    "language": "en",
-                },
-                "input_audio_noise_reduction": {
-                    "type": DEFAULT_OPENAI_NOISE_REDUCTION,
+            session["audio"] = {
+                "input": {
+                    "format": audio_fmt,
+                    "transcription": {
+                        "model": DEFAULT_OPENAI_TRANSCRIPTION_MODEL,
+                        "language": "en",
+                    },
+                    "noise_reduction": {"type": DEFAULT_OPENAI_NOISE_REDUCTION},
+                    "turn_detection": self._build_turn_detection_config(vad_config),
                 },
             }
-            session_config["session"].update(input_config)
 
         if modality == "audio":
-            # Get OpenAI format string from AudioFormat
-            openai_format = audio_format_to_openai_string(audio_format)
-            session_config["session"].update(
-                {
-                    "voice": DEFAULT_OPENAI_VOICE,
-                    "output_audio_format": openai_format,
-                }
-            )
+            session.setdefault("audio", {})["output"] = {
+                "format": audio_fmt,
+                "voice": DEFAULT_OPENAI_VOICE,
+            }
 
-        await self.ws.send(json.dumps(session_config))
+        await self.ws.send(json.dumps({"type": "session.update", "session": session}))
 
         while True:
             response = await self.ws.recv()

--- a/src/tau2/voice/audio_native/qwen/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/qwen/discrete_time_adapter.py
@@ -101,6 +101,7 @@ class DiscreteTimeQwenAdapter(DiscreteTimeAdapter):
         tick_duration_ms: int,
         send_audio_instant: bool = True,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[QwenRealtimeProvider] = None,
         voice: str = "Cherry",
     ):
@@ -111,9 +112,14 @@ class DiscreteTimeQwenAdapter(DiscreteTimeAdapter):
             send_audio_instant: If True, send audio in one call (discrete-time mode).
             model: Model to use. Defaults to None (provider default).
                 If provider is also provided, this is ignored.
+            reasoning_effort: Not supported by Qwen. Must be None.
             provider: Optional provider instance. Created lazily if not provided.
             voice: Voice to use. Default: Cherry.
         """
+        if reasoning_effort is not None:
+            raise ValueError(
+                f"Qwen provider does not support reasoning_effort (got '{reasoning_effort}')"
+            )
         super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
 
         self._chunk_size = int(

--- a/src/tau2/voice/audio_native/xai/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/xai/discrete_time_adapter.py
@@ -93,6 +93,7 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
         self,
         tick_duration_ms: int,
         send_audio_instant: bool = True,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[XAIRealtimeProvider] = None,
         voice: str = "Ara",
     ):
@@ -101,9 +102,14 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
         Args:
             tick_duration_ms: Duration of each tick in milliseconds. Must be > 0.
             send_audio_instant: If True, send audio in one call (discrete-time mode).
+            reasoning_effort: Not supported by xAI. Must be None.
             provider: Optional provider instance. Created lazily if not provided.
             voice: Voice to use. One of: Ara, Rex, Sal, Eve, Leo. Default: Ara.
         """
+        if reasoning_effort is not None:
+            raise ValueError(
+                f"xAI provider does not support reasoning_effort (got '{reasoning_effort}')"
+            )
         super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
 
         self._chunk_size = int(

--- a/src/tau2/voice/utils/openai_utils.py
+++ b/src/tau2/voice/utils/openai_utils.py
@@ -1,12 +1,12 @@
 """OpenAI Realtime API audio format utilities.
 
 This module provides conversion functions between tau2's AudioFormat
-and OpenAI Realtime API format strings.
+and OpenAI Realtime API format objects.
 
-OpenAI Realtime API supports:
-- g711_ulaw: 8kHz, 8-bit μ-law (telephony)
-- g711_alaw: 8kHz, 8-bit A-law (telephony)
-- pcm16: 24kHz, 16-bit signed PCM
+OpenAI GA API audio formats:
+- audio/pcmu: G.711 μ-law (telephony)
+- audio/pcma: G.711 A-law (telephony)
+- audio/pcm: 24kHz, 16-bit signed PCM (requires rate: 24000)
 """
 
 from tau2.config import DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
@@ -16,88 +16,76 @@ from tau2.data_model.audio import (
     AudioFormat,
 )
 
-# OpenAI Realtime API uses 24kHz for pcm16 format
 OPENAI_PCM16_SAMPLE_RATE = DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
 
 
-def audio_format_to_openai_string(audio_format: AudioFormat) -> str:
-    """Convert AudioFormat to OpenAI Realtime API format string.
+def audio_format_to_openai(audio_format: AudioFormat) -> dict:
+    """Convert AudioFormat to OpenAI GA API format object.
 
     Args:
         audio_format: The AudioFormat to convert.
 
     Returns:
-        OpenAI format string: "g711_ulaw", "g711_alaw", or "pcm16".
+        Dict with 'type' and optionally 'rate' for the GA API.
 
     Raises:
         ValueError: If the format is not supported by OpenAI Realtime API.
-
-    Example:
-        >>> fmt = AudioFormat(encoding=AudioEncoding.ULAW, sample_rate=8000)
-        >>> audio_format_to_openai_string(fmt)
-        'g711_ulaw'
     """
     if audio_format.encoding == AudioEncoding.ULAW:
         if audio_format.sample_rate != TELEPHONY_SAMPLE_RATE:
             raise ValueError(
-                f"OpenAI g711_ulaw requires {TELEPHONY_SAMPLE_RATE}Hz, "
+                f"OpenAI audio/pcmu requires {TELEPHONY_SAMPLE_RATE}Hz, "
                 f"got {audio_format.sample_rate}Hz"
             )
-        return "g711_ulaw"
+        return {"type": "audio/pcmu"}
     elif audio_format.encoding == AudioEncoding.ALAW:
         if audio_format.sample_rate != TELEPHONY_SAMPLE_RATE:
             raise ValueError(
-                f"OpenAI g711_alaw requires {TELEPHONY_SAMPLE_RATE}Hz, "
+                f"OpenAI audio/pcma requires {TELEPHONY_SAMPLE_RATE}Hz, "
                 f"got {audio_format.sample_rate}Hz"
             )
-        return "g711_alaw"
+        return {"type": "audio/pcma"}
     elif audio_format.encoding == AudioEncoding.PCM_S16LE:
         if audio_format.sample_rate != OPENAI_PCM16_SAMPLE_RATE:
             raise ValueError(
-                f"OpenAI pcm16 requires {OPENAI_PCM16_SAMPLE_RATE}Hz, "
+                f"OpenAI audio/pcm requires {OPENAI_PCM16_SAMPLE_RATE}Hz, "
                 f"got {audio_format.sample_rate}Hz"
             )
-        return "pcm16"
+        return {"type": "audio/pcm", "rate": 24000}
     else:
         raise ValueError(
             f"Unsupported encoding for OpenAI: {audio_format.encoding}. "
-            "Supported: ULAW (g711_ulaw), ALAW (g711_alaw), PCM_S16LE (pcm16)"
+            "Supported: ULAW (audio/pcmu), ALAW (audio/pcma), PCM_S16LE (audio/pcm)"
         )
 
 
-def openai_string_to_audio_format(format_string: str) -> AudioFormat:
-    """Create AudioFormat from OpenAI Realtime API format string.
+def openai_format_to_audio_format(fmt: dict) -> AudioFormat:
+    """Create AudioFormat from OpenAI GA API format object.
 
     Args:
-        format_string: "g711_ulaw", "g711_alaw", or "pcm16".
+        fmt: Dict with 'type' key (e.g. {"type": "audio/pcmu"}).
 
     Returns:
         AudioFormat configured for the specified format.
 
     Raises:
-        ValueError: If the format string is not recognized.
-
-    Example:
-        >>> fmt = openai_string_to_audio_format("g711_ulaw")
-        >>> fmt.encoding
-        <AudioEncoding.ULAW: 'ulaw'>
-        >>> fmt.sample_rate
-        8000
+        ValueError: If the format type is not recognized.
     """
-    if format_string == "g711_ulaw":
+    fmt_type = fmt.get("type", "")
+    if fmt_type == "audio/pcmu":
         return AudioFormat(
             encoding=AudioEncoding.ULAW, sample_rate=TELEPHONY_SAMPLE_RATE
         )
-    elif format_string == "g711_alaw":
+    elif fmt_type == "audio/pcma":
         return AudioFormat(
             encoding=AudioEncoding.ALAW, sample_rate=TELEPHONY_SAMPLE_RATE
         )
-    elif format_string == "pcm16":
+    elif fmt_type == "audio/pcm":
         return AudioFormat(
             encoding=AudioEncoding.PCM_S16LE, sample_rate=OPENAI_PCM16_SAMPLE_RATE
         )
     else:
         raise ValueError(
-            f"Unknown OpenAI format: {format_string}. "
-            "Supported: g711_ulaw, g711_alaw, pcm16"
+            f"Unknown OpenAI format: {fmt_type}. "
+            "Supported: audio/pcmu, audio/pcma, audio/pcm"
         )

--- a/tests/test_voice/test_audio_native/provider_suite_results.txt
+++ b/tests/test_voice/test_audio_native/provider_suite_results.txt
@@ -16,15 +16,15 @@ Provider Suite — 2026-04-16 16:52
 [livekit]
   ✅ PASS  test_connect_disconnect
   ✅ PASS  test_reconnect_after_disconnect
-  ❌ FAIL  test_single_turn_reply[medium-1120ms]
-  ❌ FAIL  test_single_turn_reply[short-720ms]
-  ❌ FAIL  test_multi_turn_reply
-  ❌ FAIL  test_tool_call_round_trip
+  ✅ PASS  test_single_turn_reply[medium-1120ms]
+  ✅ PASS  test_single_turn_reply[short-720ms]
+  ✅ PASS  test_multi_turn_reply
+  ✅ PASS  test_tool_call_round_trip
   ✅ PASS  test_tick_duration_bounds
-  ❌ FAIL  test_barge_in_baseline
-  ❌ FAIL  test_barge_in_agent_yields
-  ❌ FAIL  test_barge_in_detected[medium-1120ms]
-  ❌ FAIL  test_barge_in_detected[short-720ms]
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ✅ PASS  test_barge_in_detected[short-720ms]
 
 [nova]
   ⏭️ SKIP  test_connect_disconnect
@@ -79,16 +79,8 @@ Provider Suite — 2026-04-16 16:52
   ❌ FAIL  test_barge_in_detected[short-720ms]
 
 Failure details:
-  [livekit] test_single_turn_reply[medium-1120ms]: Tick 10 took 1115ms, expected <= 300ms (tick blocking on LLM)
-  [livekit] test_single_turn_reply[short-720ms]: Tick took 1012ms, expected <= 300ms (tick blocking on LLM)
-  [livekit] test_multi_turn_reply: Tick took 768ms, expected <= 300ms (tick blocking on LLM)
-  [livekit] test_tool_call_round_trip: Tick took 773ms, expected <= 300ms (tick blocking on LLM)
-  [livekit] test_barge_in_baseline: Tick took 3028ms, expected <= 300ms (tick blocking on LLM)
-  [livekit] test_barge_in_agent_yields: Tick took 3218ms, expected <= 300ms (tick blocking on LLM)
-  [livekit] test_barge_in_detected[medium-1120ms]: Tick took 3111ms, expected <= 300ms (tick blocking on LLM)
-  [livekit] test_barge_in_detected[short-720ms]: Tick took 7676ms, expected <= 300ms (tick blocking on LLM + TTS Payload Too Large)
   [qwen] test_tool_call_round_trip: RuntimeError: QWEN REALTIME API LIMITATION: tool/function calling does NOT work with qwen3-omni-flash-realtime.
   [xai] test_single_turn_reply[short-720ms]: Agent did not produce audio within 75 ticks (15000ms) for hello.ulaw
   [xai] test_barge_in_detected[short-720ms]: Agent never started speaking for hello.ulaw
 
-44 passed, 11 failed, 11 skipped in 66s
+52 passed, 3 failed, 11 skipped in 66s

--- a/tests/test_voice/test_audio_native/provider_suite_results.txt
+++ b/tests/test_voice/test_audio_native/provider_suite_results.txt
@@ -26,6 +26,19 @@ Provider Suite — 2026-04-16 16:52
   ✅ PASS  test_barge_in_detected[medium-1120ms]
   ✅ PASS  test_barge_in_detected[short-720ms]
 
+[livekit-thinking]
+  ✅ PASS  test_connect_disconnect
+  ✅ PASS  test_reconnect_after_disconnect
+  ✅ PASS  test_single_turn_reply[medium-1120ms]
+  ✅ PASS  test_single_turn_reply[short-720ms]
+  ✅ PASS  test_multi_turn_reply
+  ✅ PASS  test_tool_call_round_trip
+  ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ✅ PASS  test_barge_in_detected[short-720ms]
+
 [nova]
   ⏭️ SKIP  test_connect_disconnect
   ⏭️ SKIP  test_reconnect_after_disconnect
@@ -83,4 +96,4 @@ Failure details:
   [xai] test_single_turn_reply[short-720ms]: Agent did not produce audio within 75 ticks (15000ms) for hello.ulaw
   [xai] test_barge_in_detected[short-720ms]: Agent never started speaking for hello.ulaw
 
-52 passed, 3 failed, 11 skipped in 66s
+63 passed, 3 failed, 11 skipped in 66s

--- a/tests/test_voice/test_audio_native/provider_suite_results.txt
+++ b/tests/test_voice/test_audio_native/provider_suite_results.txt
@@ -1,4 +1,4 @@
-Provider Suite — 2026-04-02 22:30 
+Provider Suite — 2026-04-16 16:52 
 
 [gemini]
   ✅ PASS  test_connect_disconnect
@@ -7,20 +7,24 @@ Provider Suite — 2026-04-02 22:30
   ✅ PASS  test_single_turn_reply[short-720ms]
   ✅ PASS  test_multi_turn_reply
   ✅ PASS  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ✅ PASS  test_barge_in[short-720ms]
   ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ✅ PASS  test_barge_in_detected[short-720ms]
 
 [livekit]
   ✅ PASS  test_connect_disconnect
   ✅ PASS  test_reconnect_after_disconnect
-  ✅ PASS  test_single_turn_reply[medium-1120ms]
-  ✅ PASS  test_single_turn_reply[short-720ms]
-  ✅ PASS  test_multi_turn_reply
-  ✅ PASS  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ✅ PASS  test_barge_in[short-720ms]
+  ❌ FAIL  test_single_turn_reply[medium-1120ms]
+  ❌ FAIL  test_single_turn_reply[short-720ms]
+  ❌ FAIL  test_multi_turn_reply
+  ❌ FAIL  test_tool_call_round_trip
   ✅ PASS  test_tick_duration_bounds
+  ❌ FAIL  test_barge_in_baseline
+  ❌ FAIL  test_barge_in_agent_yields
+  ❌ FAIL  test_barge_in_detected[medium-1120ms]
+  ❌ FAIL  test_barge_in_detected[short-720ms]
 
 [nova]
   ⏭️ SKIP  test_connect_disconnect
@@ -29,9 +33,11 @@ Provider Suite — 2026-04-02 22:30
   ⏭️ SKIP  test_single_turn_reply[short-720ms]
   ⏭️ SKIP  test_multi_turn_reply
   ⏭️ SKIP  test_tool_call_round_trip
-  ⏭️ SKIP  test_barge_in[medium-1120ms]
-  ⏭️ SKIP  test_barge_in[short-720ms]
   ⏭️ SKIP  test_tick_duration_bounds
+  ⏭️ SKIP  test_barge_in_baseline
+  ⏭️ SKIP  test_barge_in_agent_yields
+  ⏭️ SKIP  test_barge_in_detected[medium-1120ms]
+  ⏭️ SKIP  test_barge_in_detected[short-720ms]
 
 [openai]
   ✅ PASS  test_connect_disconnect
@@ -40,9 +46,11 @@ Provider Suite — 2026-04-02 22:30
   ✅ PASS  test_single_turn_reply[short-720ms]
   ✅ PASS  test_multi_turn_reply
   ✅ PASS  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ✅ PASS  test_barge_in[short-720ms]
   ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ✅ PASS  test_barge_in_detected[short-720ms]
 
 [qwen]
   ✅ PASS  test_connect_disconnect
@@ -51,9 +59,11 @@ Provider Suite — 2026-04-02 22:30
   ✅ PASS  test_single_turn_reply[short-720ms]
   ✅ PASS  test_multi_turn_reply
   ❌ FAIL  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ✅ PASS  test_barge_in[short-720ms]
   ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ✅ PASS  test_barge_in_detected[short-720ms]
 
 [xai]
   ✅ PASS  test_connect_disconnect
@@ -62,16 +72,23 @@ Provider Suite — 2026-04-02 22:30
   ❌ FAIL  test_single_turn_reply[short-720ms]
   ✅ PASS  test_multi_turn_reply
   ✅ PASS  test_tool_call_round_trip
-  ✅ PASS  test_barge_in[medium-1120ms]
-  ❌ FAIL  test_barge_in[short-720ms]
   ✅ PASS  test_tick_duration_bounds
+  ✅ PASS  test_barge_in_baseline
+  ✅ PASS  test_barge_in_agent_yields
+  ✅ PASS  test_barge_in_detected[medium-1120ms]
+  ❌ FAIL  test_barge_in_detected[short-720ms]
 
 Failure details:
-  test_tool_call_round_trip: RuntimeError: Failed to connect to Qwen API: QWEN REALTIME API LIMITATION: 1 tools configured but tool/function calling does NOT work with qwen3-omni-flash-realtime. The model accepts tool configurations but NEVER invokes them - it generates audio responses instead.
-  test_single_turn_reply[short-720ms]: AssertionError: Agent did not produce audio within 75 ticks (15000ms) for hello.ulaw
-assert False
-  test_barge_in[short-720ms]: AssertionError: Agent never started speaking for hello.ulaw
-assert False
- +  where False = any(<generator object TestBargeIn.test_barge_in.<locals>.<genexpr> at 0x1255bf370>)
+  [livekit] test_single_turn_reply[medium-1120ms]: Tick 10 took 1115ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_single_turn_reply[short-720ms]: Tick took 1012ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_multi_turn_reply: Tick took 768ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_tool_call_round_trip: Tick took 773ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_barge_in_baseline: Tick took 3028ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_barge_in_agent_yields: Tick took 3218ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_barge_in_detected[medium-1120ms]: Tick took 3111ms, expected <= 300ms (tick blocking on LLM)
+  [livekit] test_barge_in_detected[short-720ms]: Tick took 7676ms, expected <= 300ms (tick blocking on LLM + TTS Payload Too Large)
+  [qwen] test_tool_call_round_trip: RuntimeError: QWEN REALTIME API LIMITATION: tool/function calling does NOT work with qwen3-omni-flash-realtime.
+  [xai] test_single_turn_reply[short-720ms]: Agent did not produce audio within 75 ticks (15000ms) for hello.ulaw
+  [xai] test_barge_in_detected[short-720ms]: Agent never started speaking for hello.ulaw
 
-42 passed, 3 failed, 9 skipped, 0 errors in 79s
+44 passed, 11 failed, 11 skipped in 66s

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -225,9 +225,54 @@ def assert_played_audio_length(
     )
 
 
+# Upper bound for tick wall-clock duration (same as test_tick_duration_bounds)
+TICK_DURATION_MAX_FACTOR = 1.5
+
+
+class TickTimer:
+    """Collects tick wall-clock durations and asserts the timing invariant."""
+
+    def __init__(self):
+        self.timings: List[float] = []
+
+    def run_tick(
+        self,
+        adapter: DiscreteTimeAdapter,
+        user_audio: bytes,
+        tick_number: int,
+    ) -> TickResult:
+        start = time.time()
+        result = adapter.run_tick(user_audio, tick_number=tick_number)
+        elapsed_ms = (time.time() - start) * 1000
+        self.timings.append(elapsed_ms)
+        max_ms = TICK_DURATION_MS * TICK_DURATION_MAX_FACTOR
+        assert elapsed_ms <= max_ms, (
+            f"Tick {tick_number} took {elapsed_ms:.0f}ms, "
+            f"expected <= {max_ms:.0f}ms (tick_duration={TICK_DURATION_MS}ms × "
+            f"{TICK_DURATION_MAX_FACTOR})"
+        )
+        return result
+
+    def print_diagnostics(self, label: str = "") -> None:
+        if not self.timings:
+            return
+        sorted_t = sorted(self.timings)
+        p95_idx = int(len(sorted_t) * 0.95)
+        p95 = sorted_t[min(p95_idx, len(sorted_t) - 1)]
+        over = sum(1 for t in self.timings if t > TICK_DURATION_MS * TICK_DURATION_MAX_FACTOR)
+        print(
+            f"\n  [{label}] {len(self.timings)} ticks: "
+            f"min={min(self.timings):.0f}ms, "
+            f"avg={sum(self.timings)/len(self.timings):.0f}ms, "
+            f"p95={p95:.0f}ms, max={max(self.timings):.0f}ms, "
+            f"over-budget={over}"
+        )
+
+
 def run_ticks_until(
     adapter: DiscreteTimeAdapter,
     audio_chunks: List[bytes],
+    timer: TickTimer,
     *,
     max_ticks: int = MAX_RESPONSE_TICKS,
     stop_when: Optional[str] = None,
@@ -237,6 +282,7 @@ def run_ticks_until(
     Args:
         adapter: The adapter to run ticks on.
         audio_chunks: Audio chunks to send (one per tick).
+        timer: TickTimer that records durations and asserts timing invariant.
         max_ticks: Maximum total ticks to run.
         stop_when: Stop condition -- "agent_audio" stops when agent produces audio,
             "tool_call" stops when a tool call is detected.
@@ -249,7 +295,7 @@ def run_ticks_until(
 
     for tick in range(max_ticks):
         user_audio = audio_chunks[tick] if tick < len(audio_chunks) else silence
-        result = adapter.run_tick(user_audio, tick_number=tick + 1)
+        result = timer.run_tick(adapter, user_audio, tick + 1)
         results.append(result)
 
         assert_audio_capping(result, adapter)
@@ -293,6 +339,14 @@ def connected_adapter(adapter: DiscreteTimeAdapter):
         modality="audio",
     )
     yield adapter
+
+
+@pytest.fixture
+def timer(request, provider_name: str):
+    """Tick timer that records durations and prints diagnostics at teardown."""
+    t = TickTimer()
+    yield t
+    t.print_diagnostics(f"{provider_name}/{request.node.name}")
 
 
 # =============================================================================
@@ -386,13 +440,15 @@ class TestSingleTurn:
 
     @pytest.mark.parametrize("audio_file", SPEECH_AUDIO)
     def test_single_turn_reply(
-        self, connected_adapter: DiscreteTimeAdapter, audio_file: str
+        self, connected_adapter: DiscreteTimeAdapter, audio_file: str, timer: TickTimer
     ):
         """Send speech audio, verify agent responds with audio and transcript."""
         audio = load_telephony_audio(audio_file)
         chunks = chunk_audio(audio, connected_adapter.bytes_per_tick)
 
-        results = run_ticks_until(connected_adapter, chunks, stop_when="agent_audio")
+        results = run_ticks_until(
+            connected_adapter, chunks, timer, stop_when="agent_audio"
+        )
 
         got_audio = any(r.agent_audio_bytes > 0 for r in results)
         assert got_audio, (
@@ -403,8 +459,8 @@ class TestSingleTurn:
         # Drain a few more ticks to let transcript arrive (may lag behind audio)
         silence = make_silence()
         for tick in range(10):
-            result = connected_adapter.run_tick(
-                silence, tick_number=len(results) + tick + 1
+            result = timer.run_tick(
+                connected_adapter, silence, len(results) + tick + 1
             )
             results.append(result)
             assert_audio_capping(result, connected_adapter)
@@ -424,14 +480,16 @@ class TestSingleTurn:
 class TestMultiTurn:
     """Verify the adapter handles multiple conversation turns."""
 
-    def test_multi_turn_reply(self, connected_adapter: DiscreteTimeAdapter):
+    def test_multi_turn_reply(
+        self, connected_adapter: DiscreteTimeAdapter, timer: TickTimer
+    ):
         """Two consecutive exchanges, both produce audio responses."""
         t1_audio = load_telephony_audio("hi_how_are_you.ulaw")
         t1_chunks = chunk_audio(t1_audio, connected_adapter.bytes_per_tick)
 
         # Turn 1: send speech, wait for response
         results_t1 = run_ticks_until(
-            connected_adapter, t1_chunks, stop_when="agent_audio"
+            connected_adapter, t1_chunks, timer, stop_when="agent_audio"
         )
         got_audio_t1 = any(r.agent_audio_bytes > 0 for r in results_t1)
         assert got_audio_t1, "Turn 1: agent did not produce audio"
@@ -439,8 +497,8 @@ class TestMultiTurn:
         # Let the agent finish responding (drain remaining audio)
         silence = make_silence()
         for tick in range(20):
-            result = connected_adapter.run_tick(
-                silence, tick_number=len(results_t1) + tick + 1
+            result = timer.run_tick(
+                connected_adapter, silence, len(results_t1) + tick + 1
             )
             assert_audio_capping(result, connected_adapter)
             assert_played_audio_length(result, connected_adapter)
@@ -453,8 +511,8 @@ class TestMultiTurn:
         results_t2: List[TickResult] = []
         for tick in range(MAX_RESPONSE_TICKS):
             user_audio = t2_chunks[tick] if tick < len(t2_chunks) else silence
-            result = connected_adapter.run_tick(
-                user_audio, tick_number=tick_offset + tick + 1
+            result = timer.run_tick(
+                connected_adapter, user_audio, tick_offset + tick + 1
             )
             results_t2.append(result)
             assert_audio_capping(result, connected_adapter)
@@ -474,7 +532,7 @@ class TestMultiTurn:
 class TestToolCall:
     """Verify tool calls work end-to-end."""
 
-    def test_tool_call_round_trip(self, adapter: DiscreteTimeAdapter):
+    def test_tool_call_round_trip(self, adapter: DiscreteTimeAdapter, timer: TickTimer):
         """Send order status audio with tool configured, verify round-trip."""
         tool = _make_order_tool()
 
@@ -489,7 +547,7 @@ class TestToolCall:
         chunks = chunk_audio(audio, adapter.bytes_per_tick)
 
         # Phase 1: send audio and wait for tool call
-        results = run_ticks_until(adapter, chunks, stop_when="tool_call")
+        results = run_ticks_until(adapter, chunks, timer, stop_when="tool_call")
 
         tool_call_results = [r for r in results if r.tool_calls]
         assert tool_call_results, (
@@ -513,7 +571,7 @@ class TestToolCall:
         got_response_audio = False
 
         for tick in range(MAX_RESPONSE_TICKS):
-            result = adapter.run_tick(silence, tick_number=tick_offset + tick + 1)
+            result = timer.run_tick(adapter, silence, tick_offset + tick + 1)
             assert_audio_capping(result, adapter)
             assert_played_audio_length(result, adapter)
             if result.agent_audio_bytes > 0:
@@ -548,7 +606,9 @@ class TestBargeIn:
     """Verify the adapter handles user interruptions and actually yields."""
 
     @pytest.mark.parametrize("audio_file", SPEECH_AUDIO)
-    def test_barge_in_detected(self, adapter: DiscreteTimeAdapter, audio_file: str):
+    def test_barge_in_detected(
+        self, adapter: DiscreteTimeAdapter, audio_file: str, timer: TickTimer
+    ):
         """Basic check: interruption event fires when user speaks over agent."""
         adapter.connect(
             system_prompt=BARGE_IN_SYSTEM_PROMPT,
@@ -560,7 +620,9 @@ class TestBargeIn:
         trigger_audio = load_telephony_audio(audio_file)
         trigger_chunks = chunk_audio(trigger_audio, adapter.bytes_per_tick)
 
-        results = run_ticks_until(adapter, trigger_chunks, stop_when="agent_audio")
+        results = run_ticks_until(
+            adapter, trigger_chunks, timer, stop_when="agent_audio"
+        )
         assert any(r.agent_audio_bytes > 0 for r in results), (
             f"Agent never started speaking for {audio_file}"
         )
@@ -577,7 +639,7 @@ class TestBargeIn:
                 if tick < len(interrupt_chunks)
                 else make_silence()
             )
-            result = adapter.run_tick(user_audio, tick_number=tick_offset + tick + 1)
+            result = timer.run_tick(adapter, user_audio, tick_offset + tick + 1)
             assert_audio_capping(result, adapter)
 
             if result.was_truncated:
@@ -592,7 +654,7 @@ class TestBargeIn:
             f"event within {MAX_RESPONSE_TICKS} ticks after sending interrupting speech"
         )
 
-    def test_barge_in_baseline(self, adapter: DiscreteTimeAdapter):
+    def test_barge_in_baseline(self, adapter: DiscreteTimeAdapter, timer: TickTimer):
         """Verify agent produces sustained audio (5s+) with the barge-in prompt.
 
         This establishes that the prompt reliably triggers a long response,
@@ -609,7 +671,9 @@ class TestBargeIn:
         trigger_audio = load_telephony_audio("hi_how_are_you.ulaw")
         trigger_chunks = chunk_audio(trigger_audio, adapter.bytes_per_tick)
 
-        results = run_ticks_until(adapter, trigger_chunks, stop_when="agent_audio")
+        results = run_ticks_until(
+            adapter, trigger_chunks, timer, stop_when="agent_audio"
+        )
         assert any(r.agent_audio_bytes > 0 for r in results), (
             "Agent never started speaking"
         )
@@ -620,7 +684,7 @@ class TestBargeIn:
 
         for _ in range(MAX_RESPONSE_TICKS):
             tick_num += 1
-            result = adapter.run_tick(silence, tick_number=tick_num)
+            result = timer.run_tick(adapter, silence, tick_num)
             assert_audio_capping(result, adapter)
             if result.agent_audio_bytes > 0:
                 agent_audio_ticks += 1
@@ -634,7 +698,9 @@ class TestBargeIn:
             f"({MIN_AGENT_AUDIO_TICKS * TICK_DURATION_MS}ms)"
         )
 
-    def test_barge_in_agent_yields(self, adapter: DiscreteTimeAdapter):
+    def test_barge_in_agent_yields(
+        self, adapter: DiscreteTimeAdapter, timer: TickTimer
+    ):
         """Full interruption lifecycle: agent speaks, user interrupts, agent yields.
 
         Relies on test_barge_in_baseline confirming the prompt produces 5s+
@@ -652,7 +718,9 @@ class TestBargeIn:
         trigger_audio = load_telephony_audio("hi_how_are_you.ulaw")
         trigger_chunks = chunk_audio(trigger_audio, adapter.bytes_per_tick)
 
-        results = run_ticks_until(adapter, trigger_chunks, stop_when="agent_audio")
+        results = run_ticks_until(
+            adapter, trigger_chunks, timer, stop_when="agent_audio"
+        )
         assert any(r.agent_audio_bytes > 0 for r in results), (
             "Agent never started speaking"
         )
@@ -664,7 +732,7 @@ class TestBargeIn:
 
         for _ in range(INTERRUPT_AFTER_TICKS + 5):
             tick_num += 1
-            result = adapter.run_tick(silence, tick_number=tick_num)
+            result = timer.run_tick(adapter, silence, tick_num)
             assert_audio_capping(result, adapter)
             if result.agent_audio_bytes > 0:
                 agent_audio_ticks += 1
@@ -689,7 +757,7 @@ class TestBargeIn:
                 interrupt_chunks[tick] if tick < len(interrupt_chunks) else silence
             )
             tick_num += 1
-            result = adapter.run_tick(user_audio, tick_number=tick_num)
+            result = timer.run_tick(adapter, user_audio, tick_num)
             assert_audio_capping(result, adapter)
 
             # Check for interruption event

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -91,6 +91,13 @@ PROVIDERS = [
         ),
     ),
     pytest.param(
+        "livekit-thinking",
+        marks=pytest.mark.skipif(
+            not os.environ.get("LIVEKIT_TEST_ENABLED"),
+            reason="LIVEKIT_TEST_ENABLED not set",
+        ),
+    ),
+    pytest.param(
         "nova",
         marks=pytest.mark.skipif(
             not os.environ.get("NOVA_TEST_ENABLED"),
@@ -320,10 +327,28 @@ def provider_name(request) -> str:
     return request.param
 
 
+CASCADED_CONFIG_ALIASES = {
+    "livekit-thinking": ("livekit", "openai-thinking"),
+}
+
+
 @pytest.fixture
 def adapter(provider_name: str):
     """Create, yield, and teardown a DiscreteTimeAdapter."""
-    adapter, _model = create_adapter(provider_name, tick_duration_ms=TICK_DURATION_MS)
+    real_provider = provider_name
+    cascaded_config = None
+
+    if provider_name in CASCADED_CONFIG_ALIASES:
+        from tau2.voice.audio_native.livekit.config import CASCADED_CONFIGS
+
+        real_provider, config_name = CASCADED_CONFIG_ALIASES[provider_name]
+        cascaded_config = CASCADED_CONFIGS[config_name]
+
+    adapter, _model = create_adapter(
+        real_provider,
+        tick_duration_ms=TICK_DURATION_MS,
+        cascaded_config=cascaded_config,
+    )
     yield adapter
     if adapter.is_connected:
         adapter.disconnect()


### PR DESCRIPTION
## Summary
- Migrates OpenAI Realtime provider from beta to GA API format.
- Removes `OpenAI-Beta: realtime=v1` header.
- Uses GA session structure: nested `audio.input`/`audio.output`, `output_modalities`, `type: realtime`.
- Updates `openai_utils.py` to return GA format objects directly (`audio/pcmu`, `audio/pcma`, `audio/pcm`) instead of legacy strings.
- Updates event types to GA names (`response.output_audio.delta`, etc.), removes legacy beta names.
- Depends on #252 (reasoning_effort plumbing).

## Test plan
- [x] Ran all 11 OpenAI provider suite tests with gpt-realtime-alpha-dolphin-6 — all pass
- [x] Ran 50 tasks from retail-regular. Scores 25/50. (Official submission is 24/50). 