### PR TITLE
feat: add leaderboard progress view

### DIFF
--- a/docs/leaderboard-submission.md
+++ b/docs/leaderboard-submission.md
@@ -400,6 +400,7 @@ Your `submission.json` must follow the schema defined in [`web/leaderboard/publi
 | `references` | array | — | Links to papers, documentation, repos |
 | `methodology` | object | — | Evaluation methodology details |
 | `voice_config` | object | — | Voice-specific configuration (required for voice) |
+| `model_release` | object | — | Model release metadata (release date + announcement link); see [Model Release](#model-release) |
 
 ### Domain Results
 
@@ -411,6 +412,30 @@ Each domain in `results` accepts:
 ### References
 
 The optional `references` array links to papers, blog posts, documentation, or other resources. Supported `type` values: `paper`, `blog_post`, `documentation`, `model_card`, `github`, `huggingface`, `other`.
+
+### Model Release
+
+The optional `model_release` object captures metadata about the **model itself** (independent of the evaluation), so the leaderboard can track model progress over time:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `release_date` | string (YYYY-MM-DD) | Date the model was first made publicly available |
+| `announcement_url` | string | URL to the release announcement (blog post, paper, model card, release notes, etc.) |
+| `announcement_title` | string | Title of the announcement (used as link text in the UI) |
+
+`release_date` is distinct from the top-level `submission_date` (which is when the evaluation was submitted) and from `methodology.evaluation_date` (which is when the evaluation was run).
+
+If `announcement_url` is provided, `release_date` is required.
+
+Example:
+
+```json
+"model_release": {
+  "release_date": "2025-08-05",
+  "announcement_url": "https://www.anthropic.com/news/claude-opus-4-1",
+  "announcement_title": "Claude Opus 4.1"
+}
+```
 
 ### Voice Config Fields
 
@@ -468,6 +493,11 @@ Include a `verification` section in the `methodology` object:
   "model_organization": "My Company",
   "submitting_organization": "My Company",
   "submission_date": "2025-01-15",
+  "model_release": {
+    "release_date": "2025-01-10",
+    "announcement_url": "https://mycompany.example.com/blog/my-model-v1",
+    "announcement_title": "Introducing My-Model-v1.0"
+  },
   "contact_info": {
     "email": "contact@mycompany.com",
     "name": "Research Team"

--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -63,13 +63,17 @@ def parse_provider(spec: str) -> ProviderSpec:
         qualifier = parts[2]
         if provider == "livekit":
             return ProviderSpec(
-                provider=provider, model=model,
-                cascaded_config=qualifier, display_name=spec,
+                provider=provider,
+                model=model,
+                cascaded_config=qualifier,
+                display_name=spec,
             )
         else:
             return ProviderSpec(
-                provider=provider, model=model,
-                reasoning_effort=qualifier, display_name=spec,
+                provider=provider,
+                model=model,
+                reasoning_effort=qualifier,
+                display_name=spec,
             )
     else:
         raise ValueError(f"Invalid provider spec: {spec}")
@@ -87,19 +91,30 @@ def build_command(
     max_concurrency: int = 8,
 ) -> list[str]:
     cmd = [
-        "uv", "run", "tau2", "run",
-        "--domain", domain,
+        "uv",
+        "run",
+        "tau2",
+        "run",
+        "--domain",
+        domain,
         "--audio-native",
-        "--audio-native-provider", spec.provider,
-        "--audio-native-model", spec.model,
-        "--speech-complexity", complexity,
-        "--seed", str(seed),
-        "--user-llm", user_llm,
-        "--max-concurrency", str(max_concurrency),
+        "--audio-native-provider",
+        spec.provider,
+        "--audio-native-model",
+        spec.model,
+        "--speech-complexity",
+        complexity,
+        "--seed",
+        str(seed),
+        "--user-llm",
+        user_llm,
+        "--max-concurrency",
+        str(max_concurrency),
         "--verbose-logs",
         "--auto-review",
         "--auto-resume",
-        "--save-to", save_to,
+        "--save-to",
+        save_to,
     ]
     if spec.reasoning_effort is not None:
         cmd.extend(["--reasoning-effort", spec.reasoning_effort])
@@ -166,7 +181,10 @@ def main():
 
         print(f"[{i}/{total}] {run_name}")
         cmd = build_command(
-            domain, spec, complexity, save_to,
+            domain,
+            spec,
+            complexity,
+            save_to,
             num_tasks=args.num_tasks,
             seed=args.seed,
             user_llm=args.user_llm,

--- a/src/tau2/scripts/leaderboard/prepare_submission.py
+++ b/src/tau2/scripts/leaderboard/prepare_submission.py
@@ -16,6 +16,7 @@ from tau2.scripts.leaderboard.submission import (
     ContactInfo,
     DomainResults,
     Methodology,
+    ModelRelease,
     Reference,
     Results,
     Submission,
@@ -720,6 +721,49 @@ def prepare_submission(
         references.append(Reference(title=ref_title, url=ref_url, type=ref_type))
         add_reference = Confirm.ask("Add another reference?", default=False)
 
+    # Model release info (optional)
+    console.print(
+        "\n📅 Model release info (optional, used to track progress over time):",
+        style="dim",
+    )
+    model_release: Optional[ModelRelease] = None
+    release_date_str = (
+        Prompt.ask(
+            "Model public release date (YYYY-MM-DD, distinct from evaluation date)",
+            default="",
+        )
+        or None
+    )
+    release_date_value: Optional[date] = None
+    if release_date_str:
+        try:
+            release_date_value = date.fromisoformat(release_date_str)
+        except ValueError:
+            console.print(
+                "  ⚠️  Invalid release date format, skipping model_release.",
+                style="yellow",
+            )
+            release_date_value = None
+
+    if release_date_value is not None:
+        announcement_url = (
+            Prompt.ask(
+                "Announcement URL (blog post, paper, model card, etc.)",
+                default="",
+            )
+            or None
+        )
+        announcement_title = None
+        if announcement_url:
+            announcement_title = (
+                Prompt.ask("Announcement title (link text in UI)", default="") or None
+            )
+        model_release = ModelRelease(
+            release_date=release_date_value,
+            announcement_url=announcement_url,
+            announcement_title=announcement_title,
+        )
+
     # Create submission objects
     contact_info = ContactInfo(email=email, name=contact_name, github=github_username)
 
@@ -824,6 +868,7 @@ def prepare_submission(
         methodology=methodology,
         voice_config=voice_config,
         reasoning_effort=reasoning_effort,
+        model_release=model_release,
     )
 
     submission_file = submission_dir / SUBMISSION_FILE_NAME

--- a/src/tau2/scripts/leaderboard/submission.py
+++ b/src/tau2/scripts/leaderboard/submission.py
@@ -123,6 +123,40 @@ class Reference(BaseModelNoExtra):
     )
 
 
+class ModelRelease(BaseModelNoExtra):
+    """Information about when and where the model was publicly released.
+
+    This metadata is about the model itself (independent of when it was
+    evaluated on tau2-bench), and is used to track model progress over time
+    on the leaderboard.
+    """
+
+    release_date: Optional[date] = Field(
+        None,
+        description="Public release date of the model (YYYY-MM-DD). "
+        "Use the date the model was first made publicly available, not the "
+        "evaluation date.",
+    )
+    announcement_url: Optional[str] = Field(
+        None,
+        description="URL to the model's release announcement (blog post, "
+        "paper, model card, release notes, etc.).",
+    )
+    announcement_title: Optional[str] = Field(
+        None,
+        description="Title of the release announcement (used as link text in the UI).",
+    )
+
+    @model_validator(mode="after")
+    def _validate_url_has_date(self) -> "ModelRelease":
+        if self.announcement_url is not None and self.release_date is None:
+            raise ValueError(
+                "model_release.announcement_url is set but model_release.release_date "
+                "is not. Provide a release date when linking to a release announcement."
+            )
+        return self
+
+
 class Verification(BaseModelNoExtra):
     """Verification details for result authenticity."""
 
@@ -199,6 +233,11 @@ class Submission(BaseModelNoExtra):
                     "submitting_organization": "OpenAI",
                     "submission_date": "2024-01-15",
                     "submission_type": "standard",
+                    "model_release": {
+                        "release_date": "2024-01-10",
+                        "announcement_url": "https://openai.com/index/gpt-4-1/",
+                        "announcement_title": "Introducing GPT-4.1",
+                    },
                     "contact_info": {
                         "email": "researcher@openai.com",
                         "name": "Jane Doe",
@@ -290,6 +329,12 @@ class Submission(BaseModelNoExtra):
     voice_config: Optional[VoiceConfig] = Field(
         None,
         description="Voice-specific configuration for audio-native evaluations (only for voice submissions)",
+    )
+    model_release: Optional[ModelRelease] = Field(
+        None,
+        description="Public release metadata for the model itself (release date "
+        "and announcement link). Distinct from `submission_date`, which is when "
+        "the evaluation was submitted. Used to track model progress over time.",
     )
     reasoning_effort: Optional[str] = Field(
         None,

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -266,11 +266,13 @@ class TickTimer:
         sorted_t = sorted(self.timings)
         p95_idx = int(len(sorted_t) * 0.95)
         p95 = sorted_t[min(p95_idx, len(sorted_t) - 1)]
-        over = sum(1 for t in self.timings if t > TICK_DURATION_MS * TICK_DURATION_MAX_FACTOR)
+        over = sum(
+            1 for t in self.timings if t > TICK_DURATION_MS * TICK_DURATION_MAX_FACTOR
+        )
         print(
             f"\n  [{label}] {len(self.timings)} ticks: "
             f"min={min(self.timings):.0f}ms, "
-            f"avg={sum(self.timings)/len(self.timings):.0f}ms, "
+            f"avg={sum(self.timings) / len(self.timings):.0f}ms, "
             f"p95={p95:.0f}ms, max={max(self.timings):.0f}ms, "
             f"over-budget={over}"
         )
@@ -484,9 +486,7 @@ class TestSingleTurn:
         # Drain a few more ticks to let transcript arrive (may lag behind audio)
         silence = make_silence()
         for tick in range(10):
-            result = timer.run_tick(
-                connected_adapter, silence, len(results) + tick + 1
-            )
+            result = timer.run_tick(connected_adapter, silence, len(results) + tick + 1)
             results.append(result)
             assert_audio_capping(result, connected_adapter)
 

--- a/web/leaderboard/public/submissions/claude-3-7-sonnet_anthropic_2024-06-20/submission.json
+++ b/web/leaderboard/public/submissions/claude-3-7-sonnet_anthropic_2024-06-20/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available."
     }
+  },
+  "model_release": {
+    "release_date": "2025-02-24",
+    "announcement_url": "https://www.anthropic.com/news/claude-3-7-sonnet",
+    "announcement_title": "Claude 3.7 Sonnet and Claude Code"
   }
 }

--- a/web/leaderboard/public/submissions/claude-opus-4-1_anthropic_2025-01-15/submission.json
+++ b/web/leaderboard/public/submissions/claude-opus-4-1_anthropic_2025-01-15/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": null,
       "details": "Unverified submission - no trajectory data available, unknown evaluation methodology, telecom domain omitted, incomplete evaluation (Pass^1 only)"
     }
+  },
+  "model_release": {
+    "release_date": "2025-08-05",
+    "announcement_url": "https://www.anthropic.com/news/claude-opus-4-1",
+    "announcement_title": "Claude Opus 4.1"
   }
 }

--- a/web/leaderboard/public/submissions/claude-opus-4-5_sierra_2026-02-26/submission.json
+++ b/web/leaderboard/public/submissions/claude-opus-4-5_sierra_2026-02-26/submission.json
@@ -59,5 +59,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available. Standard tau-bench scaffold."
     }
+  },
+  "model_release": {
+    "release_date": "2025-11-24",
+    "announcement_url": "https://www.anthropic.com/news/claude-opus-4-5",
+    "announcement_title": "Introducing Claude Opus 4.5"
   }
 }

--- a/web/leaderboard/public/submissions/claude-opus-4_anthropic_2025-05-22/submission.json
+++ b/web/leaderboard/public/submissions/claude-opus-4_anthropic_2025-05-22/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": null,
       "details": "Unverified submission - no trajectory data available, unknown evaluation methodology, telecom domain omitted, incomplete evaluation (Pass^1 only)"
     }
+  },
+  "model_release": {
+    "release_date": "2025-05-22",
+    "announcement_url": "https://www.anthropic.com/news/claude-4",
+    "announcement_title": "Introducing Claude 4"
   }
 }

--- a/web/leaderboard/public/submissions/claude-sonnet-4-5_anthropic_2025-10-02/submission.json
+++ b/web/leaderboard/public/submissions/claude-sonnet-4-5_anthropic_2025-10-02/submission.json
@@ -46,6 +46,10 @@
       "omitted_questions": null,
       "details": "Unverified submission - no trajectory data available, unknown evaluation methodology, telecom domain omitted, incomplete evaluation (Pass^1 only)"
     }
+  },
+  "model_release": {
+    "release_date": "2025-09-29",
+    "announcement_url": "https://www.anthropic.com/news/claude-sonnet-4-5",
+    "announcement_title": "Introducing Claude Sonnet 4.5"
   }
 }
-

--- a/web/leaderboard/public/submissions/claude-sonnet-4-5_sierra_2026-02-26/submission.json
+++ b/web/leaderboard/public/submissions/claude-sonnet-4-5_sierra_2026-02-26/submission.json
@@ -59,5 +59,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available. Standard tau-bench scaffold."
     }
+  },
+  "model_release": {
+    "release_date": "2025-09-29",
+    "announcement_url": "https://www.anthropic.com/news/claude-sonnet-4-5",
+    "announcement_title": "Introducing Claude Sonnet 4.5"
   }
 }

--- a/web/leaderboard/public/submissions/claude-sonnet-4_anthropic_2025-05-22/submission.json
+++ b/web/leaderboard/public/submissions/claude-sonnet-4_anthropic_2025-05-22/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": null,
       "details": "Unverified submission - no trajectory data available, unknown evaluation methodology, telecom domain omitted, incomplete evaluation (Pass^1 only)"
     }
+  },
+  "model_release": {
+    "release_date": "2025-05-22",
+    "announcement_url": "https://www.anthropic.com/news/claude-4",
+    "announcement_title": "Introducing Claude 4"
   }
 }

--- a/web/leaderboard/public/submissions/deepseek-v3.2_deepseek_2025-12-01/submission.json
+++ b/web/leaderboard/public/submissions/deepseek-v3.2_deepseek_2025-12-01/submission.json
@@ -48,6 +48,10 @@
       "omitted_questions": null,
       "details": "Unverified submission - results from technical report, no trajectory data available, exact evaluation methodology not specified"
     }
+  },
+  "model_release": {
+    "release_date": "2025-12-01",
+    "announcement_url": "https://api-docs.deepseek.com/news/news251201",
+    "announcement_title": "DeepSeek-V3.2 Release"
   }
 }
-

--- a/web/leaderboard/public/submissions/gemini-3-1-flash-live-preview-thinking-high_google_2026-04-02/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-1-flash-live-preview-thinking-high_google_2026-04-02/submission.json
@@ -44,5 +44,10 @@
     "tick_duration_seconds": 0.2,
     "max_steps_seconds": 600.0,
     "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "model_release": {
+    "release_date": "2026-03-26",
+    "announcement_url": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-live/",
+    "announcement_title": "Gemini 3.1 Flash Live: Google's latest AI audio model"
   }
 }

--- a/web/leaderboard/public/submissions/gemini-3-1-flash-live-preview-thinking-minimal_google_2026-04-13/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-1-flash-live-preview-thinking-minimal_google_2026-04-13/submission.json
@@ -44,5 +44,10 @@
     "tick_duration_seconds": 0.2,
     "max_steps_seconds": 600.0,
     "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "model_release": {
+    "release_date": "2026-03-26",
+    "announcement_url": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-live/",
+    "announcement_title": "Gemini 3.1 Flash Live: Google's latest AI audio model"
   }
 }

--- a/web/leaderboard/public/submissions/gemini-3-flash_sierra_2026-03-02/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-flash_sierra_2026-03-02/submission.json
@@ -59,5 +59,10 @@
       "omitted_questions": false,
       "details": "Standard tau-bench scaffold."
     }
+  },
+  "model_release": {
+    "release_date": "2025-12-17",
+    "announcement_url": "https://blog.google/products/gemini/gemini-3-flash/",
+    "announcement_title": "Gemini 3 Flash: frontier intelligence built for speed"
   }
 }

--- a/web/leaderboard/public/submissions/gemini-3-pro_google_2025-11-18/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-pro_google_2025-11-18/submission.json
@@ -46,6 +46,10 @@
       "omitted_questions": false,
       "details": "Prompt adjustments made to provide instructions relevant to each environment. User model uses Gemini with system instruction."
     }
+  },
+  "model_release": {
+    "release_date": "2025-11-18",
+    "announcement_url": "https://blog.google/products/gemini/gemini-3/",
+    "announcement_title": "Gemini 3: Introducing the latest Gemini AI model from Google"
   }
 }
-

--- a/web/leaderboard/public/submissions/gemini-3-pro_sierra_2026-03-02/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-pro_sierra_2026-03-02/submission.json
@@ -59,5 +59,10 @@
       "omitted_questions": false,
       "details": "Standard tau-bench scaffold."
     }
+  },
+  "model_release": {
+    "release_date": "2025-11-18",
+    "announcement_url": "https://blog.google/products/gemini/gemini-3/",
+    "announcement_title": "Gemini 3: Introducing the latest Gemini AI model from Google"
   }
 }

--- a/web/leaderboard/public/submissions/gemini-live-2.5-flash_sierra_2026-03-03/submission.json
+++ b/web/leaderboard/public/submissions/gemini-live-2.5-flash_sierra_2026-03-03/submission.json
@@ -43,5 +43,10 @@
       "modified_prompts": false,
       "omitted_questions": false
     }
+  },
+  "model_release": {
+    "release_date": "2025-12-12",
+    "announcement_url": "https://cloud.google.com/blog/products/ai-machine-learning/gemini-live-api-available-on-vertex-ai",
+    "announcement_title": "Gemini Live API on Vertex AI"
   }
 }

--- a/web/leaderboard/public/submissions/glm-5-think_sierra_2026-03-02/submission.json
+++ b/web/leaderboard/public/submissions/glm-5-think_sierra_2026-03-02/submission.json
@@ -59,5 +59,10 @@
       "omitted_questions": false,
       "details": "Standard tau-bench scaffold."
     }
+  },
+  "model_release": {
+    "release_date": "2026-02-11",
+    "announcement_url": "https://docs.z.ai/guides/llm/glm-5",
+    "announcement_title": "GLM-5 - Overview - Z.AI Developer Document"
   }
 }

--- a/web/leaderboard/public/submissions/gpt-4-1-mini_openai_2024-06-20/submission.json
+++ b/web/leaderboard/public/submissions/gpt-4-1-mini_openai_2024-06-20/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available"
     }
+  },
+  "model_release": {
+    "release_date": "2025-04-14",
+    "announcement_url": "https://openai.com/index/gpt-4-1/",
+    "announcement_title": "Introducing GPT-4.1 in the API"
   }
 }

--- a/web/leaderboard/public/submissions/gpt-4-1_openai_2024-06-20/submission.json
+++ b/web/leaderboard/public/submissions/gpt-4-1_openai_2024-06-20/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available"
     }
+  },
+  "model_release": {
+    "release_date": "2025-04-14",
+    "announcement_url": "https://openai.com/index/gpt-4-1/",
+    "announcement_title": "Introducing GPT-4.1 in the API"
   }
 }

--- a/web/leaderboard/public/submissions/gpt-5-2-none_sierra_2026-02-26/submission.json
+++ b/web/leaderboard/public/submissions/gpt-5-2-none_sierra_2026-02-26/submission.json
@@ -59,5 +59,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available. Standard tau-bench scaffold."
     }
+  },
+  "model_release": {
+    "release_date": "2025-12-11",
+    "announcement_url": "https://openai.com/index/introducing-gpt-5-2/",
+    "announcement_title": "Introducing GPT-5.2"
   }
 }

--- a/web/leaderboard/public/submissions/gpt-5-2_sierra_2026-02-26/submission.json
+++ b/web/leaderboard/public/submissions/gpt-5-2_sierra_2026-02-26/submission.json
@@ -59,5 +59,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available. Standard tau-bench scaffold."
     }
+  },
+  "model_release": {
+    "release_date": "2025-12-11",
+    "announcement_url": "https://openai.com/index/introducing-gpt-5-2/",
+    "announcement_title": "Introducing GPT-5.2"
   }
 }

--- a/web/leaderboard/public/submissions/gpt-5-4_sierra_2026-03-25/submission.json
+++ b/web/leaderboard/public/submissions/gpt-5-4_sierra_2026-03-25/submission.json
@@ -41,5 +41,10 @@
       "omitted_questions": false,
       "details": "Full evaluation on all 97 banking_knowledge tasks with 4 trials each. Standard tau-bench scaffold."
     }
+  },
+  "model_release": {
+    "release_date": "2026-03-05",
+    "announcement_url": "https://openai.com/index/introducing-gpt-5-4/",
+    "announcement_title": "Introducing GPT-5.4"
   }
 }

--- a/web/leaderboard/public/submissions/gpt-5_sierra_2025-08-09/submission.json
+++ b/web/leaderboard/public/submissions/gpt-5_sierra_2025-08-09/submission.json
@@ -43,5 +43,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available"
     }
+  },
+  "model_release": {
+    "release_date": "2025-08-07",
+    "announcement_url": "https://openai.com/index/introducing-gpt-5-for-developers/",
+    "announcement_title": "Introducing GPT-5 for developers"
   }
 }

--- a/web/leaderboard/public/submissions/gpt-realtime-1-0_openai_2026-04-13/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-1-0_openai_2026-04-13/submission.json
@@ -42,5 +42,10 @@
     "tick_duration_seconds": 0.2,
     "max_steps_seconds": 600.0,
     "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "model_release": {
+    "release_date": "2025-08-28",
+    "announcement_url": "https://openai.com/index/introducing-gpt-realtime/",
+    "announcement_title": "Introducing gpt-realtime"
   }
 }

--- a/web/leaderboard/public/submissions/gpt-realtime-1.5_sierra_2026-03-03/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-1.5_sierra_2026-03-03/submission.json
@@ -43,5 +43,10 @@
       "modified_prompts": false,
       "omitted_questions": false
     }
+  },
+  "model_release": {
+    "release_date": "2026-02-23",
+    "announcement_url": "https://developers.openai.com/api/docs/models/gpt-realtime-1.5",
+    "announcement_title": "gpt-realtime-1.5 Model | OpenAI API"
   }
 }

--- a/web/leaderboard/public/submissions/kimi-k2_moonshot-ai_2025-07-11/submission.json
+++ b/web/leaderboard/public/submissions/kimi-k2_moonshot-ai_2025-07-11/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": null,
       "details": "Unverified submission - no trajectory data available, unknown evaluation methodology, incomplete evaluation (Pass^1 only)"
     }
+  },
+  "model_release": {
+    "release_date": "2025-07-11",
+    "announcement_url": "https://moonshotai.github.io/Kimi-K2/",
+    "announcement_title": "Kimi K2: Open Agentic Intelligence"
   }
 }

--- a/web/leaderboard/public/submissions/o3_openai_2025-01-15/submission.json
+++ b/web/leaderboard/public/submissions/o3_openai_2025-01-15/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": null,
       "details": "Unverified submission - no trajectory data available, unknown evaluation methodology, incomplete evaluation (Pass@1 only)"
     }
+  },
+  "model_release": {
+    "release_date": "2025-04-16",
+    "announcement_url": "https://openai.com/index/introducing-o3-and-o4-mini/",
+    "announcement_title": "Introducing OpenAI o3 and o4-mini"
   }
 }

--- a/web/leaderboard/public/submissions/o4-mini_openai_2024-06-20/submission.json
+++ b/web/leaderboard/public/submissions/o4-mini_openai_2024-06-20/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": false,
       "details": "Verified evaluation with full trajectory data available"
     }
+  },
+  "model_release": {
+    "release_date": "2025-04-16",
+    "announcement_url": "https://openai.com/index/introducing-o3-and-o4-mini/",
+    "announcement_title": "Introducing OpenAI o3 and o4-mini"
   }
 }

--- a/web/leaderboard/public/submissions/qwen3-max_qwen_2024_09_23/submission.json
+++ b/web/leaderboard/public/submissions/qwen3-max_qwen_2024_09_23/submission.json
@@ -46,5 +46,10 @@
       "omitted_questions": null,
       "details": "Unverified submission - no trajectory data available, unknown evaluation methodology, incomplete evaluation (Pass^1, Pass^2 and Pass^4 only)"
     }
+  },
+  "model_release": {
+    "release_date": "2025-09-23",
+    "announcement_url": "https://qwen.ai/blog?id=241398b9cd6353de490b0f82806c7848c5d2777d&from=research.latest-advancements-list",
+    "announcement_title": "Qwen3-Max: Just Scale it"
   }
 }

--- a/web/leaderboard/public/submissions/qwen3-max_qwen_2026-01-23/submission.json
+++ b/web/leaderboard/public/submissions/qwen3-max_qwen_2026-01-23/submission.json
@@ -51,5 +51,10 @@
       "omitted_questions": false,
       "details": "Complete evaluation with all standard tasks"
     }
+  },
+  "model_release": {
+    "release_date": "2026-01-23",
+    "announcement_url": "https://qwen.ai/blog?id=qwen3-max-thinking",
+    "announcement_title": "Qwen3-Max-Thinking"
   }
 }

--- a/web/leaderboard/public/submissions/qwen3.5-397b-a17b-think_sierra_2026-03-02/submission.json
+++ b/web/leaderboard/public/submissions/qwen3.5-397b-a17b-think_sierra_2026-03-02/submission.json
@@ -59,5 +59,10 @@
       "omitted_questions": false,
       "details": "Standard tau-bench scaffold. Clean 4-trial runs with no infrastructure errors across all domains."
     }
+  },
+  "model_release": {
+    "release_date": "2026-02-16",
+    "announcement_url": "https://www.alibabacloud.com/blog/qwen3-5-towards-native-multimodal-agents_602894",
+    "announcement_title": "Qwen3.5: Towards Native Multimodal Agents"
   }
 }

--- a/web/leaderboard/public/submissions/schema.json
+++ b/web/leaderboard/public/submissions/schema.json
@@ -215,6 +215,54 @@
       "title": "Methodology",
       "type": "object"
     },
+    "ModelRelease": {
+      "additionalProperties": false,
+      "description": "Information about when and where the model was publicly released.\n\nThis metadata is about the model itself (independent of when it was\nevaluated on tau2-bench), and is used to track model progress over time\non the leaderboard.",
+      "properties": {
+        "release_date": {
+          "anyOf": [
+            {
+              "format": "date",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Public release date of the model (YYYY-MM-DD). Use the date the model was first made publicly available, not the evaluation date.",
+          "title": "Release Date"
+        },
+        "announcement_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URL to the model's release announcement (blog post, paper, model card, release notes, etc.).",
+          "title": "Announcement Url"
+        },
+        "announcement_title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Title of the release announcement (used as link text in the UI).",
+          "title": "Announcement Title"
+        }
+      },
+      "title": "ModelRelease",
+      "type": "object"
+    },
     "Reference": {
       "additionalProperties": false,
       "description": "A reference link (paper, blog post, github repo, etc.).",
@@ -433,6 +481,11 @@
       },
       "model_name": "GPT-4.1",
       "model_organization": "OpenAI",
+      "model_release": {
+        "announcement_title": "Introducing GPT-4.1",
+        "announcement_url": "https://openai.com/index/gpt-4-1/",
+        "release_date": "2024-01-10"
+      },
       "results": {
         "airline": {
           "pass_1": 78.9,
@@ -582,6 +635,18 @@
       ],
       "default": null,
       "description": "Voice-specific configuration for audio-native evaluations (only for voice submissions)"
+    },
+    "model_release": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ModelRelease"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Public release metadata for the model itself (release date and announcement link). Distinct from `submission_date`, which is when the evaluation was submitted. Used to track model progress over time."
     },
     "reasoning_effort": {
       "anyOf": [

--- a/web/leaderboard/public/submissions/toolorchestra_nvidia_2025-12-02/submission.json
+++ b/web/leaderboard/public/submissions/toolorchestra_nvidia_2025-12-02/submission.json
@@ -52,5 +52,10 @@
       "url": "https://github.com/NVlabs/ToolOrchestra",
       "type": "github"
     }
-  ]
+  ],
+  "model_release": {
+    "release_date": "2025-11-26",
+    "announcement_url": "https://research.nvidia.com/labs/lpr/ToolOrchestra/",
+    "announcement_title": "ToolOrchestra"
+  }
 }

--- a/web/leaderboard/public/submissions/xai-realtime_sierra_2026-03-03/submission.json
+++ b/web/leaderboard/public/submissions/xai-realtime_sierra_2026-03-03/submission.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "xai-realtime",
+  "model_name": "grok-voice-fast-1.0",
   "model_organization": "xAI",
   "submitting_organization": "Sierra",
   "submission_date": "2026-03-03",
@@ -29,7 +29,7 @@
   },
   "voice_config": {
     "provider": "xAI",
-    "model": "xai-realtime",
+    "model": "grok-voice-fast-1.0",
     "tick_duration_seconds": 0.2,
     "max_steps_seconds": 600,
     "user_tts_provider": "elevenlabs/eleven_v3"
@@ -43,5 +43,10 @@
       "modified_prompts": false,
       "omitted_questions": false
     }
+  },
+  "model_release": {
+    "release_date": "2025-12-17",
+    "announcement_url": "https://www.ainews.com/p/xai-launches-grok-voice-agent-api-for-real-time-ai-voice-apps",
+    "announcement_title": "xAI launches Grok Voice Agent API"
   }
 }

--- a/web/leaderboard/src/components/Leaderboard.css
+++ b/web/leaderboard/src/components/Leaderboard.css
@@ -22,6 +22,85 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 }
 
+/* Title row holds the h2 and the table/progress view toggle */
+.leaderboard-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin-bottom: 32px;
+}
+
+.leaderboard-title-row .leaderboard-title {
+  margin-bottom: 0;
+}
+
+.view-toggle {
+  position: relative;
+  display: inline-flex;
+  background: #e2e8f0;
+  border-radius: 12px;
+  padding: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.view-toggle-option {
+  position: relative;
+  z-index: 2;
+  padding: 8px 18px;
+  border: none;
+  background: transparent;
+  color: #475569;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: color 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 110px;
+  justify-content: center;
+  font-family: inherit;
+}
+
+.view-toggle-option.active {
+  color: #ffffff;
+}
+
+.view-toggle-option:hover:not(.active) {
+  color: #047857;
+}
+
+.view-toggle-option:focus {
+  outline: none;
+}
+
+.view-toggle-option:focus-visible {
+  outline: 2px solid rgba(4, 120, 87, 0.55);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+.view-toggle-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.view-toggle-slider {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  bottom: 4px;
+  width: calc((100% - 8px) / 2);
+  background: linear-gradient(135deg, #065f46 0%, #047857 100%);
+  border-radius: 8px;
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow: 0 2px 6px rgba(6, 95, 70, 0.3);
+  z-index: 1;
+}
+
 .leaderboard-subtitle {
   font-size: 1.125rem;
   color: #718096;

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react'
 import './Leaderboard.css'
+import ProgressView from './ProgressView'
 
 const BENCHMARK_VALUES = new Set(['text', 'voice'])
+const VIEW_VALUES = new Set(['table', 'progress'])
 
 const getBenchmarkFromHash = () => {
   const hash = window.location.hash.slice(1)
@@ -10,6 +12,15 @@ const getBenchmarkFromHash = () => {
 
   const value = new URLSearchParams(queryString).get('benchmark')
   return BENCHMARK_VALUES.has(value) ? value : null
+}
+
+const getViewFromHash = () => {
+  const hash = window.location.hash.slice(1)
+  const [route, queryString = ''] = hash.split('?')
+  if (route !== 'leaderboard') return null
+
+  const value = new URLSearchParams(queryString).get('view')
+  return VIEW_VALUES.has(value) ? value : null
 }
 
 const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
@@ -25,6 +36,13 @@ const Leaderboard = () => {
 
     const fromStorage = localStorage.getItem('benchmark')
     return BENCHMARK_VALUES.has(fromStorage) ? fromStorage : 'text'
+  })
+  // Sub-view selector: 'table' (ranked list) or 'progress' (release-date chart)
+  const [viewMode, setViewMode] = useState(() => {
+    const fromHash = getViewFromHash()
+    if (fromHash) return fromHash
+    const stored = localStorage.getItem('leaderboardView')
+    return VIEW_VALUES.has(stored) ? stored : 'table'
   })
   // Add unified domain selection state with localStorage persistence
   const [domain, setDomain] = useState(() => {
@@ -182,6 +200,7 @@ const Leaderboard = () => {
             },
             isLegacy,
             organization: submission.submitting_organization,
+            modelOrganization: submission.model_organization,
             reasoningEffort: submission.reasoning_effort || null,
             userSimulator: submission.methodology?.user_simulator || null,
             bankingRetrievalConfig: submission.results.banking_knowledge?.retrieval_config || null,
@@ -243,7 +262,8 @@ const Leaderboard = () => {
     localStorage.setItem('benchmark', benchmark)
   }, [benchmark])
 
-  // Keep benchmark in URL for shareable deep links, e.g. #leaderboard?benchmark=voice
+  // Keep benchmark + view in URL for shareable deep links, e.g.
+  // #leaderboard?benchmark=voice&view=progress
   useEffect(() => {
     if (!window.location.hash.startsWith('#leaderboard')) return
 
@@ -251,29 +271,38 @@ const Leaderboard = () => {
     const [route, queryString = ''] = hash.split('?')
     const params = new URLSearchParams(queryString)
     params.set('benchmark', benchmark)
+    params.set('view', viewMode)
 
     const nextHash = `${route}?${params.toString()}`
     if (hash !== nextHash) {
       window.history.replaceState(null, '', `#${nextHash}`)
     }
-  }, [benchmark])
+  }, [benchmark, viewMode])
 
   // React to manual hash edits or browser navigation events.
   useEffect(() => {
-    const syncBenchmarkFromHash = () => {
-      const fromHash = getBenchmarkFromHash()
-      if (fromHash) {
-        setBenchmark(prev => (prev === fromHash ? prev : fromHash))
+    const syncFromHash = () => {
+      const benchmarkFromHash = getBenchmarkFromHash()
+      if (benchmarkFromHash) {
+        setBenchmark(prev => (prev === benchmarkFromHash ? prev : benchmarkFromHash))
+      }
+      const viewFromHash = getViewFromHash()
+      if (viewFromHash) {
+        setViewMode(prev => (prev === viewFromHash ? prev : viewFromHash))
       }
     }
 
-    window.addEventListener('hashchange', syncBenchmarkFromHash)
-    window.addEventListener('popstate', syncBenchmarkFromHash)
+    window.addEventListener('hashchange', syncFromHash)
+    window.addEventListener('popstate', syncFromHash)
     return () => {
-      window.removeEventListener('hashchange', syncBenchmarkFromHash)
-      window.removeEventListener('popstate', syncBenchmarkFromHash)
+      window.removeEventListener('hashchange', syncFromHash)
+      window.removeEventListener('popstate', syncFromHash)
     }
   }, [])
+
+  useEffect(() => {
+    localStorage.setItem('leaderboardView', viewMode)
+  }, [viewMode])
 
   useEffect(() => {
     localStorage.setItem('domain', domain)
@@ -449,9 +478,35 @@ const Leaderboard = () => {
         </div>
       </div>
 
-      <h2 className="leaderboard-title">{isVoice ? 'τ-voice Leaderboard' : 'τ-bench Leaderboard'}</h2>
+      <div className="leaderboard-title-row">
+        <h2 className="leaderboard-title">{isVoice ? 'τ-voice Leaderboard' : 'τ-bench Leaderboard'}</h2>
+        <div className="view-toggle" role="tablist" aria-label="Leaderboard view">
+          <button
+            role="tab"
+            aria-selected={viewMode === 'table'}
+            className={`view-toggle-option ${viewMode === 'table' ? 'active' : ''}`}
+            onClick={() => setViewMode('table')}
+            title="Ranked list"
+          >
+            <span className="view-toggle-icon">≡</span> Ranking
+          </button>
+          <button
+            role="tab"
+            aria-selected={viewMode === 'progress'}
+            className={`view-toggle-option ${viewMode === 'progress' ? 'active' : ''}`}
+            onClick={() => setViewMode('progress')}
+            title="Progress over time"
+          >
+            <span className="view-toggle-icon">📈</span> Progress
+          </button>
+          <div
+            className="view-toggle-slider"
+            style={{ transform: viewMode === 'table' ? 'translateX(0%)' : 'translateX(100%)' }}
+          />
+        </div>
+      </div>
 
-      {/* Combined Controls Row */}
+      {/* Combined Controls Row — applies to both ranking and progress views */}
       <div className="leaderboard-controls">
         {/* Domain Toggle Switch */}
         <div className="domain-toggle-switch">
@@ -538,6 +593,19 @@ const Leaderboard = () => {
         </div>
       </div>
 
+      {viewMode === 'progress' ? (
+        <ProgressView
+          passKData={passKData}
+          fullSubmissionData={fullSubmissionData}
+          benchmark={benchmark}
+          domain={domain}
+          showStandard={showStandard}
+          showCustom={showCustom}
+          showLegacy={showLegacy}
+          baseUrl={import.meta.env.BASE_URL}
+        />
+      ) : (
+      <>
       {/* Table View */}
       {(!showStandard && !showCustom && (isVoice || !showLegacy)) ? (
           <div className="filter-empty-state">
@@ -907,6 +975,8 @@ const Leaderboard = () => {
         )}
         </div>
         )}
+      </>
+      )}
 
       {/* Submissions Notice */}
       <div className="submissions-notice">
@@ -955,6 +1025,31 @@ const Leaderboard = () => {
                   <tr><td>Submission Date</td><td>{selectedSubmission.submission_date}</td></tr>
                   <tr><td>Type</td><td>{selectedSubmission.submission_type || 'standard'}</td></tr>
                   <tr><td>Modality</td><td>{selectedSubmission.modality || 'text'}</td></tr>
+
+                  {/* Model Release */}
+                  {selectedSubmission.model_release && (
+                    <>
+                      <tr className="sd-section-header"><td colSpan="2">MODEL RELEASE</td></tr>
+                      {selectedSubmission.model_release.release_date && (
+                        <tr><td>Release Date</td><td>{selectedSubmission.model_release.release_date}</td></tr>
+                      )}
+                      {selectedSubmission.model_release.announcement_url && (
+                        <tr>
+                          <td>Announcement</td>
+                          <td>
+                            <a
+                              href={selectedSubmission.model_release.announcement_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="sd-link"
+                            >
+                              {selectedSubmission.model_release.announcement_title || selectedSubmission.model_release.announcement_url}
+                            </a>
+                          </td>
+                        </tr>
+                      )}
+                    </>
+                  )}
 
                   {/* Contact */}
                   <tr className="sd-section-header"><td colSpan="2">CONTACT</td></tr>

--- a/web/leaderboard/src/components/ProgressView.css
+++ b/web/leaderboard/src/components/ProgressView.css
@@ -1,0 +1,169 @@
+/* Progress view (leaderboard sub-view) */
+
+.progress-view {
+  width: 100%;
+  margin-top: 8px;
+}
+
+.progress-empty {
+  text-align: center;
+  padding: 60px 24px;
+  color: #718096;
+  font-size: 15px;
+}
+
+/* Card around the chart */
+.progress-card {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 20px 22px 16px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.progress-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding: 0 4px;
+}
+
+.progress-card-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #2d3748;
+}
+
+.progress-card-sub {
+  font-size: 13px;
+  color: #718096;
+  margin-top: 2px;
+  max-width: 720px;
+  line-height: 1.5;
+}
+
+.progress-card-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Reuse the shared .checkbox-container styling with a tighter footprint,
+   since this lives in a card header rather than the main filter row. */
+.progress-toggle.checkbox-container {
+  padding: 4px 8px;
+  gap: 6px;
+}
+
+.progress-toggle .checkbox-checkmark {
+  height: 16px;
+  width: 16px;
+  border-width: 1.5px;
+  border-radius: 4px;
+}
+
+.progress-toggle .checkbox-checkmark:after {
+  width: 4px;
+  height: 8px;
+  border-width: 0 1.5px 1.5px 0;
+}
+
+.progress-toggle .checkbox-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: #475569;
+}
+
+/* SVG */
+.progress-svg-wrap {
+  width: 100%;
+  overflow: hidden;
+}
+
+.progress-svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+}
+
+.progress-dot.hover circle:first-of-type {
+  stroke: #047857;
+  stroke-width: 2;
+}
+
+.progress-label {
+  pointer-events: none;
+}
+
+/* Legend */
+.progress-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 18px;
+  align-items: center;
+  font-size: 12px;
+  color: #4a5568;
+  margin-top: 12px;
+  padding: 0 4px;
+}
+
+.progress-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.progress-legend-logo {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+}
+
+.progress-legend-logo img {
+  width: 12px;
+  height: 12px;
+  object-fit: contain;
+}
+
+.progress-legend-line {
+  display: inline-block;
+  width: 22px;
+  height: 0;
+  border-top: 2.5px dashed #047857;
+}
+
+.progress-footnote {
+  font-size: 11.5px;
+  color: #718096;
+  margin-top: 10px;
+  padding: 0 4px;
+  line-height: 1.55;
+}
+
+.progress-footnote code {
+  background: #f1f5f9;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 0.95em;
+  color: #475569;
+}
+
+@media (max-width: 720px) {
+  .progress-card-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .progress-card-sub {
+    max-width: 100%;
+  }
+}

--- a/web/leaderboard/src/components/ProgressView.jsx
+++ b/web/leaderboard/src/components/ProgressView.jsx
@@ -1,0 +1,619 @@
+import React, { useMemo, useState } from 'react'
+import './ProgressView.css'
+
+const ORG_LOGOS = {
+  'Anthropic': 'claude.png',
+  'OpenAI': 'openai.svg',
+  'Google': 'Google__G__logo.svg.png',
+  'xAI': 'xai-logo.svg',
+  'DeepSeek': 'DeepSeek_logo_icon.png',
+  'Qwen': 'qwen-color.png',
+  'Alibaba Cloud': 'qwen-color.png',
+  'NVIDIA': 'Logo-nvidia-transparent-PNG.png',
+  'Moonshot AI': null, // emoji fallback
+}
+
+const ORG_TINT = {
+  'OpenAI': '#10A37F',
+  'Anthropic': '#C26B43',
+  'Google': '#4285F4',
+  'xAI': '#111111',
+  'DeepSeek': '#4D6BFE',
+  'Qwen': '#615CED',
+  'Alibaba Cloud': '#615CED',
+  'NVIDIA': '#76B900',
+  'Moonshot AI': '#000000',
+  'Zhipu AI': '#3268FB',
+  'Distyl AI': '#7C3AED',
+}
+
+const ORG_EMOJI = {
+  'Moonshot AI': '🚀',
+  'Zhipu AI': '🧠',
+  'Distyl AI': '◆',
+}
+
+const formatMonth = (d) => d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+const formatDate = (d) => d.toISOString().slice(0, 10)
+
+/**
+ * Compute the score the chart should plot for a given model+domain pair.
+ * For 'overall', match the leaderboard table semantics: average pass_1 across
+ * all available core domains for the benchmark, but only when every core
+ * domain has data. For a specific domain, just use that domain's pass_1.
+ */
+const computeScore = (model, domain, benchmark) => {
+  if (domain === 'overall') {
+    const overallDomains = benchmark === 'voice'
+      ? ['retail', 'airline', 'telecom']
+      : ['retail', 'airline', 'telecom', 'banking_knowledge']
+    const vals = overallDomains
+      .map((d) => model[d]?.[0])
+      .filter((v) => v !== null && v !== undefined)
+    if (vals.length !== overallDomains.length) return null
+    return vals.reduce((a, b) => a + b, 0) / vals.length
+  }
+  const v = model[domain]?.[0]
+  return v === null || v === undefined ? null : v
+}
+
+/**
+ * Pull a "release date" for each entry from model_release.release_date when
+ * available, otherwise fall back to methodology.evaluation_date or
+ * submission_date and tag the entry as "eval" so we can render it differently.
+ *
+ * Filters mirror the leaderboard table: benchmark modality, submission type
+ * (standard/custom), and legacy toggle. When the same model_name appears more
+ * than once (e.g. a model has both a legacy and a current submission), the
+ * higher-scoring entry wins.
+ */
+const extractEntries = (
+  passKData,
+  fullSubmissionData,
+  benchmark,
+  domain,
+  { showStandard, showCustom, showLegacy }
+) => {
+  const passesFilters = (model) => {
+    if (model.modality !== benchmark) return false
+    if (model.isLegacy && !showLegacy) return false
+    const isStandard = model.submissionType === 'standard' || !model.submissionType
+    const isCustom = model.submissionType === 'custom'
+    if (isStandard && !showStandard) return false
+    if (isCustom && !showCustom) return false
+    return true
+  }
+
+  const bestByModel = new Map()
+  for (const [key, model] of Object.entries(passKData)) {
+    if (!passesFilters(model)) continue
+    const score = computeScore(model, domain, benchmark)
+    if (score === null) continue
+    const sub = fullSubmissionData[key] || {}
+    const modelName = sub.model_name || model.modelName
+    const prev = bestByModel.get(modelName)
+    if (!prev || score > prev.score) {
+      bestByModel.set(modelName, { key, score })
+    }
+  }
+
+  const entries = []
+  for (const [key, model] of Object.entries(passKData)) {
+    if (!passesFilters(model)) continue
+    const score = computeScore(model, domain, benchmark)
+    if (score === null) continue
+    const sub = fullSubmissionData[key] || {}
+    const modelName = sub.model_name || model.modelName
+    if (bestByModel.get(modelName)?.key !== key) continue
+    const release = sub.model_release || null
+    const releaseDate = release?.release_date || null
+    const evalDate = sub.methodology?.evaluation_date || sub.submission_date || null
+    const dateStr = releaseDate || evalDate
+    if (!dateStr) continue
+    entries.push({
+      key,
+      modelName,
+      modelOrganization: sub.model_organization || model.organization,
+      submittingOrganization: sub.submitting_organization || model.organization,
+      submissionType: model.submissionType,
+      isLegacy: model.isLegacy,
+      score,
+      date: new Date(dateStr + 'T00:00:00Z'),
+      hasReleaseDate: !!releaseDate,
+      announcementUrl: release?.announcement_url || null,
+      announcementTitle: release?.announcement_title || null,
+    })
+  }
+  entries.sort((a, b) => a.date - b.date)
+  return entries
+}
+
+const computeFrontier = (entries) => {
+  const frontierKeys = new Set()
+  let running = -Infinity
+  for (const e of entries) {
+    if (e.score > running) {
+      running = e.score
+      frontierKeys.add(e.key)
+    }
+  }
+  return frontierKeys
+}
+
+const DOMAIN_LABEL = {
+  overall: 'Overall',
+  retail: 'Retail',
+  airline: 'Airline',
+  telecom: 'Telecom',
+  banking_knowledge: 'Banking',
+}
+
+const ProgressView = ({
+  passKData,
+  fullSubmissionData,
+  benchmark,
+  domain,
+  showStandard,
+  showCustom,
+  showLegacy,
+  baseUrl,
+}) => {
+  const [hoverKey, setHoverKey] = useState(null)
+  const [showAllLabels, setShowAllLabels] = useState(false)
+
+  const entries = useMemo(
+    () => extractEntries(passKData, fullSubmissionData, benchmark, domain, {
+      showStandard, showCustom, showLegacy,
+    }),
+    [passKData, fullSubmissionData, benchmark, domain, showStandard, showCustom, showLegacy]
+  )
+  const frontierKeys = useMemo(() => computeFrontier(entries), [entries])
+
+  const benchmarkLabel = benchmark === 'voice' ? 'τ-voice' : 'τ-bench'
+  const domainLabel = DOMAIN_LABEL[domain] || domain
+
+  if (entries.length === 0) {
+    return (
+      <div className="progress-empty">
+        <p>
+          No submissions match the current filters for {benchmarkLabel} ·{' '}
+          {domainLabel.toLowerCase()}.
+          {!showStandard && !showCustom && ' Enable Standard or Custom to see results.'}
+        </p>
+      </div>
+    )
+  }
+
+  // SVG layout
+  const W = 1080
+  const H = 560
+  const marginTop = 56
+  const marginBottom = 80
+  const marginLeft = 64
+  const marginRight = 32
+  const plotX0 = marginLeft
+  const plotX1 = W - marginRight
+  const plotY0 = marginTop
+  const plotY1 = H - marginBottom
+  const plotW = plotX1 - plotX0
+  const plotH = plotY1 - plotY0
+
+  const yMax = 100
+
+  const minDate = entries[0].date
+  const maxDate = entries[entries.length - 1].date
+  const axisStart = new Date(Date.UTC(minDate.getUTCFullYear(), minDate.getUTCMonth(), 1))
+  const axisEnd = new Date(Date.UTC(maxDate.getUTCFullYear(), maxDate.getUTCMonth() + 1, 1))
+  const totalDays = Math.max(1, (axisEnd - axisStart) / (1000 * 60 * 60 * 24))
+
+  const xOf = (d) => plotX0 + ((d - axisStart) / (1000 * 60 * 60 * 24) / totalDays) * plotW
+  const yOf = (v) => plotY1 - (v / yMax) * plotH
+
+  // Compute positions; nudge same-date points
+  const positioned = entries.map((e) => ({ ...e, x: xOf(e.date), y: yOf(e.score) }))
+  const dateGroups = {}
+  for (const p of positioned) {
+    const k = p.date.toISOString().slice(0, 10)
+    ;(dateGroups[k] ||= []).push(p)
+  }
+  for (const grp of Object.values(dateGroups)) {
+    if (grp.length > 1) {
+      const span = 14
+      const step = (span * 2) / (grp.length - 1)
+      grp.forEach((p, i) => {
+        p.x += -span + i * step
+      })
+    }
+  }
+
+  // Frontier line points (only running-max entries)
+  const frontierPts = positioned.filter((p) => frontierKeys.has(p.key))
+  // Step path: rise vertically at each new point's x, then horizontal to next
+  let frontierPath = ''
+  if (frontierPts.length > 0) {
+    frontierPath = `M ${frontierPts[0].x.toFixed(1)} ${frontierPts[0].y.toFixed(1)}`
+    for (let i = 1; i < frontierPts.length; i++) {
+      const prev = frontierPts[i - 1]
+      const cur = frontierPts[i]
+      frontierPath += ` L ${cur.x.toFixed(1)} ${prev.y.toFixed(1)} L ${cur.x.toFixed(1)} ${cur.y.toFixed(1)}`
+    }
+    // Extend horizontally to right edge
+    frontierPath += ` L ${plotX1.toFixed(1)} ${frontierPts[frontierPts.length - 1].y.toFixed(1)}`
+  }
+
+  // Filled area under the frontier
+  let areaPath = ''
+  if (frontierPts.length > 0) {
+    areaPath = `M ${frontierPts[0].x.toFixed(1)} ${plotY1.toFixed(1)}`
+    areaPath += ` L ${frontierPts[0].x.toFixed(1)} ${frontierPts[0].y.toFixed(1)}`
+    for (let i = 1; i < frontierPts.length; i++) {
+      const prev = frontierPts[i - 1]
+      const cur = frontierPts[i]
+      areaPath += ` L ${cur.x.toFixed(1)} ${prev.y.toFixed(1)} L ${cur.x.toFixed(1)} ${cur.y.toFixed(1)}`
+    }
+    areaPath += ` L ${plotX1.toFixed(1)} ${frontierPts[frontierPts.length - 1].y.toFixed(1)}`
+    areaPath += ` L ${plotX1.toFixed(1)} ${plotY1.toFixed(1)} Z`
+  }
+
+  // Y gridlines every 10%
+  const yTicks = []
+  for (let v = 0; v <= yMax; v += 10) yTicks.push(v)
+
+  // X tick months (sample at most ~10 to avoid clutter)
+  const allMonths = []
+  let cur = new Date(axisStart)
+  while (cur <= axisEnd) {
+    allMonths.push(new Date(cur))
+    cur = new Date(Date.UTC(cur.getUTCFullYear(), cur.getUTCMonth() + 1, 1))
+  }
+  const monthStride = Math.max(1, Math.ceil(allMonths.length / 12))
+  const xTicks = allMonths.filter((_, i) => i % monthStride === 0)
+
+  // Label decision: show all if toggled, otherwise frontier-only
+  const labeledKeys = showAllLabels
+    ? new Set(positioned.map((p) => p.key))
+    : frontierKeys
+
+  // Auto-pick anchor based on x position so labels never overflow horizontally.
+  const pickAnchor = (x) => {
+    if (x < plotX0 + 80) return 'start'
+    if (x > plotX1 - 80) return 'end'
+    return 'middle'
+  }
+  const labelOffsets = {}
+  const frontierByX = [...frontierPts].sort((a, b) => a.x - b.x)
+  frontierByX.forEach((p, i) => {
+    labelOffsets[p.key] = { dy: i % 2 === 0 ? -34 : 38, anchor: pickAnchor(p.x), dx: 0 }
+  })
+  if (showAllLabels) {
+    positioned.forEach((p, i) => {
+      if (!labelOffsets[p.key]) {
+        labelOffsets[p.key] = { dy: i % 2 === 0 ? -28 : 30, anchor: pickAnchor(p.x), dx: 0 }
+      }
+    })
+  }
+
+  const dotR = benchmark === 'voice' ? 16 : 13
+  const logoSize = benchmark === 'voice' ? 20 : 16
+
+  const renderLogo = (org, cx, cy) => {
+    const file = ORG_LOGOS[org]
+    if (file) {
+      return (
+        <image
+          href={`${baseUrl}${file}`}
+          x={cx - logoSize / 2}
+          y={cy - logoSize / 2}
+          width={logoSize}
+          height={logoSize}
+          preserveAspectRatio="xMidYMid meet"
+        />
+      )
+    }
+    const emoji = ORG_EMOJI[org] || org?.[0] || '?'
+    return (
+      <text
+        x={cx}
+        y={cy + logoSize / 3}
+        textAnchor="middle"
+        fontSize={logoSize - 2}
+        fontWeight="700"
+        fill={ORG_TINT[org] || '#1f2937'}
+      >
+        {emoji}
+      </text>
+    )
+  }
+
+  const subTitle = `Pass@1 on ${benchmarkLabel} · ${domainLabel.toLowerCase()} ` +
+    `· plotted at each model's public release date. ${entries.length} model${entries.length === 1 ? '' : 's'}.`
+
+  return (
+    <div className="progress-view">
+      <div className="progress-card">
+        <div className="progress-card-head">
+          <div>
+            <div className="progress-card-title">{benchmarkLabel} {domainLabel} pass@1 by release date</div>
+            <div className="progress-card-sub">{subTitle}</div>
+          </div>
+          <div className="progress-card-controls">
+            <label className="checkbox-container progress-toggle">
+              <input
+                type="checkbox"
+                checked={showAllLabels}
+                onChange={(e) => setShowAllLabels(e.target.checked)}
+              />
+              <span className="checkbox-checkmark"></span>
+              <span className="checkbox-label">Label every model</span>
+            </label>
+          </div>
+        </div>
+
+        <div className="progress-svg-wrap">
+          <svg
+            viewBox={`0 0 ${W} ${H}`}
+            xmlns="http://www.w3.org/2000/svg"
+            role="img"
+            aria-label={`${benchmarkLabel} progress over time`}
+            className="progress-svg"
+          >
+            <defs>
+              <linearGradient id="progress-frontier-fill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#047857" stopOpacity="0.28" />
+                <stop offset="100%" stopColor="#047857" stopOpacity="0.02" />
+              </linearGradient>
+              <filter id="progress-dot-shadow" x="-50%" y="-50%" width="200%" height="200%">
+                <feGaussianBlur in="SourceAlpha" stdDeviation="2" />
+                <feOffset dx="0" dy="1" />
+                <feComponentTransfer>
+                  <feFuncA type="linear" slope="0.25" />
+                </feComponentTransfer>
+                <feMerge>
+                  <feMergeNode />
+                  <feMergeNode in="SourceGraphic" />
+                </feMerge>
+              </filter>
+            </defs>
+
+            {/* plot bg */}
+            <rect
+              x={plotX0}
+              y={plotY0}
+              width={plotW}
+              height={plotH}
+              fill="#ffffff"
+              stroke="#e2e8f0"
+              strokeWidth="1"
+              rx="8"
+            />
+
+            {/* y gridlines + labels */}
+            {yTicks.map((v) => (
+              <g key={`y-${v}`}>
+                <line
+                  x1={plotX0}
+                  y1={yOf(v)}
+                  x2={plotX1}
+                  y2={yOf(v)}
+                  stroke="#eef2f7"
+                  strokeWidth="1"
+                />
+                <text
+                  x={plotX0 - 10}
+                  y={yOf(v) + 4}
+                  textAnchor="end"
+                  fontSize="11"
+                  fill="#64748b"
+                >
+                  {v}%
+                </text>
+              </g>
+            ))}
+
+            {/* y axis title */}
+            <text
+              x={plotX0 - 44}
+              y={(plotY0 + plotY1) / 2}
+              transform={`rotate(-90 ${plotX0 - 44} ${(plotY0 + plotY1) / 2})`}
+              textAnchor="middle"
+              fontSize="11"
+              fill="#475569"
+              fontWeight="600"
+              letterSpacing="0.08em"
+            >
+              {domainLabel.toUpperCase()} PASS@1
+            </text>
+
+            {/* x ticks (months) */}
+            {xTicks.map((m, i) => {
+              const xx = xOf(m)
+              return (
+                <g key={`x-${i}`}>
+                  <line
+                    x1={xx}
+                    y1={plotY1}
+                    x2={xx}
+                    y2={plotY1 + 5}
+                    stroke="#cbd5e1"
+                    strokeWidth="1"
+                  />
+                  <text
+                    x={xx}
+                    y={plotY1 + 20}
+                    textAnchor="middle"
+                    fontSize="11"
+                    fill="#64748b"
+                  >
+                    {formatMonth(m)}
+                  </text>
+                </g>
+              )
+            })}
+
+            {/* frontier */}
+            {areaPath && <path d={areaPath} fill="url(#progress-frontier-fill)" />}
+            {frontierPath && (
+              <path
+                d={frontierPath}
+                fill="none"
+                stroke="#047857"
+                strokeWidth="2.5"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                strokeDasharray="6,4"
+              />
+            )}
+
+            {/* dots */}
+            {positioned.map((p) => {
+              const isFrontier = frontierKeys.has(p.key)
+              const tint = ORG_TINT[p.modelOrganization] || '#888'
+              const isHover = hoverKey === p.key
+              return (
+                <g
+                  key={p.key}
+                  className={`progress-dot${isFrontier ? ' frontier' : ''}${isHover ? ' hover' : ''}`}
+                  onMouseEnter={() => setHoverKey(p.key)}
+                  onMouseLeave={() => setHoverKey(null)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <circle
+                    cx={p.x}
+                    cy={p.y}
+                    r={dotR}
+                    fill="#ffffff"
+                    stroke="#e2e8f0"
+                    strokeWidth="1.5"
+                    filter="url(#progress-dot-shadow)"
+                  />
+                  <circle
+                    cx={p.x}
+                    cy={p.y}
+                    r={dotR - 2}
+                    fill="none"
+                    stroke={tint}
+                    strokeWidth="1.5"
+                    strokeDasharray={p.hasReleaseDate ? undefined : '3,2'}
+                    opacity={isFrontier ? 0.9 : 0.45}
+                  />
+                  {renderLogo(p.modelOrganization, p.x, p.y)}
+                  <title>
+                    {p.modelName} ({p.modelOrganization}) · {formatDate(p.date)}
+                    {p.hasReleaseDate ? '' : ' (eval date)'} · {p.score.toFixed(1)}% {domainLabel.toLowerCase()}
+                  </title>
+                </g>
+              )
+            })}
+
+            {/* labels */}
+            {positioned
+              .filter((p) => labeledKeys.has(p.key) || hoverKey === p.key)
+              .map((p) => {
+                const off = labelOffsets[p.key] || { dy: -34, anchor: 'middle', dx: 0 }
+                const lx = p.x + (off.dx || 0)
+                const ly = p.y + off.dy
+                const isFrontier = frontierKeys.has(p.key)
+                const isHover = hoverKey === p.key
+
+                // Approximate text widths (avg glyph ~ 0.58em for our fonts)
+                const scoreStr = `${p.score.toFixed(1)}%`
+                const nameW = p.modelName.length * 12 * 0.58
+                const scoreW = scoreStr.length * 11 * 0.58
+                const textW = Math.max(nameW, scoreW)
+                const padX = 6
+                const rectW = textW + padX * 2
+                const padTop = 11
+                const padBottom = 7
+                // model name baseline at ly, score baseline at ly+14
+                const rectH = padTop + 14 + padBottom
+
+                let rectX
+                if (off.anchor === 'start') rectX = lx - padX
+                else if (off.anchor === 'end') rectX = lx - rectW + padX
+                else rectX = lx - rectW / 2
+                const rectY = ly - padTop
+
+                return (
+                  <g key={`label-${p.key}`} className="progress-label">
+                    {isHover && (
+                      <rect
+                        x={rectX}
+                        y={rectY}
+                        width={rectW}
+                        height={rectH}
+                        fill="white"
+                        fillOpacity={0.95}
+                        stroke="#e2e8f0"
+                        rx="4"
+                      />
+                    )}
+                    {/* Halo: render the same text twice with a thick white
+                        stroke underneath the fill so labels stay legible on
+                        top of gridlines and the frontier line/fill. */}
+                    <text
+                      x={lx}
+                      y={ly}
+                      textAnchor={off.anchor}
+                      fontSize="12"
+                      fontWeight={isFrontier ? 700 : 600}
+                      fill="#0f172a"
+                      stroke="#ffffff"
+                      strokeWidth="3.5"
+                      strokeLinejoin="round"
+                      paintOrder="stroke"
+                    >
+                      {p.modelName}
+                    </text>
+                    <text
+                      x={lx}
+                      y={ly + 14}
+                      textAnchor={off.anchor}
+                      fontSize="11"
+                      fontWeight={isFrontier ? 700 : 500}
+                      fill={isFrontier ? '#047857' : '#334155'}
+                      stroke="#ffffff"
+                      strokeWidth="3"
+                      strokeLinejoin="round"
+                      paintOrder="stroke"
+                    >
+                      {scoreStr}
+                    </text>
+                  </g>
+                )
+              })}
+          </svg>
+        </div>
+
+        <div className="progress-legend">
+          {Array.from(new Set(positioned.map((p) => p.modelOrganization))).map((org) => (
+            <span className="progress-legend-item" key={org}>
+              <span className="progress-legend-logo">
+                {ORG_LOGOS[org] ? (
+                  <img src={`${baseUrl}${ORG_LOGOS[org]}`} alt={org} />
+                ) : (
+                  <span style={{ color: ORG_TINT[org] || '#1f2937' }}>
+                    {ORG_EMOJI[org] || org?.[0] || '?'}
+                  </span>
+                )}
+              </span>
+              {org}
+            </span>
+          ))}
+          <span className="progress-legend-item progress-legend-frontier">
+            <span className="progress-legend-line" />
+            Frontier (best so far)
+          </span>
+        </div>
+
+        <div className="progress-footnote">
+          Markers show each model's overall pass@1 plotted at its public release date.
+          Hover any marker for details. The dashed line tracks the running best.
+          Submissions without a published <code>model_release.release_date</code> fall back
+          to the evaluation date.
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProgressView


### PR DESCRIPTION
## Summary

- Adds a new **Progress View** to the leaderboard web app (`ProgressView.jsx` / `ProgressView.css`) and wires it into `Leaderboard.jsx`, giving a new way to visualize model progress across submissions over time.
- Introduces a submissions `schema.json` and updates existing submission JSON files to conform to it; adds leaderboard submission helpers under `src/tau2/scripts/leaderboard/` (`prepare_submission.py`, `submission.py`) and documents the submission flow in `docs/leaderboard-submission.md`.
- Minor supporting changes: small tweaks to `src/tau2/config.py`, `src/experiments/tau_voice/run_multiple.py`, and `tests/test_voice/test_audio_native/test_provider_suite.py`.

## Test plan

- [ ] `make check-all` passes
- [ ] `make test` passes
- [ ] Build the leaderboard web app locally and verify the Progress View renders and the existing Leaderboard view still works
- [ ] Spot-check a few `submission.json` files against `schema.json`


Made with [Cursor](https://cursor.com)