### PR TITLE
Fall back NL-assertions judge to agent LLM when OPENAI_API_KEY missing + tolerate task loaders without task_split_name

### DIFF
--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -101,6 +101,18 @@ def add_run_args(parser):
         help=f"The arguments to pass to the LLM for the user. Default is '{{\"temperature\": {DEFAULT_LLM_TEMPERATURE_USER}}}'.",
     )
     parser.add_argument(
+        "--llm-nl-assertions",
+        type=str,
+        default=None,
+        help=(
+            "Override the model used by the NL-assertions judge "
+            "(LLM Judge Review). When omitted, the judge falls back to "
+            "--agent-llm if OPENAI_API_KEY isn't set, instead of crashing "
+            "the entire retail/telecom run. Equivalent to setting the "
+            "TAU2_LLM_NL_ASSERTIONS env var."
+        ),
+    )
+    parser.add_argument(
         "--task-set-name",
         type=str,
         default=None,
@@ -571,6 +583,18 @@ def main():
     add_run_args(run_parser)
 
     def run_command(args):
+        # Propagate the NL-assertions judge override + agent/user LLM defaults
+        # to the evaluator via env vars, so single-provider runs (e.g. Bedrock
+        # only, no OPENAI_API_KEY) don't crash in `LLM Judge Review`.
+        import os
+
+        if getattr(args, "llm_nl_assertions", None):
+            os.environ["TAU2_LLM_NL_ASSERTIONS"] = args.llm_nl_assertions
+        if getattr(args, "agent_llm", None):
+            os.environ.setdefault("TAU2_AGENT_LLM", args.agent_llm)
+        if getattr(args, "user_llm", None):
+            os.environ.setdefault("TAU2_USER_LLM", args.user_llm)
+
         user_persona_config = None
         if args.user_persona:
             user_persona_config = PersonaConfig.from_dict(args.user_persona)  # noqa: F841

--- a/src/tau2/evaluator/evaluator_nl_assertions.py
+++ b/src/tau2/evaluator/evaluator_nl_assertions.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from tau2.agent.base.streaming import (
     LinearizationStrategy,
@@ -11,6 +12,32 @@ from tau2.data_model.simulation import NLAssertionCheck, RewardInfo
 from tau2.data_model.tasks import RewardType, Task
 from tau2.evaluator.evaluator_base import EvaluatorBase
 from tau2.utils.llm_utils import generate
+
+
+def _resolve_nl_assertions_model() -> str:
+    """Pick the model used by the natural-language-assertions judge.
+
+    Upstream tau2 hardcodes OpenAI `gpt-4.1-*`, which breaks every run that
+    doesn't also set `OPENAI_API_KEY` (the infamous "OPENAI_API_KEY missing"
+    LLM Judge Review failure on retail). Order of precedence:
+
+    1. ``TAU2_LLM_NL_ASSERTIONS`` env var -- explicit override, wins always.
+    2. The upstream default, if ``OPENAI_API_KEY`` is set (OpenAI path still
+       works).
+    3. Any Bedrock agent/user LLM that was supplied via
+       ``TAU2_AGENT_LLM`` / ``TAU2_USER_LLM`` env (set by the CLI when we
+       extend it) -- auto-fallback so single-provider runs "just work".
+    4. Upstream default as a final best effort.
+    """
+    env_override = os.environ.get("TAU2_LLM_NL_ASSERTIONS")
+    if env_override:
+        return env_override
+    if os.environ.get("OPENAI_API_KEY"):
+        return DEFAULT_LLM_NL_ASSERTIONS
+    fallback = os.environ.get("TAU2_AGENT_LLM") or os.environ.get("TAU2_USER_LLM")
+    if fallback:
+        return fallback
+    return DEFAULT_LLM_NL_ASSERTIONS
 
 
 class NLAssertionsEvaluator(EvaluatorBase[Message]):
@@ -119,7 +146,7 @@ class NLAssertionsEvaluator(EvaluatorBase[Message]):
         ]
 
         assistant_message = generate(
-            model=DEFAULT_LLM_NL_ASSERTIONS,
+            model=_resolve_nl_assertions_model(),
             messages=messages,
             call_name="nl_assertions_eval",
             **DEFAULT_LLM_NL_ASSERTIONS_ARGS,

--- a/src/tau2/runner/helpers.py
+++ b/src/tau2/runner/helpers.py
@@ -49,7 +49,11 @@ def load_task_splits(task_set_name: str) -> Optional[dict[str, list[str]]]:
 def load_tasks(task_set_name: str, task_split_name: Optional[str] = None) -> list[Task]:
     """Load tasks for a given task set, optionally filtering by split."""
     task_loader = registry.get_tasks_loader(task_set_name)
-    tasks = task_loader(task_split_name=task_split_name)
+    try:
+        tasks = task_loader(task_split_name=task_split_name)
+    except TypeError:
+        # Some loaders (e.g. telecom_small/full) don't accept task_split_name.
+        tasks = task_loader()
     return tasks
 
 


### PR DESCRIPTION
# tau2-bench upstream PR: NL-assertions judge fallback

Branch: `external/tau2-bench @ nl-assertions-judge-fallback`
Target: `sierra-research/tau2-bench:main`

## Why

The natural-language-assertions judge (`src/tau2/evaluator/evaluator_nl_assertions.py`)
hardcodes `DEFAULT_LLM_NL_ASSERTIONS = "gpt-4.1-2025-04-14"`. For
single-provider runs (Bedrock-only, Vertex-only), every `LLM Judge Review`
call crashes with `OPENAI_API_KEY missing`. On tau2-retail this silently
eliminates ~30-35% of tasks from the final Pass^1 metric, forcing users
to compute partial scores on the evaluable subset -- see the evox 2026-04
evaluation report, section tau3 results, for a concrete reproduction
(retail 74/114 and 77/114 evaluable for Opus-4.6 and Sonnet-4.5
respectively, 37-40 tasks lost to infra errors).

Additionally, `telecom_small` / `telecom_full` loaders don't accept the
`task_split_name` kwarg, so every tau2 telecom run aborts before any
task executes with a `TypeError`.

## What

Two commits in this branch:

1. **Feat: fall back NL-assertions judge to agent LLM when OPENAI_API_KEY missing**
   - New `--llm-nl-assertions` CLI flag on `tau2 run`.
   - `run_command` propagates `--agent-llm` / `--user-llm` / `--llm-nl-assertions`
     into `TAU2_AGENT_LLM` / `TAU2_USER_LLM` / `TAU2_LLM_NL_ASSERTIONS` env
     vars before the evaluator loads.
   - `_resolve_nl_assertions_model()` in `evaluator_nl_assertions.py` picks
     the judge model with this precedence:
     1. `TAU2_LLM_NL_ASSERTIONS` env (from the new CLI flag) -- explicit
        override, wins always.
     2. Upstream default when `OPENAI_API_KEY` is set (no behaviour change
        for OpenAI users).
     3. `TAU2_AGENT_LLM` / `TAU2_USER_LLM` -- auto-fallback so single-
        provider runs "just work".
     4. Upstream default as final best effort.
2. **Fix: tolerate task loaders that don't accept task_split_name**
   - `load_tasks` now tries the kwarg call first, then falls back to the
     zero-arg call if the loader raises `TypeError`. Unblocks telecom.

## How to test

```bash
# OpenAI path unchanged:
OPENAI_API_KEY=sk-... tau2 run --domain retail --task-set-name retail \
  --agent-llm gpt-4.1 --user-llm gpt-4.1 --num-trials 1

# Bedrock-only, previously broken:
AWS_REGION=us-east-1 tau2 run --domain retail --task-set-name retail \
  --agent-llm bedrock/global.anthropic.claude-sonnet-4-5-v1 \
  --user-llm  bedrock/global.anthropic.claude-sonnet-4-5-v1 \
  --num-trials 1

# telecom, previously broken by TypeError:
tau2 run --domain telecom --task-set-name telecom_small \
  --agent-llm bedrock/global.anthropic.claude-sonnet-4-5-v1 \
  --user-llm  bedrock/global.anthropic.claude-sonnet-4-5-v1 \
  --num-trials 1
```

## Backwards compatibility

- No default behaviour change for `OPENAI_API_KEY`-equipped runs.
- New CLI flag is optional.
- Two new env vars are read-only (only set by tau2's own CLI), not required.

## Files changed

- `src/tau2/cli.py` (+24) -- new flag + env propagation in `run_command`.
- `src/tau2/evaluator/evaluator_nl_assertions.py` (+28 / -1) -- resolver
  function + call-site swap.
- `src/tau2/runner/helpers.py` (+4 / -1) -- loader kwarg fallback.

## Local repro artefacts

- tau3 retail "infra errors": `evox-bench/tau3/logs/opus46-retail.log` and
  `evox-bench/tau3/runs/opus46/retail.json/results.json` show the 40
  tasks that crashed in `LLM Judge Review` against an un-patched tau2,
  plus the remaining 74 that were evaluable.
- After applying this branch to `external/tau2-bench` in-place the full
  114 retail tasks evaluate.
