### PR TITLE
Add Qwen3.6-35B-A3B (V0) Comvera baseline submission

### DIFF
--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -9,7 +9,8 @@
     "gemini-3-flash_sierra_2026-03-02",
     "gemini-3-pro_sierra_2026-03-02",
     "distyl-buttonagent_distyl_2026-03-25",
-    "gpt-5-4_sierra_2026-03-25"
+    "gpt-5-4_sierra_2026-03-25",
+    "qwen3.6-35b-a3b-v0_comvera_2026-04-26"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",

--- a/web/leaderboard/public/submissions/qwen3.6-35b-a3b-v0_comvera_2026-04-26/submission.json
+++ b/web/leaderboard/public/submissions/qwen3.6-35b-a3b-v0_comvera_2026-04-26/submission.json
@@ -1,0 +1,60 @@
+{
+  "model_name": "hosted_vllm/Qwen3.6-35B-A3B",
+  "model_organization": "Qwen / Alibaba",
+  "submitting_organization": "Comvera",
+  "submission_date": "2026-04-26",
+  "contact_info": {
+    "email": "debdoot.iitd@gmail.com",
+    "name": "Debdoot Mukherjee"
+  },
+  "is_new": true,
+  "submission_type": "standard",
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_results.json",
+    "retail": "retail_results.json",
+    "telecom": "telecom_results.json"
+  },
+  "references": [
+    {
+      "title": "Trajectory data on Hugging Face Datasets",
+      "url": "https://huggingface.co/datasets/debdootmiitd/tau3-bench-qwen3.6-35b-a3b-v0",
+      "type": "dataset"
+    }
+  ],
+  "results": {
+    "airline": {
+      "pass_1": 81.0,
+      "pass_2": 74.33333333333334,
+      "pass_3": 70.5,
+      "pass_4": 68.0,
+      "cost": 0.0
+    },
+    "retail": {
+      "pass_1": 83.33333333333334,
+      "pass_2": 74.56140350877193,
+      "pass_3": 68.2017543859649,
+      "pass_4": 63.1578947368421,
+      "cost": 0.0
+    },
+    "telecom": {
+      "pass_1": 99.3421052631579,
+      "pass_2": 98.68421052631578,
+      "pass_3": 98.02631578947368,
+      "pass_4": 97.36842105263158,
+      "cost": 0.0
+    }
+  },
+  "reasoning_effort": "standard",
+  "methodology": {
+    "evaluation_date": "2026-04-26",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "gpt-4.1",
+    "notes": "Comvera Phase 0 baseline (V0) — first of a planned series. Qwen3.6-35B-A3B (HF SHA 995ad96e) served via vLLM 0.19.1 with --tool-call-parser qwen3_xml and --reasoning-parser qwen3. Default Qwen3.5 chat template (thinking-mode available, default). Agent llm_args: {'temperature': 0.6}. User simulator gpt-4.1-2025-04-14 at temperature 0.0 — happy to re-run with gpt-5.2 (current leaderboard recommendation) if maintainers prefer. --num-trials 4, --max-concurrency 4, default --task-split-name base. No fine-tuning, no scaffold modifications, no prompt edits. Cost not reported because vLLM is self-hosted; OpenAI user-simulator cost was ~$35 USD across 1112 sims. tau2-bench commit 3b005ddbdb4127c60cf2100e894807b6f6786a7a. Trajectories: https://huggingface.co/datasets/debdootmiitd/tau3-bench-qwen3.6-35b-a3b-v0. Note on telecom: 82% of telecom tasks (94/114) have reward_basis=('ENV_ASSERTION',) only with no agent-action check. The strict subset (20 tasks with reward_basis=('ENV_ASSERTION','ACTION')) gives a more conservative pass^4 of 0.850 vs the headline 0.974. Reported headline matches benchmark convention.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard tau-bench scaffold; no modifications to agent or user-simulator prompts; all 50 airline + 114 retail + 114 telecom base-split tasks evaluated with 4 trials each. Banking_knowledge omitted (out of Phase 0 scope)."
+    }
+  }
+}


### PR DESCRIPTION
## Submission summary

- **Model:** `Qwen/Qwen3.6-35B-A3B` (Qwen / Alibaba), HF SHA `995ad96e...`
- **Submitting organization:** Comvera
- **Modality:** text
- **User simulator:** `gpt-4.1-2025-04-14`, temperature 0.0
- **Submission type:** standard (general-purpose LLM, default τ-bench scaffold, no fine-tuning, no prompt edits)
- **Domains:** airline, retail, telecom (banking_knowledge omitted, planned follow-up)
- **Trials:** 4 per task, default seed 300, default `--task-split-name base`

## Headline results (pass^k)

| Domain | pass^1 | pass^2 | pass^3 | pass^4 |
|---|---:|---:|---:|---:|
| airline | 0.810 | 0.743 | 0.705 | **0.680** |
| retail  | 0.833 | 0.746 | 0.682 | **0.632** |
| telecom | 0.993 | 0.987 | 0.980 | **0.974** |

## Trajectory data

Hosted on Hugging Face Datasets (public, Apache-2.0):
**https://huggingface.co/datasets/debdootmiitd/tau3-bench-qwen3.6-35b-a3b-v0**

Total ~165 MB across the three domain `results.json` files. Maintainers may move
into `sierra-tau-bench-public` upon merge.

## Methodology notes

- Served via vLLM 0.19.1 with `--tool-call-parser qwen3_xml --reasoning-parser qwen3 --enable-auto-tool-choice`. Default Qwen3.5 chat template, thinking-mode available (model decides per-turn whether to emit a `<think>` block).
- Agent llm_args: `{"temperature": 0.6}`. No top_p / top_k / penalty overrides.
- tau2-bench commit `3b005ddbdb4127c60cf2100e894807b6f6786a7a` (= τ³-bench v1.0.0).
- We used `gpt-4.1` rather than the now-recommended `gpt-5.2` user simulator. **Happy to re-run with gpt-5.2 if maintainers prefer.** This was to align with our internal Phase 0 spec; we expect numbers to shift somewhat with the newer simulator.
- **Telecom caveat:** 82% of telecom tasks (94/114) have `reward_basis=('ENV_ASSERTION',)` only, with no agent-action check. The reported headline 0.974 reflects this. The strict subset (20 tasks with `reward_basis=('ENV_ASSERTION', 'ACTION')`) gives a more conservative pass^4 of 0.850. Reported headline matches benchmark convention.

## Verification

- No prompt modifications.
- No tasks omitted within the submitted domains.
- All 50 airline + 114 retail + 114 telecom base-split tasks evaluated with 4 trials.
- Banking_knowledge domain not run (planned for a follow-up submission).

## Schema validation

`tau2 submit validate <submission_dir>` passed (run against the prepared package
which includes the trajectories alongside; trajectories are not committed to the
PR per submission guide convention).
