### PR TITLE
Add GPT-4.1 retail submission (10 Academy, tau2-bench v1.0.0)

### DIFF
--- a/web/leaderboard/public/submissions/gpt-4-1_openai_2026-04-24/submission.json
+++ b/web/leaderboard/public/submissions/gpt-4-1_openai_2026-04-24/submission.json
@@ -1,0 +1,41 @@
+{
+  "model_name": "GPT-4.1",
+  "model_organization": "OpenAI",
+  "submitting_organization": "10 Academy",
+  "submission_date": "2026-04-24",
+  "submission_type": "standard",
+  "contact_info": {
+    "email": "kirubel@10academy.org",
+    "name": "Kirubel Tewodros",
+    "github": "78gk"
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "retail": "gpt-4-1_retail_gpt-4.1-usersim_1trial.json"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 83.33,
+      "cost": 0.0207
+    }
+  },
+  "references": [
+    {
+      "title": "The Conversion Engine — Automated Lead Generation Agent (source code)",
+      "url": "https://github.com/78gk/The-Conversion-Engine",
+      "type": "github"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-04-24",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "openai/gpt-4.1",
+    "notes": "Retail-domain evaluation of GPT-4.1 using τ²-bench v1.0.0 (includes 75+ task quality fixes from the SABER analysis). Agent and user simulator both use GPT-4.1 at temperature=0. API access via OpenRouter (openrouter/openai/gpt-4.1) routed to OpenAI — model behavior is identical to direct OpenAI API access. 1 trial, 30 tasks, 0 infrastructure errors. 25/30 tasks passed. Run as part of a week-long AI agent capstone at 10 Academy (The Conversion Engine project). Note: single-trial CI is wide [0.700, 0.967]; the higher pass@1 vs. the Sierra v0.1.3 result (74.0%) is consistent with the task quality improvements in v1.0.0 and single-trial variance.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard τ²-bench retail policy and tool set used without modification. All 30 retail tasks evaluated."
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -1,5 +1,6 @@
 {
   "submissions": [
+    "gpt-4-1_openai_2026-04-24",
     "claude-opus-4-5_sierra_2026-02-26",
     "claude-sonnet-4-5_sierra_2026-02-26",
     "gpt-5-2_sierra_2026-02-26",


### PR DESCRIPTION
## GPT-4.1 retail evaluation — tau2-bench v1.0.0 (10 Academy)

**Model:** GPT-4.1 (OpenAI)  
**Submitter:** Kirubel Tewodros / 10 Academy  
**Domain:** retail  
**Result:** pass@1 = 83.33% (25/30 tasks, 1 trial, 0 infra errors)  
**Benchmark version:** tau2-bench v1.0.0

**Trajectory file (external):**  
https://huggingface.co/datasets/kirutew17654321/tau2bench-gpt41-retail/resolve/main/gpt-4-1_retail_gpt-4.1-usersim_1trial.json

**Notes:**
- Standard tau2-bench retail policy and tool set, no prompt modifications
- GPT-4.1 accessed via OpenRouter proxy (identical model behavior)
- Single trial; 95% CI [0.700, 0.967]
- Higher pass@1 vs Sierra's v0.1.3 entry (74.0%) is consistent with
  v1.0.0 task quality improvements (75+ SABER fixes) and single-trial variance
- Run as part of The Conversion Engine capstone project at 10 Academy
