### PR TITLE
feat: migrate OpenAI provider to GA Realtime API

### DIFF
--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -102,7 +102,7 @@ DEFAULT_AUDIO_NATIVE_PROVIDER = (
     "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
-DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable, 20 minutes max
+DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable
 DEFAULT_SEND_AUDIO_INSTANT = False  # overridable
 
 # Turn-taking thresholds (overridable, in seconds, converted to ticks at runtime)
@@ -201,7 +201,7 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
 }
 
 DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
-    "openai": "high",
+    "openai": None,
     "gemini": "high",
     "xai": None,
     "nova": None,

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -102,7 +102,7 @@ DEFAULT_AUDIO_NATIVE_PROVIDER = (
     "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
-DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable, 20 minutes max
+DEFAULT_MAX_STEPS_SECONDS = 120  # overridable
 DEFAULT_SEND_AUDIO_INSTANT = False  # overridable
 
 # Turn-taking thresholds (overridable, in seconds, converted to ticks at runtime)

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -102,7 +102,7 @@ DEFAULT_AUDIO_NATIVE_PROVIDER = (
     "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
-DEFAULT_MAX_STEPS_SECONDS = 120  # overridable
+DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable, 20 minutes max
 DEFAULT_SEND_AUDIO_INSTANT = False  # overridable
 
 # Turn-taking thresholds (overridable, in seconds, converted to ticks at runtime)

--- a/src/tau2/voice/audio_native/openai/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/openai/discrete_time_adapter.py
@@ -68,6 +68,7 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
         tick_duration_ms: int,
         send_audio_instant: bool = False,
         model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         provider: Optional[OpenAIRealtimeProvider] = None,
         audio_format: Optional[AudioFormat] = None,
     ):
@@ -85,6 +86,7 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
             raise ValueError("model and provider cannot be provided together")
 
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self._provider = provider
         self._owns_provider = provider is None
 
@@ -94,7 +96,10 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
     @property
     def provider(self) -> OpenAIRealtimeProvider:
         if self._provider is None:
-            self._provider = OpenAIRealtimeProvider(model=self.model)
+            self._provider = OpenAIRealtimeProvider(
+                model=self.model,
+                reasoning_effort=self.reasoning_effort,
+            )
         return self._provider
 
     @property

--- a/src/tau2/voice/audio_native/openai/events.py
+++ b/src/tau2/voice/audio_native/openai/events.py
@@ -26,7 +26,7 @@ class TextDoneEvent(BaseRealtimeEvent):
 
 
 class AudioDeltaEvent(BaseRealtimeEvent):
-    type: Literal["response.audio.delta"]
+    type: Literal["response.output_audio.delta"]
     delta: str = Field(
         default="", description="Base64-encoded audio delta", exclude=True
     )  # Exclude from serialization due to large size
@@ -35,19 +35,19 @@ class AudioDeltaEvent(BaseRealtimeEvent):
 
 
 class AudioDoneEvent(BaseRealtimeEvent):
-    type: Literal["response.audio.done"]
+    type: Literal["response.output_audio.done"]
     item_id: Optional[str] = None
 
 
 class AudioTranscriptDeltaEvent(BaseRealtimeEvent):
-    type: Literal["response.audio_transcript.delta"]
+    type: Literal["response.output_audio_transcript.delta"]
     delta: str
     response_id: Optional[str] = None
     item_id: Optional[str] = None
 
 
 class AudioTranscriptDoneEvent(BaseRealtimeEvent):
-    type: Literal["response.audio_transcript.done"]
+    type: Literal["response.output_audio_transcript.done"]
     transcript: str = ""
     item_id: Optional[str] = None
 
@@ -214,10 +214,10 @@ RealtimeEvent = Annotated[_KnownEvents, Field(discriminator="type")]
 _EVENT_TYPE_MAP: dict[str, type[BaseRealtimeEvent]] = {
     "response.text.delta": TextDeltaEvent,
     "response.text.done": TextDoneEvent,
-    "response.audio.delta": AudioDeltaEvent,
-    "response.audio.done": AudioDoneEvent,
-    "response.audio_transcript.delta": AudioTranscriptDeltaEvent,
-    "response.audio_transcript.done": AudioTranscriptDoneEvent,
+    "response.output_audio.delta": AudioDeltaEvent,
+    "response.output_audio.done": AudioDoneEvent,
+    "response.output_audio_transcript.delta": AudioTranscriptDeltaEvent,
+    "response.output_audio_transcript.done": AudioTranscriptDoneEvent,
     "response.function_call_arguments.delta": FunctionCallArgumentsDeltaEvent,
     "response.function_call_arguments.done": FunctionCallArgumentsDoneEvent,
     "response.output_item.added": OutputItemAddedEvent,

--- a/src/tau2/voice/audio_native/openai/provider.py
+++ b/src/tau2/voice/audio_native/openai/provider.py
@@ -31,7 +31,7 @@ from tau2.voice.audio_native.openai.events import (
     UnknownEvent,
     parse_realtime_event,
 )
-from tau2.voice.utils.openai_utils import audio_format_to_openai_string
+from tau2.voice.utils.openai_utils import audio_format_to_openai
 
 load_dotenv()
 
@@ -113,13 +113,20 @@ class OpenAIRealtimeProvider:
     BASE_URL = DEFAULT_OPENAI_REALTIME_BASE_URL
     DEFAULT_MODEL = DEFAULT_OPENAI_REALTIME_MODEL
 
-    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+    ):
         """Initialize the OpenAI Realtime provider.
 
         Args:
             api_key: OpenAI API key. If not provided, reads from OPENAI_API_KEY
                 environment variable.
             model: Model identifier to use. Defaults to DEFAULT_MODEL.
+            reasoning_effort: Reasoning effort for thinking models ("minimal",
+                "low", "medium", "high"). If None, not sent to the API.
 
         Raises:
             ValueError: If no API key is provided or found in environment.
@@ -129,6 +136,7 @@ class OpenAIRealtimeProvider:
             raise ValueError("OpenAI API key not provided. Set OPENAI_API_KEY env var.")
 
         self.model = model or self.DEFAULT_MODEL
+        self.reasoning_effort = reasoning_effort
         self.ws: Optional[websockets.WebSocketClientProtocol] = None
         self._current_vad_config: Optional[OpenAIVADConfig] = None
         self._audio_format: AudioFormat = TELEPHONY_AUDIO_FORMAT
@@ -170,10 +178,7 @@ class OpenAIRealtimeProvider:
             return
 
         url = f"{self.BASE_URL}?model={self.model}"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "OpenAI-Beta": "realtime=v1",
-        }
+        headers = {"Authorization": f"Bearer {self.api_key}"}
 
         self.ws = await websockets.connect(url, additional_headers=headers)
 
@@ -297,7 +302,7 @@ class OpenAIRealtimeProvider:
         if modality == "text":
             modalities = ["text"]
         elif modality == "audio":
-            modalities = ["text", "audio"]
+            modalities = ["audio"]
         elif modality == "audio_in_text_out":
             modalities = ["text"]
         else:
@@ -310,43 +315,39 @@ class OpenAIRealtimeProvider:
         # Store audio format for reference
         self._audio_format = audio_format
 
-        session_config = {
-            "type": "session.update",
-            "session": {
-                "instructions": system_prompt,
-                "modalities": modalities,
-                "tools": self._format_tools_for_api(tools),
-                "tool_choice": "auto",
-                "turn_detection": self._build_turn_detection_config(vad_config),
-            },
+        audio_fmt = audio_format_to_openai(audio_format)
+
+        session = {
+            "type": "realtime",
+            "instructions": system_prompt,
+            "output_modalities": modalities,
+            "tools": self._format_tools_for_api(tools),
+            "tool_choice": "auto",
         }
 
+        if self.reasoning_effort is not None:
+            session["reasoning"] = {"effort": self.reasoning_effort}
+
         if modality in ("audio", "audio_in_text_out"):
-            # Get OpenAI format string from AudioFormat
-            openai_format = audio_format_to_openai_string(audio_format)
-            input_config = {
-                "input_audio_format": openai_format,
-                "input_audio_transcription": {
-                    "model": DEFAULT_OPENAI_TRANSCRIPTION_MODEL,
-                    "language": "en",
-                },
-                "input_audio_noise_reduction": {
-                    "type": DEFAULT_OPENAI_NOISE_REDUCTION,
+            session["audio"] = {
+                "input": {
+                    "format": audio_fmt,
+                    "transcription": {
+                        "model": DEFAULT_OPENAI_TRANSCRIPTION_MODEL,
+                        "language": "en",
+                    },
+                    "noise_reduction": {"type": DEFAULT_OPENAI_NOISE_REDUCTION},
+                    "turn_detection": self._build_turn_detection_config(vad_config),
                 },
             }
-            session_config["session"].update(input_config)
 
         if modality == "audio":
-            # Get OpenAI format string from AudioFormat
-            openai_format = audio_format_to_openai_string(audio_format)
-            session_config["session"].update(
-                {
-                    "voice": DEFAULT_OPENAI_VOICE,
-                    "output_audio_format": openai_format,
-                }
-            )
+            session.setdefault("audio", {})["output"] = {
+                "format": audio_fmt,
+                "voice": DEFAULT_OPENAI_VOICE,
+            }
 
-        await self.ws.send(json.dumps(session_config))
+        await self.ws.send(json.dumps({"type": "session.update", "session": session}))
 
         while True:
             response = await self.ws.recv()

--- a/src/tau2/voice/utils/openai_utils.py
+++ b/src/tau2/voice/utils/openai_utils.py
@@ -1,12 +1,12 @@
 """OpenAI Realtime API audio format utilities.
 
 This module provides conversion functions between tau2's AudioFormat
-and OpenAI Realtime API format strings.
+and OpenAI Realtime API format objects.
 
-OpenAI Realtime API supports:
-- g711_ulaw: 8kHz, 8-bit μ-law (telephony)
-- g711_alaw: 8kHz, 8-bit A-law (telephony)
-- pcm16: 24kHz, 16-bit signed PCM
+OpenAI GA API audio formats:
+- audio/pcmu: G.711 μ-law (telephony)
+- audio/pcma: G.711 A-law (telephony)
+- audio/pcm: 24kHz, 16-bit signed PCM (requires rate: 24000)
 """
 
 from tau2.config import DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
@@ -16,88 +16,76 @@ from tau2.data_model.audio import (
     AudioFormat,
 )
 
-# OpenAI Realtime API uses 24kHz for pcm16 format
 OPENAI_PCM16_SAMPLE_RATE = DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
 
 
-def audio_format_to_openai_string(audio_format: AudioFormat) -> str:
-    """Convert AudioFormat to OpenAI Realtime API format string.
+def audio_format_to_openai(audio_format: AudioFormat) -> dict:
+    """Convert AudioFormat to OpenAI GA API format object.
 
     Args:
         audio_format: The AudioFormat to convert.
 
     Returns:
-        OpenAI format string: "g711_ulaw", "g711_alaw", or "pcm16".
+        Dict with 'type' and optionally 'rate' for the GA API.
 
     Raises:
         ValueError: If the format is not supported by OpenAI Realtime API.
-
-    Example:
-        >>> fmt = AudioFormat(encoding=AudioEncoding.ULAW, sample_rate=8000)
-        >>> audio_format_to_openai_string(fmt)
-        'g711_ulaw'
     """
     if audio_format.encoding == AudioEncoding.ULAW:
         if audio_format.sample_rate != TELEPHONY_SAMPLE_RATE:
             raise ValueError(
-                f"OpenAI g711_ulaw requires {TELEPHONY_SAMPLE_RATE}Hz, "
+                f"OpenAI audio/pcmu requires {TELEPHONY_SAMPLE_RATE}Hz, "
                 f"got {audio_format.sample_rate}Hz"
             )
-        return "g711_ulaw"
+        return {"type": "audio/pcmu"}
     elif audio_format.encoding == AudioEncoding.ALAW:
         if audio_format.sample_rate != TELEPHONY_SAMPLE_RATE:
             raise ValueError(
-                f"OpenAI g711_alaw requires {TELEPHONY_SAMPLE_RATE}Hz, "
+                f"OpenAI audio/pcma requires {TELEPHONY_SAMPLE_RATE}Hz, "
                 f"got {audio_format.sample_rate}Hz"
             )
-        return "g711_alaw"
+        return {"type": "audio/pcma"}
     elif audio_format.encoding == AudioEncoding.PCM_S16LE:
         if audio_format.sample_rate != OPENAI_PCM16_SAMPLE_RATE:
             raise ValueError(
-                f"OpenAI pcm16 requires {OPENAI_PCM16_SAMPLE_RATE}Hz, "
+                f"OpenAI audio/pcm requires {OPENAI_PCM16_SAMPLE_RATE}Hz, "
                 f"got {audio_format.sample_rate}Hz"
             )
-        return "pcm16"
+        return {"type": "audio/pcm", "rate": 24000}
     else:
         raise ValueError(
             f"Unsupported encoding for OpenAI: {audio_format.encoding}. "
-            "Supported: ULAW (g711_ulaw), ALAW (g711_alaw), PCM_S16LE (pcm16)"
+            "Supported: ULAW (audio/pcmu), ALAW (audio/pcma), PCM_S16LE (audio/pcm)"
         )
 
 
-def openai_string_to_audio_format(format_string: str) -> AudioFormat:
-    """Create AudioFormat from OpenAI Realtime API format string.
+def openai_format_to_audio_format(fmt: dict) -> AudioFormat:
+    """Create AudioFormat from OpenAI GA API format object.
 
     Args:
-        format_string: "g711_ulaw", "g711_alaw", or "pcm16".
+        fmt: Dict with 'type' key (e.g. {"type": "audio/pcmu"}).
 
     Returns:
         AudioFormat configured for the specified format.
 
     Raises:
-        ValueError: If the format string is not recognized.
-
-    Example:
-        >>> fmt = openai_string_to_audio_format("g711_ulaw")
-        >>> fmt.encoding
-        <AudioEncoding.ULAW: 'ulaw'>
-        >>> fmt.sample_rate
-        8000
+        ValueError: If the format type is not recognized.
     """
-    if format_string == "g711_ulaw":
+    fmt_type = fmt.get("type", "")
+    if fmt_type == "audio/pcmu":
         return AudioFormat(
             encoding=AudioEncoding.ULAW, sample_rate=TELEPHONY_SAMPLE_RATE
         )
-    elif format_string == "g711_alaw":
+    elif fmt_type == "audio/pcma":
         return AudioFormat(
             encoding=AudioEncoding.ALAW, sample_rate=TELEPHONY_SAMPLE_RATE
         )
-    elif format_string == "pcm16":
+    elif fmt_type == "audio/pcm":
         return AudioFormat(
             encoding=AudioEncoding.PCM_S16LE, sample_rate=OPENAI_PCM16_SAMPLE_RATE
         )
     else:
         raise ValueError(
-            f"Unknown OpenAI format: {format_string}. "
-            "Supported: g711_ulaw, g711_alaw, pcm16"
+            f"Unknown OpenAI format: {fmt_type}. "
+            "Supported: audio/pcmu, audio/pcma, audio/pcm"
         )


### PR DESCRIPTION
Replaces #253. GA session format, GA event names, no beta header, all 11 OpenAI tests pass.

Made with [Cursor](https://cursor.com)