### PR TITLE
feat: add reasoning_effort support for audio-native providers

### DIFF
--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -2,69 +2,109 @@
 """
 Run audio-native evaluations across providers and speech complexities.
 
+Provider syntax: "provider", "provider:model", or "provider:model:reasoning"
+  - openai                           (default model, no reasoning)
+  - openai:gpt-realtime-1.5          (specific model)
+  - openai:gpt-realtime-1.5:high     (model + reasoning effort)
+  - livekit                           (default cascaded config)
+  - livekit::openai-thinking          (default model + cascaded config)
+
 Usage:
-    python -m experiments.tau_voice.run_multiple --providers openai,gemini,xai --save-to data/exp/my_run
-    python -m experiments.tau_voice.run_multiple --providers openai --save-to data/exp/my_run --num-tasks 5
-    python -m experiments.tau_voice.run_multiple --providers openai,gemini --save-to data/exp/my_run --domains airline --complexities control
+    python -m experiments.tau_voice.run_multiple --providers openai,gemini --save-to data/exp/my_run
+    python -m experiments.tau_voice.run_multiple --providers openai:gpt-realtime-1.5:high --save-to data/exp/run --num-tasks 5
+    python -m experiments.tau_voice.run_multiple --providers livekit,livekit::openai-thinking --save-to data/exp/run
 """
 
 import argparse
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 from tau2.config import DEFAULT_AUDIO_NATIVE_MODELS, DEFAULT_LLM_USER, DEFAULT_SEED
 
 DEFAULT_DOMAINS = ["airline", "retail"]
 DEFAULT_COMPLEXITIES = ["control", "regular"]
 
-# Virtual providers that map to a real provider + cascaded config
-VIRTUAL_PROVIDERS = {
-    "livekit-thinking": ("livekit", "openai-thinking"),
-}
+
+@dataclass
+class ProviderSpec:
+    provider: str
+    model: str
+    reasoning_effort: Optional[str] = None
+    cascaded_config: Optional[str] = None
+    display_name: str = ""
+
+    def __post_init__(self):
+        if not self.display_name:
+            self.display_name = self.provider
+
+
+def parse_provider(spec: str) -> ProviderSpec:
+    """Parse provider spec: 'provider', 'provider:model', or 'provider:model:qualifier'.
+
+    For livekit, the third field is a cascaded config name (e.g. 'openai-thinking').
+    For all other providers, the third field is reasoning effort (e.g. 'high').
+    """
+    parts = spec.split(":")
+    provider = parts[0]
+    model = DEFAULT_AUDIO_NATIVE_MODELS.get(provider, "dummy")
+
+    if len(parts) == 1:
+        return ProviderSpec(provider=provider, model=model, display_name=spec)
+    elif len(parts) == 2:
+        if parts[1]:
+            model = parts[1]
+        return ProviderSpec(provider=provider, model=model, display_name=spec)
+    elif len(parts) == 3:
+        if parts[1]:
+            model = parts[1]
+        qualifier = parts[2]
+        if provider == "livekit":
+            return ProviderSpec(
+                provider=provider, model=model,
+                cascaded_config=qualifier, display_name=spec,
+            )
+        else:
+            return ProviderSpec(
+                provider=provider, model=model,
+                reasoning_effort=qualifier, display_name=spec,
+            )
+    else:
+        raise ValueError(f"Invalid provider spec: {spec}")
 
 
 def build_command(
     domain: str,
-    provider: str,
-    model: str,
+    spec: ProviderSpec,
     complexity: str,
     save_to: str,
     *,
-    cascaded_config: str | None = None,
     num_tasks: int | None = None,
     seed: int = DEFAULT_SEED,
     user_llm: str = DEFAULT_LLM_USER,
     max_concurrency: int = 8,
 ) -> list[str]:
     cmd = [
-        "uv",
-        "run",
-        "tau2",
-        "run",
-        "--domain",
-        domain,
+        "uv", "run", "tau2", "run",
+        "--domain", domain,
         "--audio-native",
-        "--audio-native-provider",
-        provider,
-        "--audio-native-model",
-        model,
-        "--speech-complexity",
-        complexity,
-        "--seed",
-        str(seed),
-        "--user-llm",
-        user_llm,
-        "--max-concurrency",
-        str(max_concurrency),
+        "--audio-native-provider", spec.provider,
+        "--audio-native-model", spec.model,
+        "--speech-complexity", complexity,
+        "--seed", str(seed),
+        "--user-llm", user_llm,
+        "--max-concurrency", str(max_concurrency),
         "--verbose-logs",
         "--auto-review",
         "--auto-resume",
-        "--save-to",
-        save_to,
+        "--save-to", save_to,
     ]
-    if cascaded_config is not None:
-        cmd.extend(["--cascaded-config", cascaded_config])
+    if spec.reasoning_effort is not None:
+        cmd.extend(["--reasoning-effort", spec.reasoning_effort])
+    if spec.cascaded_config is not None:
+        cmd.extend(["--cascaded-config", spec.cascaded_config])
     if num_tasks is not None:
         cmd.extend(["--num-tasks", str(num_tasks)])
     return cmd
@@ -78,7 +118,7 @@ def main():
         "--providers",
         type=str,
         required=True,
-        help="Comma-separated providers (e.g. openai,gemini,xai,livekit,livekit-thinking)",
+        help="Comma-separated provider specs (e.g. openai,openai:model:high,livekit::openai-thinking)",
     )
     parser.add_argument(
         "--domains",
@@ -104,49 +144,29 @@ def main():
     )
     args = parser.parse_args()
 
-    providers = [p.strip() for p in args.providers.split(",")]
+    specs = [parse_provider(p.strip()) for p in args.providers.split(",")]
     domains = [d.strip() for d in args.domains.split(",")]
     complexities = [c.strip() for c in args.complexities.split(",")]
-
-    # Resolve provider -> (real_provider, model, cascaded_config, display_name)
-    provider_entries = []
-    for p in providers:
-        if p in VIRTUAL_PROVIDERS:
-            real_provider, cascaded = VIRTUAL_PROVIDERS[p]
-            model = DEFAULT_AUDIO_NATIVE_MODELS[real_provider]
-            provider_entries.append((real_provider, model, cascaded, p))
-        elif ":" in p:
-            prov, model = p.split(":", 1)
-            provider_entries.append((prov, model, None, p))
-        else:
-            provider_entries.append((p, DEFAULT_AUDIO_NATIVE_MODELS[p], None, p))
 
     base_dir = Path(args.save_to).resolve()
 
     combos = [
-        (domain, prov, model, cascaded, display, complexity)
+        (domain, spec, complexity)
         for domain in domains
-        for prov, model, cascaded, display in provider_entries
+        for spec in specs
         for complexity in complexities
     ]
     total = len(combos)
 
     print(f"Running {total} combinations -> {base_dir}\n")
 
-    for i, (domain, provider, model, cascaded, display, complexity) in enumerate(
-        combos, 1
-    ):
-        run_name = f"{domain}_{complexity}_{display}_{model}"
+    for i, (domain, spec, complexity) in enumerate(combos, 1):
+        run_name = f"{domain}_{complexity}_{spec.display_name}".replace(":", "_")
         save_to = str(base_dir / run_name)
 
         print(f"[{i}/{total}] {run_name}")
         cmd = build_command(
-            domain,
-            provider,
-            model,
-            complexity,
-            save_to,
-            cascaded_config=cascaded,
+            domain, spec, complexity, save_to,
             num_tasks=args.num_tasks,
             seed=args.seed,
             user_llm=args.user_llm,

--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -206,6 +206,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         audio_format: Optional[AudioFormat] = None,
         provider: AudioNativeProvider = DEFAULT_AUDIO_NATIVE_PROVIDER,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         max_inactive_seconds: float = DEFAULT_AUDIO_NATIVE_MAX_INACTIVE_SECONDS,
         use_xml_prompt: bool = False,
         cascaded_config: Optional["CascadedConfig"] = None,
@@ -250,6 +251,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         self.provider = provider
         self.use_xml_prompt = use_xml_prompt
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self.max_inactive_seconds = max_inactive_seconds
         self.cascaded_config = cascaded_config
 
@@ -362,6 +364,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
                 tick_duration_ms=self.tick_duration_ms,
                 send_audio_instant=self.send_audio_instant,
                 model=self.model,
+                reasoning_effort=self.reasoning_effort,
                 audio_format=self.audio_format,
                 cascaded_config=self.cascaded_config,
             )
@@ -810,6 +813,7 @@ def create_discrete_time_audio_native_agent(tools, domain_policy, **kwargs):
             send_audio_instant=audio_native_config.send_audio_instant,
             provider=audio_native_config.provider,
             model=audio_native_config.model,
+            reasoning_effort=audio_native_config.reasoning_effort,
             use_xml_prompt=audio_native_config.use_xml_prompt,
             cascaded_config=getattr(audio_native_config, "cascaded_config", None),
             audio_taps_dir=audio_taps_dir,

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -257,6 +257,13 @@ def add_run_args(parser):
         help="Audio native model to use. If not specified, uses the default model for the selected provider.",
     )
     parser.add_argument(
+        "--reasoning-effort",
+        type=str,
+        choices=["minimal", "low", "medium", "high"],
+        default=None,
+        help="Reasoning effort for thinking models. Only applies to providers that support it (e.g. OpenAI).",
+    )
+    parser.add_argument(
         "--tick-duration",
         type=float,
         default=DEFAULT_TICK_DURATION_SECONDS,
@@ -595,6 +602,7 @@ def main():
                 provider=args.audio_native_provider,
                 model=audio_native_model,
                 cascaded_config_name=args.cascaded_config,
+                reasoning_effort=args.reasoning_effort,
                 # Timing
                 tick_duration_seconds=args.tick_duration,
                 max_steps_seconds=args.max_steps_seconds,

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -102,7 +102,7 @@ DEFAULT_AUDIO_NATIVE_PROVIDER = (
     "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
-DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable, 20 minutes max
+DEFAULT_MAX_STEPS_SECONDS = 120  # overridable
 DEFAULT_SEND_AUDIO_INSTANT = False  # overridable
 
 # Turn-taking thresholds (overridable, in seconds, converted to ticks at runtime)
@@ -156,7 +156,6 @@ DEFAULT_WHISPER_MODEL = "whisper-1"  # fixed
 DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-live-preview"  # overridable
 _LEGACY_GEMINI_MODEL = "gemini-live-2.5-flash-native-audio"
 DEFAULT_GEMINI_VOICE = "Zephyr"  # overridable
-DEFAULT_GEMINI_THINKING_LEVEL = "high"  # overridable: minimal, low, medium, high
 DEFAULT_GEMINI_PROACTIVE_AUDIO = True  # fixed
 DEFAULT_GEMINI_LOCATION = "us-central1"  # fixed
 DEFAULT_GEMINI_INPUT_SAMPLE_RATE = 16000  # fixed, API-defined
@@ -199,6 +198,15 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
     "nova": DEFAULT_NOVA_MODEL,
     "qwen": DEFAULT_QWEN_MODEL,
     "livekit": "dummy",
+}
+
+DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
+    "openai": "high",
+    "gemini": "high",
+    "xai": None,
+    "nova": None,
+    "qwen": None,
+    "livekit": None,
 }
 
 AUDIO_NATIVE_PROVIDER_TYPES = {

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -102,7 +102,7 @@ DEFAULT_AUDIO_NATIVE_PROVIDER = (
     "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
-DEFAULT_MAX_STEPS_SECONDS = 120  # overridable
+DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable, 20 minutes max
 DEFAULT_SEND_AUDIO_INSTANT = False  # overridable
 
 # Turn-taking thresholds (overridable, in seconds, converted to ticks at runtime)

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -84,6 +84,10 @@ class AudioNativeConfig(BaseModel):
         default=DEFAULT_AUDIO_NATIVE_MODELS[DEFAULT_AUDIO_NATIVE_PROVIDER],
         description="Audio native model to use",
     )
+    reasoning_effort: Optional[str] = Field(
+        default=None,
+        description="Reasoning effort for thinking models: 'minimal', 'low', 'medium', 'high'. If None, not sent.",
+    )
 
     # Timing configuration
     tick_duration_seconds: float = Field(

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from tau2.config import (
     DEFAULT_AUDIO_NATIVE_MODELS,
+    DEFAULT_AUDIO_NATIVE_REASONING_EFFORT,
     DEFAULT_AUDIO_NATIVE_VOIP_PACKET_INTERVAL_MS,
     DEFAULT_SEND_AUDIO_INSTANT,
     TELEPHONY_ULAW_SILENCE,
@@ -359,6 +360,10 @@ def create_adapter(
     Raises:
         ValueError: If the provider is unknown.
     """
+    # --- Resolve reasoning_effort default ---
+    if reasoning_effort is None:
+        reasoning_effort = DEFAULT_AUDIO_NATIVE_REASONING_EFFORT.get(provider)
+
     # --- Resolve model default ---
     if model is None:
         if provider == "livekit":
@@ -400,6 +405,7 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
         )
     elif provider == "xai":
         from tau2.voice.audio_native.xai.discrete_time_adapter import (

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -415,6 +415,7 @@ def create_adapter(
         adapter = DiscreteTimeXAIAdapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
+            reasoning_effort=reasoning_effort,
         )
     elif provider == "nova":
         from tau2.voice.audio_native.nova.discrete_time_adapter import (
@@ -425,6 +426,7 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
         )
     elif provider == "qwen":
         from tau2.voice.audio_native.qwen.discrete_time_adapter import (
@@ -435,6 +437,7 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
         )
     elif provider == "livekit":
         from tau2.voice.audio_native.livekit.config import CascadedConfig

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -333,6 +333,7 @@ def create_adapter(
     tick_duration_ms: int,
     send_audio_instant: bool = DEFAULT_SEND_AUDIO_INSTANT,
     model: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     audio_format: Optional[AudioFormat] = None,
     cascaded_config: Any = None,
 ) -> Tuple[DiscreteTimeAdapter, str]:
@@ -387,6 +388,7 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
             audio_format=audio_format,
         )
     elif provider == "gemini":

--- a/src/tau2/voice/audio_native/gemini/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/gemini/discrete_time_adapter.py
@@ -96,6 +96,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
         tick_duration_ms: int,
         send_audio_instant: bool = True,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[GeminiLiveProvider] = None,
         max_resumptions: int = 3,
         resume_only_on_timeout: bool = True,
@@ -132,6 +133,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
             raise ValueError("model and provider cannot be provided together")
 
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self._max_resumptions = max_resumptions
         self._resume_only_on_timeout = resume_only_on_timeout
 
@@ -158,6 +160,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
         if self._provider is None:
             self._provider = GeminiLiveProvider(
                 model=self.model,
+                reasoning_effort=self.reasoning_effort,
                 max_resumptions=self._max_resumptions,
                 resume_only_on_timeout=self._resume_only_on_timeout,
             )

--- a/src/tau2/voice/audio_native/gemini/provider.py
+++ b/src/tau2/voice/audio_native/gemini/provider.py
@@ -19,7 +19,6 @@ from tau2.config import (
     DEFAULT_GEMINI_MODEL,
     DEFAULT_GEMINI_OUTPUT_SAMPLE_RATE,
     DEFAULT_GEMINI_PROACTIVE_AUDIO,
-    DEFAULT_GEMINI_THINKING_LEVEL,
     DEFAULT_GEMINI_VOICE,
 )
 from tau2.environment.tool import Tool
@@ -140,6 +139,7 @@ class GeminiLiveProvider:
         self,
         api_key: Optional[str] = None,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         project_id: Optional[str] = None,
         location: Optional[str] = None,
         use_raw_json_schema: bool = True,
@@ -275,6 +275,8 @@ class GeminiLiveProvider:
                 "  - GOOGLE_SERVICE_ACCOUNT_KEY (JSON content for Vertex AI)\n"
                 "  - GOOGLE_APPLICATION_CREDENTIALS (file path for Vertex AI)"
             )
+
+        self.reasoning_effort = reasoning_effort
 
         self._client = None
         self._session = None
@@ -480,10 +482,9 @@ class GeminiLiveProvider:
                     proactive_audio=True,
                 )
 
-            # Add thinking config if a thinking level is set
-            if DEFAULT_GEMINI_THINKING_LEVEL:
+            if self.reasoning_effort:
                 config_kwargs["thinking_config"] = types.ThinkingConfig(
-                    thinking_level=DEFAULT_GEMINI_THINKING_LEVEL.upper(),
+                    thinking_level=self.reasoning_effort.upper(),
                 )
 
             config = types.LiveConnectConfig(**config_kwargs)

--- a/src/tau2/voice/audio_native/livekit/config.py
+++ b/src/tau2/voice/audio_native/livekit/config.py
@@ -70,7 +70,7 @@ class OpenAILLMConfig(BaseModel):
         model: Model name (e.g., "gpt-4.1", "o3-mini", "gpt-4.1-mini").
         temperature: Sampling temperature (0.0-2.0). Not used for thinking models.
         top_p: Nucleus sampling parameter.
-        reasoning_effort: For thinking models (o1, o3): "low", "medium", "high".
+        reasoning_effort: For thinking models (o1, o3): "minimal", "low", "medium", "high".
             Controls how much "thinking" the model does before responding.
         max_completion_tokens: Maximum tokens in the response.
         timeout_seconds: Request timeout in seconds.
@@ -81,7 +81,7 @@ class OpenAILLMConfig(BaseModel):
     model: str = "gpt-4.1"
     temperature: Optional[float] = None
     top_p: Optional[float] = None
-    reasoning_effort: Optional[Literal["low", "medium", "high"]] = None
+    reasoning_effort: Optional[Literal["minimal", "low", "medium", "high"]] = None
     max_completion_tokens: Optional[int] = None
     timeout_seconds: Optional[float] = None
     parallel_tool_calls: Optional[bool] = None
@@ -199,6 +199,6 @@ CASCADED_CONFIGS: Dict[str, CascadedConfig] = {
         stt=DeepgramSTTConfig(model="nova-3"),
         llm=OpenAILLMConfig(model="gpt-5.2", reasoning_effort="high"),
         tts=DeepgramTTSConfig(model="aura-asteria-en"),
-        preamble=True,
+        # preamble=True,
     ),
 }

--- a/src/tau2/voice/audio_native/nova/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/nova/discrete_time_adapter.py
@@ -96,6 +96,7 @@ class DiscreteTimeNovaAdapter(DiscreteTimeAdapter):
         tick_duration_ms: int,
         send_audio_instant: bool = True,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[NovaSonicProvider] = None,
         voice: str = "tiffany",
     ):
@@ -106,9 +107,14 @@ class DiscreteTimeNovaAdapter(DiscreteTimeAdapter):
             send_audio_instant: If True, send audio in one call (discrete-time mode).
             model: Model to use. Defaults to None (provider default).
                 If provider is also provided, this is ignored.
+            reasoning_effort: Not supported by Nova. Must be None.
             provider: Optional provider instance. Created lazily if not provided.
             voice: Voice to use. Options: matthew, tiffany, amy. Default: tiffany.
         """
+        if reasoning_effort is not None:
+            raise ValueError(
+                f"Nova provider does not support reasoning_effort (got '{reasoning_effort}')"
+            )
         super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
 
         self._chunk_size = int(NOVA_BYTES_PER_SECOND * self._voip_interval_ms / 1000)

--- a/src/tau2/voice/audio_native/qwen/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/qwen/discrete_time_adapter.py
@@ -101,6 +101,7 @@ class DiscreteTimeQwenAdapter(DiscreteTimeAdapter):
         tick_duration_ms: int,
         send_audio_instant: bool = True,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[QwenRealtimeProvider] = None,
         voice: str = "Cherry",
     ):
@@ -111,9 +112,14 @@ class DiscreteTimeQwenAdapter(DiscreteTimeAdapter):
             send_audio_instant: If True, send audio in one call (discrete-time mode).
             model: Model to use. Defaults to None (provider default).
                 If provider is also provided, this is ignored.
+            reasoning_effort: Not supported by Qwen. Must be None.
             provider: Optional provider instance. Created lazily if not provided.
             voice: Voice to use. Default: Cherry.
         """
+        if reasoning_effort is not None:
+            raise ValueError(
+                f"Qwen provider does not support reasoning_effort (got '{reasoning_effort}')"
+            )
         super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
 
         self._chunk_size = int(

--- a/src/tau2/voice/audio_native/xai/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/xai/discrete_time_adapter.py
@@ -93,6 +93,7 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
         self,
         tick_duration_ms: int,
         send_audio_instant: bool = True,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[XAIRealtimeProvider] = None,
         voice: str = "Ara",
     ):
@@ -101,9 +102,14 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
         Args:
             tick_duration_ms: Duration of each tick in milliseconds. Must be > 0.
             send_audio_instant: If True, send audio in one call (discrete-time mode).
+            reasoning_effort: Not supported by xAI. Must be None.
             provider: Optional provider instance. Created lazily if not provided.
             voice: Voice to use. One of: Ara, Rex, Sal, Eve, Leo. Default: Ara.
         """
+        if reasoning_effort is not None:
+            raise ValueError(
+                f"xAI provider does not support reasoning_effort (got '{reasoning_effort}')"
+            )
         super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
 
         self._chunk_size = int(


### PR DESCRIPTION
Replaces #252. Threads reasoning_effort through full stack, unified defaults dict, all providers accept it.

Made with [Cursor](https://cursor.com)