### PR TITLE
fix: correct leaderboard table column width CSS after Released column addition

### DIFF
--- a/web/leaderboard/src/components/Leaderboard.css
+++ b/web/leaderboard/src/components/Leaderboard.css
@@ -684,22 +684,26 @@
 }
 
 .reliability-table th:nth-child(3) {
-  width: 160px; /* Organization column */
+  width: 100px; /* Released column */
 }
 
 .reliability-table th:nth-child(4) {
-  width: 100px; /* Reasoning column */
+  width: 160px; /* Organization / Provider column */
 }
 
 .reliability-table th:nth-child(5) {
-  width: 120px; /* User Sim column */
+  width: 100px; /* Reasoning column */
 }
 
 .reliability-table th:nth-child(6) {
-  min-width: 320px; /* Score column with progress bar and inline toggle */
+  width: 120px; /* User Sim column */
 }
 
 .reliability-table th:nth-child(7) {
+  min-width: 320px; /* Score column with progress bar and inline toggle */
+}
+
+.reliability-table th:nth-child(8) {
   width: 36px; /* Expand toggle column */
   padding: 20px 4px;
 }


### PR DESCRIPTION
## Summary
- The "Released" column was added to the leaderboard table but the `nth-child` CSS width rules were never bumped, shifting every column's sizing one position left.
- This caused the User Sim column (now 6th child) to inherit `min-width: 320px` (meant for the Score column), making the table overflow horizontally on most screens.
- Updated all `nth-child` indices to match the current 8-column layout (Rank, Model, Released, Org, Reasoning, User Sim, Score, Expand).

## Test plan
- [x] Verified locally that the leaderboard table no longer overflows on both τ-bench and τ-voice views
- [x] Confirmed all columns have correct widths matching their intended sizing

Made with [Cursor](https://cursor.com)