### PR TITLE
feat: improve audio-native OpenAI defaults and experiment tooling

### DIFF
--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -82,6 +82,7 @@ def build_command(
     save_to: str,
     *,
     num_tasks: int | None = None,
+    max_steps_seconds: int | None = None,
     seed: int = DEFAULT_SEED,
     user_llm: str = DEFAULT_LLM_USER,
     max_concurrency: int = 8,
@@ -107,6 +108,8 @@ def build_command(
         cmd.extend(["--cascaded-config", spec.cascaded_config])
     if num_tasks is not None:
         cmd.extend(["--num-tasks", str(num_tasks)])
+    if max_steps_seconds is not None:
+        cmd.extend(["--max-steps-seconds", str(max_steps_seconds)])
     return cmd
 
 
@@ -133,6 +136,7 @@ def main():
         help=f"Comma-separated speech complexities. Default: {','.join(DEFAULT_COMPLEXITIES)}",
     )
     parser.add_argument("--num-tasks", type=int, default=None)
+    parser.add_argument("--max-steps-seconds", type=int, default=None)
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--user-llm", type=str, default=DEFAULT_LLM_USER)
     parser.add_argument("--max-concurrency", type=int, default=8)
@@ -168,6 +172,7 @@ def main():
         cmd = build_command(
             domain, spec, complexity, save_to,
             num_tasks=args.num_tasks,
+            max_steps_seconds=args.max_steps_seconds,
             seed=args.seed,
             user_llm=args.user_llm,
             max_concurrency=args.max_concurrency,

--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -128,6 +128,18 @@ You are a customer service agent handling a VOICE CALL with a customer.
 2. If authenticating the user fails based on user provided information, ALWAYS explicitly ask the customer to SPELL THINGS OUT or provide information LETTER BY LETTER (e.g. "first name J, O, H, N last name S, M, I, T, H").
 """.strip()
 
+# TODO: Allow configuring "preamble" terminology if providers use different terms (or use a generic term like "progress updates" if that is sufficient).
+OPENAI_THINKING_PREAMBLE_INSTRUCTION = """
+# Progress Updates and Preambles
+Use a preamble when the user would otherwise experience a noticeable pause before the next useful response due to longer thinking.
+
+For example:
+- Use a preamble for multi-step work, escalations
+- Do not use a preamble for lightweight lookups, direct answers
+
+When a preamble is used, ensure it is no more than one sentence. 1-2 words, a short sentence, or one sentence are all okay.
+""".strip()
+
 # System prompt without XML tags (for xAI and other providers that prefer plain text)
 AUDIO_NATIVE_SYSTEM_PROMPT_PLAIN = """
 {agent_instruction}
@@ -349,6 +361,10 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
             agent_instruction = CASCADED_MODEL_INSTRUCTION
         else:
             agent_instruction = AUDIO_NATIVE_VOICE_INSTRUCTION
+
+        # TODO: generalize this check as more providers support preambles
+        if self.provider == "openai" and self.reasoning_effort in ("medium", "high"):
+            agent_instruction += "\n\n" + OPENAI_THINKING_PREAMBLE_INSTRUCTION
 
         return template.format(
             agent_instruction=agent_instruction,

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -135,7 +135,7 @@ DEFAULT_AUDIO_NATIVE_MAX_INACTIVE_SECONDS = 40.0  # fixed, stall detection
 # =============================================================================
 # OPENAI PROVIDER (overridable model/voice, fixed API constants)
 # =============================================================================
-DEFAULT_OPENAI_REALTIME_MODEL = "gpt-realtime-1.5"  # overridable
+DEFAULT_OPENAI_REALTIME_MODEL = "gpt-realtime-alpha-dolphin-6"  # overridable
 _LEGACY_OPENAI_REALTIME_MODEL = "gpt-realtime-2025-08-28"
 DEFAULT_OPENAI_REALTIME_BASE_URL = "wss://api.openai.com/v1/realtime"  # fixed
 DEFAULT_OPENAI_VOICE = "alloy"  # overridable
@@ -201,7 +201,7 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
 }
 
 DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
-    "openai": None,
+    "openai": "high",
     "gemini": "high",
     "xai": None,
     "nova": None,

--- a/src/tau2/voice/synthesis/conversation_builder.py
+++ b/src/tau2/voice/synthesis/conversation_builder.py
@@ -248,6 +248,31 @@ def generate_audacity_labels(
             f"Generated {len(tc_segments)} tool call labels for {role}: {tc_label_path}"
         )
 
+    # Unified timeline: all events in one file with a type column
+    all_entries = []
+    for role in ["user", "assistant"]:
+        for seg in _collect_speech_segments(ticks, role):
+            start_sec = seg.start_tick * tick_duration_ms / 1000.0
+            end_sec = (seg.end_tick + 1) * tick_duration_ms / 1000.0
+            text = seg.text.replace("\n", " ").replace("\t", " ").strip()
+            if len(text) > 200:
+                text = text[:197] + "..."
+            all_entries.append((start_sec, end_sec, role, text))
+        for seg in _collect_tool_call_segments(ticks, role):
+            start_sec = seg.start_tick * tick_duration_ms / 1000.0
+            end_sec = (seg.end_tick + 1) * tick_duration_ms / 1000.0
+            all_entries.append(
+                (start_sec, end_sec, f"{role}_tool_call", seg.tool_name)
+            )
+
+    all_entries.sort(key=lambda e: e[0])
+    timeline_path = output_dir / "timeline.txt"
+    with open(timeline_path, "w", encoding="utf-8") as f:
+        for start, end, entry_type, text in all_entries:
+            f.write(f"{start:.3f}\t{end:.3f}\t{entry_type}\t{text}\n")
+    label_files["timeline"] = timeline_path
+    logger.debug(f"Generated unified timeline with {len(all_entries)} entries: {timeline_path}")
+
     return label_files
 
 


### PR DESCRIPTION
## Summary
- update the audio-native OpenAI defaults to use `gpt-realtime-alpha-dolphin-6`, raise the default reasoning effort, and add short progress-update guidance for longer responses
- allow `src/experiments/tau_voice/run_multiple.py` to pass through `--max-steps-seconds`
- emit a unified `timeline.txt` label artifact alongside the existing voice synthesis labels for easier inspection

Made with [Cursor](https://cursor.com)