### PR TITLE
fix: deepcopy default_vpn_details in _connect_vpn to prevent shared state corruption across concurrent simulations

### DIFF
--- a/src/tau2/domains/telecom/user_tools.py
+++ b/src/tau2/domains/telecom/user_tools.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 from tau2.domains.telecom.user_data_model import (
@@ -762,7 +763,7 @@ class TelecomUserTools(ToolKitBase):
         if self.device.vpn_connected:
             return None
         self.device.vpn_connected = True
-        self.device.vpn_details = self.default_vpn_details
+        self.device.vpn_details = copy.deepcopy(self.default_vpn_details)
         return True
 
     @is_tool(ToolType.WRITE)

--- a/tests/test_domains/test_telecom/test_user_tools_telecom.py
+++ b/tests/test_domains/test_telecom/test_user_tools_telecom.py
@@ -432,6 +432,35 @@ class TestTelecomUserTools:
             in telecom_tools.can_send_mms()
         )
 
+    def test_vpn_state_not_shared_across_instances(self):
+        """Regression test for issue #154: default_vpn_details is a class-level
+        attribute. _connect_vpn() must deep-copy it so that break_vpn() on one
+        instance cannot corrupt the VPN state seen by a concurrent simulation."""
+
+        def make_tools():
+            db = TelecomUserDB(
+                device=MockPhoneAttributes(), surroundings=UserSurroundings()
+            )
+            return TelecomUserTools(db=db)
+
+        sim1 = make_tools()
+        sim2 = make_tools()
+
+        # sim1 connects then breaks its VPN (mutates server_performance to POOR)
+        sim1._connect_vpn()
+        sim1.break_vpn()
+        assert sim1.device.vpn_details.server_performance == PerformanceLevel.POOR
+
+        # sim2 connects independently — must get a fresh EXCELLENT copy
+        sim2._connect_vpn()
+        assert sim2.device.vpn_details.server_performance == PerformanceLevel.EXCELLENT
+
+        # The class-level default must also be untouched
+        assert (
+            TelecomUserTools.default_vpn_details.server_performance
+            == PerformanceLevel.EXCELLENT
+        )
+
     def test_run_speed_test(self, telecom_tools: TelecomUserTools):
         # Basic connected state
         telecom_tools.device.airplane_mode = False


### PR DESCRIPTION
Fixes #154

## Summary
`_connect_vpn()` assigned `default_vpn_details` by reference instead of by value. Because `default_vpn_details` is a class-level field shared across all `TelecomUserTools` instances, a subsequent call to `break_vpn()` mutated the shared object — corrupting the VPN state for every other simulation running concurrently.

## Changes Made
- `src/tau2/domains/telecom/user_tools.py`: added `import copy`, changed reference assignment to `copy.deepcopy()` in `_connect_vpn()`
- `tests/test_domains/test_telecom/test_user_tools_telecom.py`: added regression test `test_vpn_state_not_shared_across_instances`
- 2 lines changed in source, no behavior change for single-task runs, no breaking changes

## Testing
Reproduced the bug with a two-instance script before applying the fix:

**Before fix:**
sim1 breaks VPN → default_vpn_details.server_performance becomes POOR
sim2 connects VPN → gets POOR instead of EXCELLENT ❌

**After fix:**
sim1 breaks VPN → default_vpn_details.server_performance stays EXCELLENT
sim2 connects VPN → gets EXCELLENT ✅

Added regression test to prevent reintroduction.

- `test_domains/test_telecom/test_user_tools_telecom.py` — 26/26 ✅ (includes new regression test)
- `test_domains/test_telecom/test_tools_telecom.py` — 26/26 ✅

## Documentation
No documentation changes needed.

## Checklist
- [x] Tests pass (`make test`)
- [x] Code follows style guidelines (`make check-all`)
- [x] Documentation updated (no changes needed)
- [x] Breaking changes noted (none)