### PR TITLE
fix: skip hallucinated tool calls during replay instead of raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Hallucinated tool calls in agent trajectories are now treated as no-ops during `Environment.set_state` replay (matching the live env, which returns a `ToolMessage(error=True)` and applies no state change), instead of raising `ValueError`. Previously, the exception propagated through `run_with_retry`, causing the entire task to be re-run up to `--max-retries` times before being binned as `INFRASTRUCTURE_ERROR` (which is excluded from `pass^k` and `avg_reward` metrics). Trajectories that hallucinate and then successfully recover now score correctly; trajectories that hallucinate without recovering still fail naturally via DB-state mismatch. Repeated hallucination remains bounded by the orchestrator's `max_errors` guard (`TerminationReason.TOO_MANY_ERRORS`).
 
 ## [1.0.0] - 2026-MM-DD
 

--- a/src/tau2/environment/environment.py
+++ b/src/tau2/environment/environment.py
@@ -365,7 +365,7 @@ class Environment:
                 # upstream by the orchestrator's max_errors guard, which
                 # ends the live sim with TerminationReason.TOO_MANY_ERRORS
                 # before evaluation runs.
-                logger.warning(
+                logger.debug(
                     f"Skipping unknown tool '{tool_call.name}' during replay "
                     "(no-op, matching live env behavior on hallucinated tools)."
                 )

--- a/src/tau2/environment/environment.py
+++ b/src/tau2/environment/environment.py
@@ -357,10 +357,19 @@ class Environment:
         action_responses = get_actions_from_messages(message_history)
         for tool_call, expected_response in action_responses:
             if not self._has_tool(tool_call.name):
-                raise ValueError(
-                    f"Unknown tool '{tool_call.name}' encountered during replay. "
-                    "The tool does not exist in the current environment."
+                # Hallucinated tool name. The live env returned a
+                # ToolMessage(error=True) for this call and made no state
+                # change, so replay it as a no-op. The agent's subsequent
+                # recovery (if any) will still be replayed and determine
+                # the final state. Repeated hallucination is bounded
+                # upstream by the orchestrator's max_errors guard, which
+                # ends the live sim with TerminationReason.TOO_MANY_ERRORS
+                # before evaluation runs.
+                logger.warning(
+                    f"Skipping unknown tool '{tool_call.name}' during replay "
+                    "(no-op, matching live env behavior on hallucinated tools)."
                 )
+                continue
             # Non-mutating tools (reads, thinks, etc.) don't change state --
             # skip them to avoid re-execution and non-deterministic output
             # comparison issues.

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -13,10 +13,12 @@ from tau2.data_model.tasks import (
     EnvAssertion,
     EnvFunctionCall,
     InitializationData,
+    Task,
 )
 from tau2.environment.environment import Environment
 from tau2.environment.tool import Tool
 from tau2.environment.toolkit import ToolKitBase, ToolType, is_tool
+from tau2.evaluator.evaluator_env import EnvironmentEvaluator
 
 
 @pytest.fixture
@@ -472,3 +474,137 @@ def test_environment_set_state_initialization_actions(
             arguments={"user_id": "user_1", "expected_number": 2},
         )
     )
+
+
+def _hallucinated_tool_call_messages() -> list[Message]:
+    """A two-message snippet representing a hallucinated tool call and the
+    error response the live environment would have produced for it."""
+    return [
+        AssistantMessage(
+            id="bad_call",
+            role="assistant",
+            content=None,
+            tool_calls=[
+                ToolCall(
+                    id="bad_call",
+                    name="this_tool_does_not_exist",
+                    arguments={},
+                )
+            ],
+        ),
+        ToolMessage(
+            id="bad_call",
+            role="tool",
+            content="Error: Tool 'this_tool_does_not_exist' not found.",
+            error=True,
+        ),
+    ]
+
+
+def test_environment_set_state_skips_unknown_tool_calls(
+    get_environment: Callable[[], Environment], message_history: list[Message]
+):
+    """Hallucinated tool calls in a replayed trajectory must be treated as
+    no-ops (matching the live env's behavior of returning ToolMessage(error=True)
+    with no state mutation), not raise. The agent's recovery actions in the
+    rest of the trajectory must still apply normally so the final DB state
+    matches a successful run."""
+    environment = get_environment()
+    augmented_history = _hallucinated_tool_call_messages() + message_history
+
+    environment.set_state(
+        initialization_data=None,
+        initialization_actions=None,
+        message_history=augmented_history,
+    )
+
+    environment.run_env_assertion(
+        EnvAssertion(
+            env_type="assistant",
+            func_name="assert_task_status",
+            arguments={"task_id": "task_1", "expected_status": "completed"},
+        )
+    )
+    environment.run_env_assertion(
+        EnvAssertion(
+            env_type="assistant",
+            func_name="assert_task_status",
+            arguments={"task_id": "task_2", "expected_status": "pending"},
+        )
+    )
+    environment.run_env_assertion(
+        EnvAssertion(
+            env_type="assistant",
+            func_name="assert_number_of_tasks",
+            arguments={"user_id": "user_1", "expected_number": 2},
+        )
+    )
+
+
+def test_environment_evaluator_hallucinated_then_recovered_scores_one(
+    get_environment: Callable[[], Environment], base_task: Task
+):
+    """A trajectory containing a hallucinated tool call AND the correct
+    recovery action should score the same as a clean trajectory."""
+    full_trajectory = [
+        UserMessage(
+            id="1",
+            content="Create a task called 'Important Meeting' for user_1",
+            role="user",
+        ),
+        *_hallucinated_tool_call_messages(),
+        AssistantMessage(
+            id="2",
+            content=None,
+            role="assistant",
+            tool_calls=[
+                ToolCall(
+                    id="recover",
+                    name="create_task",
+                    arguments={"user_id": "user_1", "title": "Important Meeting"},
+                )
+            ],
+        ),
+        ToolMessage(
+            id="recover",
+            content='{"task_id": "task_2", "title": "Important Meeting", "description": null, "status": "pending"}',
+            role="tool",
+        ),
+        AssistantMessage(id="3", content="Created the task for you.", role="assistant"),
+    ]
+
+    reward_info = EnvironmentEvaluator.calculate_reward(
+        environment_constructor=get_environment,
+        task=base_task,
+        full_trajectory=full_trajectory,
+    )
+
+    assert reward_info.reward == 1.0
+    assert reward_info.db_check is not None and reward_info.db_check.db_match
+
+
+def test_environment_evaluator_hallucinated_only_scores_zero(
+    get_environment: Callable[[], Environment], base_task: Task
+):
+    """A trajectory containing ONLY a hallucinated tool call (no recovery)
+    must still score 0 because the resulting DB state does not match the
+    gold (which requires the real create_task call to fire)."""
+    full_trajectory = [
+        UserMessage(
+            id="1",
+            content="Create a task called 'Important Meeting' for user_1",
+            role="user",
+        ),
+        *_hallucinated_tool_call_messages(),
+        AssistantMessage(id="end", role="assistant", content="done"),
+    ]
+
+    reward_info = EnvironmentEvaluator.calculate_reward(
+        environment_constructor=get_environment,
+        task=base_task,
+        full_trajectory=full_trajectory,
+    )
+
+    assert reward_info.reward == 0.0
+    assert reward_info.db_check is not None
+    assert not reward_info.db_check.db_match


### PR DESCRIPTION
## Summary

When a model hallucinates a tool name, the live env returns a `ToolMessage(error=True)` with no state mutation. But `Environment.set_state()` raised `ValueError` on the unknown tool during trajectory replay, which propagated through `run_with_retry` and caused the entire task to be re-run up to `--max-retries` times before being binned as `INFRASTRUCTURE_ERROR` -- which `compute_metrics` then excludes from `pass^k` / `avg_reward`. So a single hallucination wasted ~3x budget *and* silently dropped the task from headline metrics.

This PR makes `set_state` skip unknown tool calls during replay (a no-op matching what the live env did), letting the agent's recovery actions in the rest of the trajectory determine the final state via DB-state comparison. Hallucinate-then-recover scores normally; hallucinate-without-recovery still fails naturally via DB mismatch. Repeated hallucination is already bounded upstream by the orchestrator's `max_errors` guard.

## Testing

- `make check-all` clean.
- `make test` passes; 3 new regression tests in `tests/test_environment.py` cover (1) replay no longer raises on unknown tools, (2) hallucination-then-recovery scores 1.0, (3) hallucination-only scores 0.0 via DB mismatch.