### PR TITLE
Fix #234: Under certain circumstances, the model only returns thinkin...

### DIFF
--- a/src/tau2/data_model/message.py
+++ b/src/tau2/data_model/message.py
@@ -1,6 +1,9 @@
 import json
+import logging
 from copy import deepcopy
 from typing import Literal, Optional
+
+logger = logging.getLogger(__name__)
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -284,9 +287,11 @@ class ParticipantMessageBase(BaseModel):
     def validate(self):  # NOTE: It would be better to do this in the Pydantic model
         """Ensure that the message has either text/audio content or tool calls."""
         if not (self.has_content() or self.is_tool_call()):
-            raise ValueError(
-                f"{self.__class__.__name__} must have either content or tool_calls. Got {self}"
+            logger.warning(
+                f"{self.__class__.__name__} has no content or tool calls, "
+                f"injecting placeholder. Original: {self}"
             )
+            self.content = "[No response generated]"
 
     def has_content(self) -> bool:
         """Check if message has any non-empty content (text or audio)."""

--- a/tests/test_message_validate.py
+++ b/tests/test_message_validate.py
@@ -1,0 +1,34 @@
+"""Tests for ParticipantMessageBase.validate() placeholder injection."""
+
+import logging
+
+from tau2.data_model.message import AssistantMessage
+
+
+def test_validate_injects_placeholder_when_no_content_or_tool_calls(caplog):
+    """validate() should inject a placeholder instead of raising ValueError."""
+    msg = AssistantMessage(role="assistant", content=None, tool_calls=None)
+
+    with caplog.at_level(logging.WARNING, logger="tau2.data_model.message"):
+        msg.validate()
+
+    assert msg.content == "[No response generated]"
+    assert any("injecting placeholder" in record.message for record in caplog.records)
+
+
+def test_validate_does_not_modify_message_with_content():
+    """validate() should leave messages with text content unchanged."""
+    msg = AssistantMessage(role="assistant", content="Hello!")
+    msg.validate()
+    assert msg.content == "Hello!"
+
+
+def test_validate_does_not_modify_message_with_tool_calls():
+    """validate() should leave messages with tool calls unchanged."""
+    from tau2.data_model.message import ToolCall
+
+    tc = ToolCall(name="my_tool", arguments={})
+    msg = AssistantMessage(role="assistant", content=None, tool_calls=[tc])
+    msg.validate()
+    assert msg.tool_calls == [tc]
+    assert msg.content is None


### PR DESCRIPTION
Closes #234

## Before

`ParticipantMessageBase.validate()` in `src/tau2/data_model/message.py` raised a hard `ValueError` whenever a model response contained neither text/audio content nor tool calls:

```python
raise ValueError(
    f"{self.__class__.__name__} must have either content or tool_calls. Got {self}"
)
```

This surfaced under extended thinking models that occasionally emit only thinking tokens with no content block. The uncaught exception propagated up through the tau2 framework, terminating the entire evaluation sample rather than allowing the simulation to continue.

## After

Instead of raising, `validate()` now logs a `WARNING` via the module-level `logger = logging.getLogger(__name__)` and injects a `"[No response generated]"` placeholder into `self.content`. The simulation continues running; the placeholder makes the empty turn visible in transcripts without silently swallowing the anomaly.

## Changes

- **`src/tau2/data_model/message.py`**
  - Added `import logging` and a module-level `logger` (moved above the `pydantic` imports to keep logger definition at module scope).
  - In `ParticipantMessageBase.validate()`: replaced the `raise ValueError(...)` branch with `logger.warning(...)` + `self.content = "[No response generated]"`.

- **`tests/test_message_validate.py`** *(new file)*
  - `test_validate_injects_placeholder_when_no_content_or_tool_calls`: constructs an `AssistantMessage` with `content=None, tool_calls=None`, calls `validate()`, and asserts both that `msg.content == "[No response generated]"` and that the expected warning was emitted.
  - `test_validate_does_not_modify_message_with_content`: confirms messages with existing text are untouched.
  - `test_validate_does_not_modify_message_with_tool_calls`: confirms messages with tool calls are untouched and `content` remains `None`.

## Testing

All three new tests pass:

```
tests/test_message_validate.py::test_validate_injects_placeholder_when_no_content_or_tool_calls PASSED
tests/test_message_validate.py::test_validate_does_not_modify_message_with_content PASSED
tests/test_message_validate.py::test_validate_does_not_modify_message_with_tool_calls PASSED
```

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*