### PR TITLE
leaderboard: add gpt-realtime-2 voice submission request

### DIFF
--- a/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-05-12/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-05-12/submission.json
@@ -1,0 +1,46 @@
+{
+  "model_name": "gpt-realtime-2",
+  "model_organization": "OpenAI",
+  "submitting_organization": "Pending official τ-voice evaluation",
+  "submission_date": "2026-05-12",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {},
+  "is_new": true,
+  "trajectories_available": false,
+  "results": {
+    "retail": {
+      "pass_1": null
+    },
+    "airline": {
+      "pass_1": null
+    },
+    "telecom": {
+      "pass_1": null
+    }
+  },
+  "voice_config": {
+    "provider": "OpenAI",
+    "model": "gpt-realtime-2",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 600,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "methodology": {
+    "evaluation_date": "2026-05-12",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "v1.0",
+    "notes": "Metadata-only request for Sierra maintainers to run official τ-voice evaluation for OpenAI gpt-realtime-2 with official voice personas and regular speech complexity. Local smoke testing used non-official voices and is not included as leaderboard-comparable evidence.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Official results and trajectories should be populated by maintainers after running the standard τ-voice protocol."
+    }
+  },
+  "model_release": {
+    "release_date": "2026-05-07",
+    "announcement_url": "https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/",
+    "announcement_title": "Advancing voice intelligence with new models in the API"
+  },
+  "reasoning_effort": null
+}


### PR DESCRIPTION
## Summary
- Adds a metadata-only voice submission request for OpenAI `gpt-realtime-2`.
- Leaves official pass@1 scores and trajectories unset pending Sierra's official τ-voice run.
- Does not include local non-official-voice smoke results as leaderboard evidence.

## Notes
- `gpt-realtime-2` is not currently listed in the τ-voice submissions.
- The OpenAI audio-native adapter already exists; local smoke work only checked plumbing/connectivity.
- Official comparability requires Sierra's official voice personas and regular speech complexity.
- I intentionally left the manifest unchanged so placeholder null scores are not listed before maintainers run/fill official results.

## Reasoning configuration
- `gpt-realtime-2` supports configurable reasoning levels, so official τ-voice results should record the reasoning level used for the run.
- If Sierra evaluates multiple reasoning levels, those should either be reported as separate entries or clearly annotated so the leaderboard comparison is unambiguous.

## Validation
- Validated `submission.json` against `web/leaderboard/public/submissions/schema.json`.
- Reviewed committed diff for obvious secret markers.
