### PR TITLE
Clarify text user simulator should wait for action completion

### DIFF
--- a/data/tau2/user_simulator/simulation_guidelines.md
+++ b/data/tau2/user_simulator/simulation_guidelines.md
@@ -11,6 +11,8 @@ Your goal is to simulate realistic customer interactions while following specifi
 
 ## Task Completion
 - The goal is to continue the conversation until the task is complete.
+- Do not end the conversation prematurely. Agreeing to an action is not the same as the action being completed. If the agent offers to do something (e.g., cancel an order, process a refund), wait for the agent to confirm it is done before ending the conversation.
+- Before ending the conversation, verify that all items in your scenario instructions have been addressed. If your instructions include multiple requests, questions, or tasks, make sure every single one has been completed; do not stop after only some of them are resolved.
 - If the instruction goal is satisified, generate the '###STOP###' token to end the conversation.
 - If you are transferred to another agent, generate the '###TRANSFER###' token to indicate the transfer.
 - If you find yourself in a situation in which the scenario does not provide enough information for you to continue the conversation, generate the '###OUT-OF-SCOPE###' token to end the conversation.

--- a/data/tau2/user_simulator/simulation_guidelines_tools.md
+++ b/data/tau2/user_simulator/simulation_guidelines_tools.md
@@ -23,6 +23,8 @@ You have some tools to perform the actions on your end that might be requested b
 
 ## Task Completion
 - The goal is to continue the conversation until the task is complete.
+- Do not end the conversation prematurely. Agreeing to an action is not the same as the action being completed. If the agent offers to do something (e.g., cancel an order, process a refund), wait for the agent to confirm it is done before ending the conversation.
+- Before ending the conversation, verify that all items in your scenario instructions have been addressed. If your instructions include multiple requests, questions, or tasks, make sure every single one has been completed; do not stop after only some of them are resolved.
 - If the instruction goal is satisified, generate the '###STOP###' token to end the conversation.
 - If you have been transferred to another agent, generate the '###TRANSFER###' token to indicate the transfer. Only do this after the agent has clearly indicated that you are being transferred.
 - If you find yourself in a situation in which the scenario does not provide enough information for you to continue the conversation, generate the '###OUT-OF-SCOPE###' token to end the conversation.

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,7 +1,11 @@
 import pytest
+from pathlib import Path
 
 from tau2.data_model.message import AssistantMessage, UserMessage
 from tau2.user.user_simulator import DummyUser, UserSimulator
+
+
+GUIDELINES_DIR = Path(__file__).resolve().parents[1] / "data" / "tau2" / "user_simulator"
 
 
 @pytest.fixture
@@ -64,3 +68,15 @@ def test_dummy_user_no_args():
     dummy = DummyUser()
     state = dummy.get_init_state()
     assert state.messages == []
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["simulation_guidelines.md", "simulation_guidelines_tools.md"],
+)
+def test_text_user_simulator_guidelines_wait_for_action_completion(filename: str):
+    guidelines = (GUIDELINES_DIR / filename).read_text()
+
+    assert "Agreeing to an action is not the same as the action being completed" in guidelines
+    assert "wait for the agent to confirm it is done before ending the conversation" in guidelines
+    assert "do not stop after only some of them are resolved" in guidelines


### PR DESCRIPTION
## Motivation

The voice user simulator already says that agreeing to an action is not the same as completing the action: after the user confirms an action, the simulator should wait until the agent confirms that the action has actually been completed.

The text user simulator guidelines were missing that same completion-boundary language. In action-oriented tasks, this can cause the simulated user to emit `###STOP###` immediately after giving confirmation, before the agent has a chance to call the required write tool.

## Observed failure mode

A typical pattern is:

1. The agent asks the user to confirm a write action, such as cancelling an order or processing an exchange/refund.
2. The user confirms.
3. The simulator emits `###STOP###` in the same turn.
4. The conversation ends before the agent executes the write action, so the final DB state is wrong.

This is a simulator completion-boundary issue: the user has agreed to the action, but the task is not complete yet.

## Evidence from local runs

I tested this with Doubao Seed 2.0 Pro for both the agent and user simulator. These numbers are not meant to replace the official GPT/Claude leaderboard runs, but they show that the guideline change can materially affect the no-memory standard scaffold score.

### Full-domain airline A/B

Same native TAU-2 protocol, no memory, `airline` base split, 50 tasks x 4 trials = 200 simulations.

| Setting | Source | Avg reward | Pass^1 | Pass^2 | Pass^3 | Pass^4 | DB match |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Current guideline | upstream/main `2be6916` | 0.725 | 72.5 | 65.3 | 61.0 | 58.0 | 149/200 |
| Patched guideline | this PR branch `79dbf0c` | 0.800 | 80.0 | 74.3 | 71.0 | 68.0 | 166/200 |

### Retail reproduction cases

These are smaller targeted runs on retail tasks where user confirmation is required before a write action.

| Task | Setting | Trials | Reward / DB match | Premature confirmation STOP |
| --- | --- | ---: | ---: | ---: |
| retail task 40 | current guideline | 10 | 1/10 | 9/10 |
| retail task 40 | patched guideline | 10 | 10/10 | 0/10 |
| retail task 74 | current guideline | 10 | 8/10 | 1/10 |
| retail task 74 | patched guideline | 10 | 10/10 | 0/10 |
| retail task 56 | current guideline | 10 | 4/10 | 2/10 |
| retail task 56 | patched guideline | 10 | 6/10 | 0/10 |

Task 56 is included as a boundary case: the patch removes premature user stops, but it does not hide unrelated agent failures where the agent still fails to perform the required write.

I am also running full-domain retail A/B locally. Retail has evaluator-side LLM usage in some cases, so my local run uses Doubao for that evaluator path as well; I will share those results separately once complete.

## Proposed fix

This PR copies the already-existing action-completion clarification from the voice user simulator guideline into both text user simulator guideline files:

- `data/tau2/user_simulator/simulation_guidelines.md`
- `data/tau2/user_simulator/simulation_guidelines_tools.md`

The intended behavior is narrow: the simulated user should not end the conversation merely because it agreed to an action. It should wait for the agent to report that the requested action has been completed.

## Compatibility

This is a prompt-only change. It does not change task data, reward code, tool schemas, stop tokens, or evaluator logic.

It should make the text simulator closer to the existing voice simulator completion boundary.

## Request for maintainer validation

Because my full-domain evidence is from Doubao Seed 2.0 Pro, it would be helpful for maintainers to rerun the same A/B with the models used for official reporting, especially GPT and Claude user simulators.

Suggested checks:

- Full-domain `airline`, no memory, 4 trials, current guideline vs patched guideline.
- Full-domain `retail`, no memory, 4 trials, current guideline vs patched guideline.
- A few confirmation-heavy retail cases such as tasks 40, 56, and 74.

## Regression plan

Added a small non-LLM regression test that checks both text guideline files contain the action-completion boundary language.

Verified locally:

```bash
uv run pytest tests/test_user.py -q -k text_user_simulator_guidelines
```

Result: `2 passed, 3 deselected`.
