### PR TITLE
feat(voice): add Inworld Realtime API as audio-native provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ OPENAI_API_KEY=<your_key_here>
 ELEVENLABS_API_KEY=<your_key_here>
 DEEPGRAM_API_KEY=<your_key_here>
 
+# Realtime voice-agent providers (only set the ones you'll use)
+INWORLD_API_KEY=<your_key_here>     # Inworld Realtime API (base64 key from portal)
+GEMINI_API_KEY=<your_key_here>      # Gemini Live (or GOOGLE_API_KEY / GOOGLE_SERVICE_ACCOUNT_KEY)
+XAI_API_KEY=<your_key_here>         # xAI Grok Voice Agent
+
 # Required for banking_knowledge qwen_embeddings* retrieval configs (via OpenRouter)
 OPENROUTER_API_KEY=<your_key_here>
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,31 @@ uv run tau2 check-data         # verify installation
 
 **Note:** `langfuse` and `redis` are not declared dependencies but may be needed if you enable `USE_LANGFUSE=True` or `LLM_CACHE_ENABLED=True` with `redis` cache type in `config.py`. Install them manually if needed (`uv pip install langfuse redis`).
 
-Environment variables: copy `.env.example` to `.env` and set API keys. Uses [LiteLLM](https://github.com/BerriAI/litellm) for LLM provider abstraction.
+### If `uv` errors with `pyenv: version '3.12' is not installed`
+
+`.python-version` pins 3.12. If your `uv` on PATH is the pyenv shim at `~/.pyenv/shims/uv` and pyenv has no 3.12 installed, the shim fails before uv runs. Fix:
+
+```bash
+brew install uv          # gives a standalone /opt/homebrew/bin/uv (no shim)
+hash -r                  # refresh shell command cache
+which uv                 # should now show /opt/homebrew/bin/uv
+```
+
+Alternatively, register a 3.12 with pyenv (`ln -sf /opt/homebrew/opt/python@3.12 ~/.pyenv/versions/3.12` if you have it from brew, otherwise `pyenv install 3.12`). Last-resort escape hatch when you can't install anything: `PYENV_VERSION=3.10.14 ~/.pyenv/versions/3.10.14/bin/uv run …` — bypasses the shim and uv still uses its own cached 3.12 internally.
+
+### API keys
+
+Environment variables: copy `.env.example` to `.env` and set API keys. `.env` is gitignored (`^.env$` in `.gitignore`). Uses [LiteLLM](https://github.com/BerriAI/litellm) for LLM provider abstraction.
 
 Required keys depend on the task:
-- `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` — for LLM-based agents and user simulators
-- `ELEVENLABS_API_KEY` — voice synthesis
+- `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` — for LLM-based agents and user simulators (Anthropic is also needed for the post-eval hallucination reviewer — without it, voice eval still produces Pass^1 but the reviewer step errors near the end)
+- `ELEVENLABS_API_KEY` — voice synthesis (creator tier or higher; free tier's 10k char cap is exhausted in ~1 run, and creator tier caps concurrent TTS at 5 — see "Things to Watch Out For")
 - `DEEPGRAM_API_KEY` — voice transcription
+- `INWORLD_API_KEY` — Inworld Realtime audio-native provider (key is already base64 from the portal; do not re-encode)
+- `GEMINI_API_KEY` / `GOOGLE_API_KEY` — Gemini Live
+- `XAI_API_KEY` — xAI Grok Voice
+
+The default ElevenLabs voice IDs in `src/tau2/data_model/voice_personas.py` are Sierra-internal and 404 for external accounts. Override per persona via `TAU2_VOICE_ID_<PERSONA_NAME_UPPER>` env vars (see `.env.example`). Tau2 prints a `NON-OFFICIAL voice ID` warning when overrides are in use — that's expected, but results are **not directly comparable to the official τ-voice leaderboard** because of it.
 
 ## Common Commands
 
@@ -52,14 +71,19 @@ Required keys depend on the task:
 # Text half-duplex (standard)
 tau2 run --domain airline --agent-llm gpt-4.1 --user-llm gpt-4.1 --num-trials 1 --num-tasks 5
 
-# Voice full-duplex (audio native)
-tau2 run --domain retail --audio-native --num-tasks 1 --verbose-logs
+# Voice full-duplex (audio native) — provider choices: openai, gemini, xai, nova, qwen, inworld, livekit
+tau2 run --domain airline --audio-native --audio-native-provider inworld \
+    --num-tasks 10 --speech-complexity regular --verbose-logs --max-concurrency 4
+```
 
+`--verbose-logs` is the difference between "I have a pass/fail number" and "I can listen back to the conversation." Always include it for voice runs — it writes per-task `audio/both.wav` (stereo: user L, agent R), `assistant_labels.txt`, `user_labels.txt`, and `llm_debug/` under `data/simulations/<run>/artifacts/task_<N>/sim_<uuid>/`.
+
+```bash
 # Knowledge domain (requires --retrieval-config)
 tau2 run --domain banking_knowledge --retrieval-config qwen_embeddings --agent-llm gpt-4.1 --user-llm gpt-4.1 --num-tasks 5
 ```
 
-Results go to `data/simulations/`. Use `tau2 view` to browse them.
+Results go to `data/simulations/`. Use `uv run tau2 view` to browse them in a TUI (plays audio, scrolls transcripts, shows per-tick events).
 
 ## Architecture
 
@@ -83,7 +107,7 @@ src/tau2/
 ├── user/            # User simulator implementations
 ├── utils/           # Shared utilities
 └── voice/           # Voice synthesis, transcription, audio-native providers
-    └── audio_native/  # Real-time voice providers (openai, gemini, nova, xai, deepgram, qwen, livekit)
+    └── audio_native/  # Real-time voice providers (openai, gemini, nova, xai, qwen, inworld, livekit)
 ```
 
 Other top-level directories:
@@ -199,6 +223,10 @@ test: add integration tests for retail domain
 - **`config.py`**: Single source of truth for default configuration values. Import constants from here rather than defining local duplicates.
 - **`registry.py`**: All new agents, domains, and user simulators must be registered here to be usable via CLI.
 - **Audio native providers**: Each has its own WebSocket protocol and event format. Always verify against provider documentation. See `.cursor/rules/audio-native-provider.md` for the full implementation guide.
+- **Inworld provider quirks** (`src/tau2/voice/audio_native/inworld/`): Auth is `Authorization: Basic <api_key>` (key is already base64; do NOT re-encode). URL requires `?key=voice-<ts>&protocol=realtime`. Audio is PCM16 @ 24 kHz only — telephony μ-law gets transcoded via `StreamingTelephonyConverter`. Function-call `name` lives in `response.output_item.added` (item payload), NOT in `response.function_call_arguments.done`; the adapter caches `call_id → name` so the `.done` handler can resolve it. Barge-in is handled by sending `response.cancel` (Inworld auto-cancels too because `interrupt_response: true`, but the explicit cancel is belt-and-suspenders).
+- **Voice eval timing/quotas**: Per-tick wall clock has a 200 ms minimum floor (the base class sleeps the remainder if processing was faster) — so per-task wall clock ≈ call time + ~10–15% (post-eval review tail). At `--max-concurrency 4`, a 50-task airline run takes ~2.5h wall clock. ElevenLabs creator tier caps concurrent TTS at 5 — `--max-concurrency 4` occasionally hits 429s near the end of runs; the runner's retries absorb them.
+- **`max_steps` terminations are eval failures.** If a non-trivial fraction of tasks hit it, bump `--max-steps-seconds` from the 300s default to 480–600s. (Some gpt-5.4 conversations on airline genuinely need more time to resolve.)
+- **`semantic_vad` ignores very short user audio.** The `short-720ms` provider-suite tests fail for Inworld AND xAI because their server-side VAD doesn't trigger an end-of-turn on <~1s of audio — inherent provider sensitivity, not a code bug. Real eval traffic with multi-second utterances works fine.
 - **Task splits**: The `base` split is the default for evaluation. The `train`/`test` splits are for RL experiments.
 - **Pre-commit hook**: Runs `make check-all` (ruff lint + format). Fix any issues before committing.
 - **Notebooks**: Excluded from ruff (`*.ipynb` in pyproject.toml exclude).

--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -46,6 +46,7 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from tau2.voice.audio_native.gemini.provider import GeminiVADConfig
+    from tau2.voice.audio_native.inworld.provider import InworldVADConfig
     from tau2.voice.audio_native.livekit.config import CascadedConfig
     from tau2.voice.audio_native.nova.provider import NovaVADConfig
     from tau2.voice.audio_native.openai.provider import OpenAIVADConfig
@@ -80,7 +81,9 @@ from tau2.voice.audio_native.adapter import DiscreteTimeAdapter, create_adapter
 from tau2.voice.audio_native.tick_result import TickResult
 
 # Provider type alias
-AudioNativeProvider = Literal["openai", "gemini", "xai", "nova", "qwen", "livekit"]
+AudioNativeProvider = Literal[
+    "openai", "gemini", "xai", "nova", "qwen", "inworld", "livekit"
+]
 
 # VAD config union type (string annotations for lazy resolution)
 VADConfig = Union[
@@ -89,6 +92,7 @@ VADConfig = Union[
     "XAIVADConfig",
     "NovaVADConfig",
     "QwenVADConfig",
+    "InworldVADConfig",
 ]
 
 AUDIO_NATIVE_VOICE_INSTRUCTION = """
@@ -294,6 +298,10 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
             )
 
             self.vad_config = LiveKitVADConfig()
+        elif provider == "inworld":
+            from tau2.voice.audio_native.inworld.provider import InworldVADConfig
+
+            self.vad_config = InworldVADConfig()
         else:  # nova
             from tau2.voice.audio_native.nova.provider import NovaVADConfig
 

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -238,7 +238,7 @@ def add_run_args(parser):
     parser.add_argument(
         "--audio-native-provider",
         type=str,
-        choices=["openai", "gemini", "xai", "livekit"],
+        choices=["openai", "gemini", "xai", "nova", "qwen", "inworld", "livekit"],
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
         help=f"Audio native API provider. Default is '{DEFAULT_AUDIO_NATIVE_PROVIDER}'.",
     )

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -189,6 +189,16 @@ DEFAULT_QWEN_INPUT_SAMPLE_RATE = 16000  # fixed, API-defined
 DEFAULT_QWEN_OUTPUT_SAMPLE_RATE = 24000  # fixed, API-defined
 
 # =============================================================================
+# INWORLD PROVIDER (overridable model/voice, fixed API constants)
+# =============================================================================
+DEFAULT_INWORLD_REALTIME_URL = "wss://api.inworld.ai/api/v1/realtime/session"  # fixed
+DEFAULT_INWORLD_MODEL = "openai/gpt-4.1-mini"  # overridable LLM backbone
+DEFAULT_INWORLD_TTS_MODEL = "inworld-tts-1.5-mini"  # overridable TTS engine
+DEFAULT_INWORLD_VOICE = "Clive"  # overridable
+DEFAULT_INWORLD_EAGERNESS = "high"  # overridable: auto, low, medium, high
+DEFAULT_INWORLD_OUTPUT_SAMPLE_RATE = 24000  # fixed, API-defined (PCM16 mono)
+
+# =============================================================================
 # PROVIDER REGISTRY (derived from above)
 # =============================================================================
 DEFAULT_AUDIO_NATIVE_MODELS = {
@@ -197,6 +207,7 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
     "xai": DEFAULT_XAI_MODEL,
     "nova": DEFAULT_NOVA_MODEL,
     "qwen": DEFAULT_QWEN_MODEL,
+    "inworld": DEFAULT_INWORLD_MODEL,
     "livekit": "dummy",
 }
 
@@ -206,6 +217,7 @@ DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
     "xai": None,
     "nova": None,
     "qwen": None,
+    "inworld": None,
     "livekit": None,
 }
 
@@ -215,6 +227,7 @@ AUDIO_NATIVE_PROVIDER_TYPES = {
     "xai": "audio_native",
     "nova": "audio_native",
     "qwen": "audio_native",
+    "inworld": "audio_native",
     "livekit": "cascaded",
 }
 

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -69,9 +69,11 @@ class AudioNativeConfig(BaseModel):
     """
 
     # Provider selection
-    provider: Literal["openai", "gemini", "xai", "nova", "qwen", "livekit"] = Field(
+    provider: Literal[
+        "openai", "gemini", "xai", "nova", "qwen", "inworld", "livekit"
+    ] = Field(
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
-        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
+        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), 'inworld' (Inworld Realtime API), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
     )
 
     # Cascaded config (for livekit provider)

--- a/src/tau2/voice/README.md
+++ b/src/tau2/voice/README.md
@@ -13,6 +13,7 @@ tau2 run --domain retail --audio-native --num-tasks 1 --verbose-logs
 | OpenAI Realtime | `--audio-native-provider openai` | `OPENAI_API_KEY` |
 | Google Gemini Live | `--audio-native-provider gemini` | `GOOGLE_API_KEY` |
 | xAI Grok Voice | `--audio-native-provider xai` | `XAI_API_KEY` |
+| Inworld Realtime | `--audio-native-provider inworld` | `INWORLD_API_KEY` |
 
 The default provider is `openai`. Use `--audio-native-model` to override the default model for a provider.
 
@@ -133,6 +134,10 @@ See the [Voice Persona Setup Guide](../../docs/voice-personas.md) for step-by-st
 | `OPENAI_API_KEY` | OpenAI Realtime provider |
 | `GOOGLE_API_KEY` | Gemini Live provider |
 | `XAI_API_KEY` | xAI Grok Voice provider |
+| `INWORLD_API_KEY` | Inworld Realtime provider (base64 key from Inworld Portal) |
+| `INWORLD_MODEL` | Inworld LLM backbone override (e.g. `openai/gpt-4.1-mini`) |
+| `INWORLD_VOICE` | Inworld TTS voice override (e.g. `Clive`) |
+| `INWORLD_TTS_MODEL` | Inworld TTS engine override (e.g. `inworld-tts-1.5-mini`) |
 | `ELEVENLABS_API_KEY` | User simulator TTS (synthesis) |
 | `DEEPGRAM_API_KEY` | Transcription (Deepgram nova-2, nova-3) |
 | `TAU2_VOICE_ID_*` | Custom voice ID overrides (see [Voice Persona Setup](../../docs/voice-personas.md)) |

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -439,6 +439,17 @@ def create_adapter(
             model=model,
             reasoning_effort=reasoning_effort,
         )
+    elif provider == "inworld":
+        from tau2.voice.audio_native.inworld.discrete_time_adapter import (
+            DiscreteTimeInworldAdapter,
+        )
+
+        adapter = DiscreteTimeInworldAdapter(
+            tick_duration_ms=tick_duration_ms,
+            send_audio_instant=send_audio_instant,
+            model=model,
+            reasoning_effort=reasoning_effort,
+        )
     elif provider == "livekit":
         from tau2.voice.audio_native.livekit.config import CascadedConfig
         from tau2.voice.audio_native.livekit.discrete_time_adapter import (

--- a/src/tau2/voice/audio_native/inworld/__init__.py
+++ b/src/tau2/voice/audio_native/inworld/__init__.py
@@ -1,0 +1,1 @@
+"""Inworld Realtime API provider for tau2-bench."""

--- a/src/tau2/voice/audio_native/inworld/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/inworld/discrete_time_adapter.py
@@ -1,0 +1,384 @@
+"""Discrete-time adapter for Inworld Realtime API.
+
+Provides a tick-based interface for the Inworld Realtime API with audio
+conversion between tau2's telephony format (8 kHz μ-law) and Inworld's
+required PCM16 @ 24 kHz.
+
+Audio format notes:
+- Telephony: 8 kHz μ-law (8000 bytes/sec)
+- Inworld input/output: 24 kHz PCM16 (48000 bytes/sec)
+
+Inworld-specific behavior: on user interruption (SpeechStartedEvent) the
+adapter sends ``response.cancel`` to the server (no per-item truncate
+handshake like OpenAI requires).
+"""
+
+import asyncio
+import base64
+import json
+from typing import Any, List, Optional
+
+from loguru import logger
+
+from tau2.config import (
+    DEFAULT_AUDIO_NATIVE_CONNECT_TIMEOUT,
+    DEFAULT_AUDIO_NATIVE_DISCONNECT_TIMEOUT,
+    DEFAULT_AUDIO_NATIVE_TICK_TIMEOUT_BUFFER,
+    DEFAULT_INWORLD_OUTPUT_SAMPLE_RATE,
+)
+from tau2.data_model.message import ToolCall
+from tau2.environment.tool import Tool
+from tau2.voice.audio_native.adapter import DiscreteTimeAdapter
+from tau2.voice.audio_native.async_loop import BackgroundAsyncLoop
+from tau2.voice.audio_native.audio_converter import StreamingTelephonyConverter
+from tau2.voice.audio_native.inworld.events import (
+    InworldAudioDeltaEvent,
+    InworldAudioDoneEvent,
+    InworldAudioTranscriptDeltaEvent,
+    InworldAudioTranscriptDoneEvent,
+    InworldErrorEvent,
+    InworldFunctionCallArgumentsDoneEvent,
+    InworldInputTranscriptionCompletedEvent,
+    InworldResponseDoneEvent,
+    InworldResponseOutputItemAddedEvent,
+    InworldSpeechStartedEvent,
+    InworldSpeechStoppedEvent,
+    InworldTimeoutEvent,
+)
+from tau2.voice.audio_native.inworld.provider import (
+    InworldRealtimeProvider,
+    InworldVADConfig,
+)
+from tau2.voice.audio_native.tick_result import TickResult, UtteranceTranscript
+
+# Bytes/sec for the chunk size used when send_audio_instant=False
+INWORLD_INPUT_BYTES_PER_SECOND = DEFAULT_INWORLD_OUTPUT_SAMPLE_RATE * 2
+
+
+class DiscreteTimeInworldAdapter(DiscreteTimeAdapter):
+    """Adapter for discrete-time full-duplex simulation with Inworld Realtime API.
+
+    The orchestrator hands us telephony bytes (8 kHz μ-law); we transcode to
+    Inworld's PCM16 @ 24 kHz before sending and back to telephony on the way
+    out. ``bytes_per_tick`` stays in telephony units so the base class's
+    capping/buffering logic is unchanged.
+    """
+
+    def __init__(
+        self,
+        tick_duration_ms: int,
+        send_audio_instant: bool = False,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        provider: Optional[InworldRealtimeProvider] = None,
+        voice: Optional[str] = None,
+    ):
+        """Initialize the discrete-time Inworld adapter.
+
+        Args:
+            tick_duration_ms: Duration of each tick in milliseconds. Must be > 0.
+            send_audio_instant: If True, send audio in one call per tick.
+                If False, send in VoIP-style chunks.
+            model: LLM backbone (e.g., "openai/gpt-4.1-mini"). Defaults from
+                config / env.
+            reasoning_effort: Not supported by Inworld. Must be None.
+            provider: Optional pre-built provider instance.
+            voice: TTS voice name. Defaults from config / env.
+        """
+        if reasoning_effort is not None:
+            raise ValueError(
+                f"Inworld provider does not support reasoning_effort "
+                f"(got '{reasoning_effort}')"
+            )
+        super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
+
+        if model is not None and provider is not None:
+            raise ValueError("model and provider cannot be provided together")
+
+        self.model = model
+        self.voice = voice
+
+        # Send-side chunk size, in Inworld input bytes (PCM16 @ 24 kHz)
+        self._chunk_size = int(
+            INWORLD_INPUT_BYTES_PER_SECOND * self._voip_interval_ms / 1000
+        )
+
+        # Telephony ↔ Inworld PCM16 (24 kHz both directions)
+        self._audio_converter = StreamingTelephonyConverter(
+            input_sample_rate=DEFAULT_INWORLD_OUTPUT_SAMPLE_RATE,
+            output_sample_rate=DEFAULT_INWORLD_OUTPUT_SAMPLE_RATE,
+        )
+
+        self._provider = provider
+        self._owns_provider = provider is None
+
+        self._bg_loop = BackgroundAsyncLoop()
+        self._connected = False
+
+        # Inworld emits function-call name in response.output_item.added (under
+        # item.name) but only call_id + arguments in
+        # response.function_call_arguments.done. Cache name keyed by call_id so
+        # the .done handler can look it up.
+        self._function_call_names: dict[str, str] = {}
+
+    @property
+    def provider(self) -> InworldRealtimeProvider:
+        if self._provider is None:
+            self._provider = InworldRealtimeProvider(
+                model=self.model,
+                voice=self.voice,
+            )
+        return self._provider
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected and self._bg_loop.is_running
+
+    def connect(
+        self,
+        system_prompt: str,
+        tools: List[Tool],
+        vad_config: Any = None,
+        modality: str = "audio",
+    ) -> None:
+        if self._connected:
+            logger.warning("Already connected, disconnecting first")
+            self.disconnect()
+
+        if vad_config is None:
+            vad_config = InworldVADConfig()
+
+        self._bg_loop.start()
+
+        try:
+            self._bg_loop.run_coroutine(
+                self._async_connect(system_prompt, tools, vad_config, modality),
+                timeout=DEFAULT_AUDIO_NATIVE_CONNECT_TIMEOUT,
+            )
+            self._connected = True
+            logger.info(
+                f"DiscreteTimeInworldAdapter connected to Inworld Realtime API "
+                f"(tick={self.tick_duration_ms}ms, bytes_per_tick={self.bytes_per_tick})"
+            )
+        except Exception as e:
+            logger.error(f"DiscreteTimeInworldAdapter failed to connect: {e}")
+            self._bg_loop.stop()
+            raise RuntimeError(f"Failed to connect to Inworld Realtime API: {e}") from e
+
+    async def _async_connect(
+        self,
+        system_prompt: str,
+        tools: List[Tool],
+        vad_config: InworldVADConfig,
+        modality: str,
+    ) -> None:
+        await self.provider.connect()
+        await self.provider.configure_session(
+            system_prompt=system_prompt,
+            tools=tools,
+            vad_config=vad_config,
+            modality=modality,
+        )
+
+    def disconnect(self) -> None:
+        if not self._connected:
+            return
+
+        if self._bg_loop.is_running:
+            try:
+                self._bg_loop.run_coroutine(
+                    self._async_disconnect(),
+                    timeout=DEFAULT_AUDIO_NATIVE_DISCONNECT_TIMEOUT,
+                )
+            except Exception as e:
+                logger.warning(f"Error during disconnect: {e}")
+
+        self._bg_loop.stop()
+        self._connected = False
+        self._tick_count = 0
+        self._cumulative_user_audio_ms = 0
+        self.clear_buffers()
+        self._audio_converter.reset()
+        self._function_call_names.clear()
+        logger.info("DiscreteTimeInworldAdapter disconnected")
+
+    async def _async_disconnect(self) -> None:
+        if self._owns_provider and self._provider is not None:
+            await self.provider.disconnect()
+
+    def run_tick(
+        self, user_audio: bytes, tick_number: Optional[int] = None
+    ) -> TickResult:
+        if not self.is_connected:
+            raise RuntimeError(
+                "Not connected to Inworld Realtime API. Call connect() first."
+            )
+
+        if tick_number is None:
+            tick_number = self._tick_count
+        self._tick_count = tick_number + 1
+
+        try:
+            return self._bg_loop.run_coroutine(
+                self._async_run_tick(user_audio, tick_number),
+                timeout=self.tick_duration_ms / 1000
+                + DEFAULT_AUDIO_NATIVE_TICK_TIMEOUT_BUFFER,
+            )
+        except Exception as e:
+            logger.error(f"Error in run_tick (tick={tick_number}): {e}")
+            raise
+
+    async def _flush_pending_tool_results(self) -> None:
+        for (
+            call_id,
+            result_str,
+            request_response,
+            _is_error,
+        ) in self._pending_tool_results:
+            await self.provider.send_tool_result(call_id, result_str, request_response)
+        self._pending_tool_results.clear()
+
+    async def _execute_tick(
+        self,
+        user_audio: bytes,
+        tick_number: int,
+        result: TickResult,
+        tick_start: float,
+    ) -> None:
+        """Inworld-specific: convert audio, send, receive events, process."""
+        inworld_audio = self._audio_converter.convert_input(user_audio)
+
+        async def receive_events():
+            elapsed_so_far = asyncio.get_running_loop().time() - tick_start
+            remaining = max(0.01, (self.tick_duration_ms / 1000) - elapsed_so_far)
+            return await self.provider.receive_events_for_duration(remaining)
+
+        _, events = await asyncio.gather(
+            self._send_audio_chunked(
+                inworld_audio, self.provider.send_audio, self._chunk_size
+            ),
+            receive_events(),
+        )
+
+        for event in events:
+            await self._process_event(result, event)
+
+    async def _process_event(self, result: TickResult, event: Any) -> None:
+        """Process an Inworld Realtime event."""
+        result.events.append(event)
+
+        if isinstance(event, InworldAudioDeltaEvent):
+            item_id = event.item_id or self._current_item_id
+
+            # Skip audio from a truncated item, but still account for the
+            # discarded bytes in telephony units.
+            if result.skip_item_id is not None and item_id == result.skip_item_id:
+                if event.delta:
+                    inworld_bytes = base64.b64decode(event.delta)
+                    telephony_bytes = self._audio_converter.convert_output(
+                        inworld_bytes
+                    )
+                    result.truncated_audio_bytes += len(telephony_bytes)
+                return
+
+            if event.delta:
+                inworld_bytes = base64.b64decode(event.delta)
+                telephony_bytes = self._audio_converter.convert_output(inworld_bytes)
+                if telephony_bytes:
+                    result.agent_audio_chunks.append((telephony_bytes, item_id))
+
+                if item_id:
+                    self._current_item_id = item_id
+                    if item_id not in self._utterance_transcripts:
+                        self._utterance_transcripts[item_id] = UtteranceTranscript(
+                            item_id=item_id
+                        )
+                    self._utterance_transcripts[item_id].add_audio(len(telephony_bytes))
+
+        elif isinstance(event, InworldAudioTranscriptDeltaEvent):
+            item_id = event.item_id or self._current_item_id
+            if item_id and event.delta:
+                if item_id not in self._utterance_transcripts:
+                    self._utterance_transcripts[item_id] = UtteranceTranscript(
+                        item_id=item_id
+                    )
+                self._utterance_transcripts[item_id].add_transcript(event.delta)
+
+        elif isinstance(event, InworldSpeechStartedEvent):
+            logger.debug("Inworld VAD: speech started — interruption")
+            result.vad_events.append("speech_started")
+
+            # Clear any audio buffered for the next tick.
+            if self._buffered_agent_audio:
+                buffered_bytes = sum(len(c[0]) for c in self._buffered_agent_audio)
+                result.truncated_audio_bytes += buffered_bytes
+                self._buffered_agent_audio.clear()
+
+            # Reset converter state so any subsequent audio decodes cleanly.
+            self._audio_converter.reset()
+
+            result.was_truncated = True
+            result.skip_item_id = self._current_item_id
+
+            # Inworld's `interrupt_response: True` makes the server auto-cancel
+            # on speech_started, but sending response.cancel here is harmless
+            # and ensures any in-flight response stops if interrupt_response
+            # is later disabled.
+            try:
+                await self.provider.cancel_response()
+            except Exception as e:
+                logger.debug(f"Inworld response.cancel failed (non-fatal): {e}")
+
+        elif isinstance(event, InworldSpeechStoppedEvent):
+            logger.debug("Inworld VAD: speech stopped")
+            result.vad_events.append("speech_stopped")
+
+        elif isinstance(event, InworldResponseOutputItemAddedEvent):
+            # Inworld puts function-call name here; the .done event only has
+            # call_id + arguments. Cache name keyed by call_id for later lookup.
+            item = event.item or {}
+            if item.get("type") == "function_call":
+                call_id = item.get("call_id")
+                name = item.get("name")
+                if call_id and name:
+                    self._function_call_names[call_id] = name
+
+        elif isinstance(event, InworldFunctionCallArgumentsDoneEvent):
+            try:
+                arguments = json.loads(event.arguments) if event.arguments else {}
+            except json.JSONDecodeError:
+                arguments = {}
+
+            call_id = event.call_id or ""
+            # Resolve name: prefer the event field, fall back to cached name
+            # from the output_item.added event (Inworld's normal path).
+            name = event.name or self._function_call_names.get(call_id, "")
+
+            tool_call = ToolCall(
+                id=call_id,
+                name=name,
+                arguments=arguments,
+            )
+            result.tool_calls.append(tool_call)
+            logger.debug(f"Tool call detected: {name}({call_id})")
+
+        elif isinstance(event, InworldInputTranscriptionCompletedEvent):
+            logger.debug(f"Input transcription: {event.transcript}")
+
+        elif isinstance(event, InworldResponseDoneEvent):
+            logger.debug("Response done (turn complete)")
+
+        elif isinstance(event, InworldAudioDoneEvent):
+            logger.debug(f"Audio done for item {event.item_id}")
+
+        elif isinstance(event, InworldAudioTranscriptDoneEvent):
+            logger.debug(f"Transcript done for item {event.item_id}")
+
+        elif isinstance(event, InworldErrorEvent):
+            logger.error(f"Inworld error: {event.message or event.error}")
+
+        elif isinstance(event, InworldTimeoutEvent):
+            pass
+
+        else:
+            logger.debug(f"Event {type(event).__name__} received")

--- a/src/tau2/voice/audio_native/inworld/events.py
+++ b/src/tau2/voice/audio_native/inworld/events.py
@@ -1,0 +1,397 @@
+"""Pydantic models for Inworld Realtime API events.
+
+Inworld's Realtime API uses a WebSocket protocol that's OpenAI-Realtime compatible.
+Confirmed event names (via live probe against api.inworld.ai):
+- Audio output: response.output_audio.delta / response.output_audio.done
+- Audio transcript: response.output_audio_transcript.delta / .done
+- Input transcription: conversation.item.input_audio_transcription.completed
+- Function calls: response.function_call_arguments.delta / .done
+- VAD: input_audio_buffer.speech_started / .speech_stopped
+- Turn completion: response.done
+
+Reference: https://docs.inworld.ai/api-reference/realtimeAPI/realtime/realtime-websocket
+"""
+
+from typing import Any, Dict, Literal, Optional, Union
+
+from loguru import logger
+from pydantic import BaseModel, Field
+
+
+class BaseInworldEvent(BaseModel):
+    """Base class for all Inworld Realtime API events."""
+
+    type: str
+    event_id: Optional[str] = None
+
+
+# =============================================================================
+# Session Events
+# =============================================================================
+
+
+class InworldSessionCreatedEvent(BaseInworldEvent):
+    """First message at connection — session created."""
+
+    type: Literal["session.created"] = "session.created"
+    session: Optional[Dict[str, Any]] = None
+
+
+class InworldSessionUpdatedEvent(BaseInworldEvent):
+    """Session configuration has been updated."""
+
+    type: Literal["session.updated"] = "session.updated"
+    session: Optional[Dict[str, Any]] = None
+
+
+# =============================================================================
+# Input Audio Buffer Events (VAD)
+# =============================================================================
+
+
+class InworldSpeechStartedEvent(BaseInworldEvent):
+    """Server VAD detected start of speech (used for barge-in)."""
+
+    type: Literal["input_audio_buffer.speech_started"] = (
+        "input_audio_buffer.speech_started"
+    )
+    item_id: Optional[str] = None
+    audio_start_ms: Optional[int] = None
+
+
+class InworldSpeechStoppedEvent(BaseInworldEvent):
+    """Server VAD detected end of speech."""
+
+    type: Literal["input_audio_buffer.speech_stopped"] = (
+        "input_audio_buffer.speech_stopped"
+    )
+    item_id: Optional[str] = None
+    audio_end_ms: Optional[int] = None
+
+
+class InworldInputAudioBufferCommittedEvent(BaseInworldEvent):
+    """Input audio buffer has been committed."""
+
+    type: Literal["input_audio_buffer.committed"] = "input_audio_buffer.committed"
+    previous_item_id: Optional[str] = None
+    item_id: Optional[str] = None
+
+
+class InworldInputAudioBufferClearedEvent(BaseInworldEvent):
+    """Input audio buffer has been cleared."""
+
+    type: Literal["input_audio_buffer.cleared"] = "input_audio_buffer.cleared"
+
+
+# =============================================================================
+# Conversation Item Events
+# =============================================================================
+
+
+class InworldConversationItemAddedEvent(BaseInworldEvent):
+    """A new item has been added to conversation history."""
+
+    type: Literal["conversation.item.added"] = "conversation.item.added"
+    previous_item_id: Optional[str] = None
+    item: Optional[Dict[str, Any]] = None
+
+
+class InworldConversationItemDoneEvent(BaseInworldEvent):
+    """A conversation item has completed."""
+
+    type: Literal["conversation.item.done"] = "conversation.item.done"
+    previous_item_id: Optional[str] = None
+    item: Optional[Dict[str, Any]] = None
+
+
+class InworldInputTranscriptionCompletedEvent(BaseInworldEvent):
+    """Transcription of user's audio input is complete."""
+
+    type: Literal["conversation.item.input_audio_transcription.completed"] = (
+        "conversation.item.input_audio_transcription.completed"
+    )
+    item_id: Optional[str] = None
+    transcript: str = ""
+
+
+# =============================================================================
+# Response Events
+# =============================================================================
+
+
+class InworldResponseCreatedEvent(BaseInworldEvent):
+    """A new assistant response turn is in progress."""
+
+    type: Literal["response.created"] = "response.created"
+    response: Optional[Dict[str, Any]] = None
+
+
+class InworldResponseOutputItemAddedEvent(BaseInworldEvent):
+    """A new assistant response item is added to message history."""
+
+    type: Literal["response.output_item.added"] = "response.output_item.added"
+    response_id: Optional[str] = None
+    output_index: Optional[int] = None
+    item: Optional[Dict[str, Any]] = None
+
+
+class InworldResponseOutputItemDoneEvent(BaseInworldEvent):
+    """Response output item is complete."""
+
+    type: Literal["response.output_item.done"] = "response.output_item.done"
+    response_id: Optional[str] = None
+    output_index: Optional[int] = None
+    item: Optional[Dict[str, Any]] = None
+
+
+class InworldResponseContentPartAddedEvent(BaseInworldEvent):
+    """Content part added to response."""
+
+    type: Literal["response.content_part.added"] = "response.content_part.added"
+    item_id: Optional[str] = None
+    response_id: Optional[str] = None
+    content_index: Optional[int] = None
+    output_index: Optional[int] = None
+    part: Optional[Dict[str, Any]] = None
+
+
+class InworldResponseContentPartDoneEvent(BaseInworldEvent):
+    """Content part is complete."""
+
+    type: Literal["response.content_part.done"] = "response.content_part.done"
+    item_id: Optional[str] = None
+    response_id: Optional[str] = None
+    content_index: Optional[int] = None
+    output_index: Optional[int] = None
+    part: Optional[Dict[str, Any]] = None
+
+
+class InworldResponseDoneEvent(BaseInworldEvent):
+    """Assistant's response is completed (turn complete)."""
+
+    type: Literal["response.done"] = "response.done"
+    response: Optional[Dict[str, Any]] = None
+
+
+# =============================================================================
+# Audio Output Events
+# =============================================================================
+
+
+class InworldAudioDeltaEvent(BaseInworldEvent):
+    """Audio chunk received from the model.
+
+    Audio is base64-encoded PCM16 at 24 kHz.
+    """
+
+    type: Literal["response.output_audio.delta"] = "response.output_audio.delta"
+    delta: str = Field(
+        default="",
+        description="Base64-encoded audio delta (PCM16 @ 24 kHz)",
+        exclude=True,  # Exclude from serialization due to large size
+    )
+    response_id: Optional[str] = None
+    item_id: Optional[str] = None
+    output_index: Optional[int] = None
+    content_index: Optional[int] = None
+
+
+class InworldAudioDoneEvent(BaseInworldEvent):
+    """Audio stream completed for current response."""
+
+    type: Literal["response.output_audio.done"] = "response.output_audio.done"
+    response_id: Optional[str] = None
+    item_id: Optional[str] = None
+    output_index: Optional[int] = None
+    content_index: Optional[int] = None
+
+
+# =============================================================================
+# Audio Transcript Events (Model's speech transcription)
+# =============================================================================
+
+
+class InworldAudioTranscriptDeltaEvent(BaseInworldEvent):
+    """Transcript delta of the assistant's audio response."""
+
+    type: Literal["response.output_audio_transcript.delta"] = (
+        "response.output_audio_transcript.delta"
+    )
+    delta: str = ""
+    response_id: Optional[str] = None
+    item_id: Optional[str] = None
+    output_index: Optional[int] = None
+    content_index: Optional[int] = None
+
+
+class InworldAudioTranscriptDoneEvent(BaseInworldEvent):
+    """Audio transcript of assistant response is complete."""
+
+    type: Literal["response.output_audio_transcript.done"] = (
+        "response.output_audio_transcript.done"
+    )
+    response_id: Optional[str] = None
+    item_id: Optional[str] = None
+    transcript: str = ""
+
+
+# Inworld also emits response.output_text.* events alongside audio. We model
+# them so they parse cleanly, but the adapter ignores them (the audio
+# transcript is the source of truth for what the model said).
+class InworldOutputTextDeltaEvent(BaseInworldEvent):
+    type: Literal["response.output_text.delta"] = "response.output_text.delta"
+    delta: str = ""
+    response_id: Optional[str] = None
+    item_id: Optional[str] = None
+
+
+class InworldOutputTextDoneEvent(BaseInworldEvent):
+    type: Literal["response.output_text.done"] = "response.output_text.done"
+    text: str = ""
+    response_id: Optional[str] = None
+    item_id: Optional[str] = None
+
+
+# =============================================================================
+# Function Call Events
+# =============================================================================
+
+
+class InworldFunctionCallArgumentsDeltaEvent(BaseInworldEvent):
+    """Function call arguments delta (streaming)."""
+
+    type: Literal["response.function_call_arguments.delta"] = (
+        "response.function_call_arguments.delta"
+    )
+    delta: str = ""
+    call_id: Optional[str] = None
+    name: Optional[str] = None
+    response_id: Optional[str] = None
+    item_id: Optional[str] = None
+
+
+class InworldFunctionCallArgumentsDoneEvent(BaseInworldEvent):
+    """Function call arguments are complete."""
+
+    type: Literal["response.function_call_arguments.done"] = (
+        "response.function_call_arguments.done"
+    )
+    call_id: Optional[str] = None
+    name: Optional[str] = None
+    arguments: str = "{}"
+    response_id: Optional[str] = None
+    item_id: Optional[str] = None
+
+
+# =============================================================================
+# Error and Utility Events
+# =============================================================================
+
+
+class InworldErrorEvent(BaseInworldEvent):
+    """Error from the Inworld API."""
+
+    type: Literal["error"] = "error"
+    error: Optional[Dict[str, Any]] = None
+    code: Optional[str] = None
+    message: Optional[str] = None
+
+
+class InworldTimeoutEvent(BaseInworldEvent):
+    """Timeout waiting for events (used internally)."""
+
+    type: Literal["timeout"] = "timeout"
+
+
+class InworldUnknownEvent(BaseInworldEvent):
+    """Unknown/unrecognized event type."""
+
+    type: str = "unknown"
+    raw: Optional[Dict[str, Any]] = None
+
+
+# =============================================================================
+# Type Aliases
+# =============================================================================
+
+InworldEvent = Union[
+    InworldSessionCreatedEvent,
+    InworldSessionUpdatedEvent,
+    InworldSpeechStartedEvent,
+    InworldSpeechStoppedEvent,
+    InworldInputAudioBufferCommittedEvent,
+    InworldInputAudioBufferClearedEvent,
+    InworldConversationItemAddedEvent,
+    InworldConversationItemDoneEvent,
+    InworldInputTranscriptionCompletedEvent,
+    InworldResponseCreatedEvent,
+    InworldResponseOutputItemAddedEvent,
+    InworldResponseOutputItemDoneEvent,
+    InworldResponseContentPartAddedEvent,
+    InworldResponseContentPartDoneEvent,
+    InworldResponseDoneEvent,
+    InworldAudioDeltaEvent,
+    InworldAudioDoneEvent,
+    InworldAudioTranscriptDeltaEvent,
+    InworldAudioTranscriptDoneEvent,
+    InworldOutputTextDeltaEvent,
+    InworldOutputTextDoneEvent,
+    InworldFunctionCallArgumentsDeltaEvent,
+    InworldFunctionCallArgumentsDoneEvent,
+    InworldErrorEvent,
+    InworldTimeoutEvent,
+    InworldUnknownEvent,
+]
+
+
+# =============================================================================
+# Event Parsing
+# =============================================================================
+
+_EVENT_TYPE_MAP: Dict[str, type[BaseInworldEvent]] = {
+    "session.created": InworldSessionCreatedEvent,
+    "session.updated": InworldSessionUpdatedEvent,
+    "input_audio_buffer.speech_started": InworldSpeechStartedEvent,
+    "input_audio_buffer.speech_stopped": InworldSpeechStoppedEvent,
+    "input_audio_buffer.committed": InworldInputAudioBufferCommittedEvent,
+    "input_audio_buffer.cleared": InworldInputAudioBufferClearedEvent,
+    "conversation.item.added": InworldConversationItemAddedEvent,
+    "conversation.item.done": InworldConversationItemDoneEvent,
+    "conversation.item.input_audio_transcription.completed": InworldInputTranscriptionCompletedEvent,
+    "response.created": InworldResponseCreatedEvent,
+    "response.output_item.added": InworldResponseOutputItemAddedEvent,
+    "response.output_item.done": InworldResponseOutputItemDoneEvent,
+    "response.content_part.added": InworldResponseContentPartAddedEvent,
+    "response.content_part.done": InworldResponseContentPartDoneEvent,
+    "response.done": InworldResponseDoneEvent,
+    "response.output_audio.delta": InworldAudioDeltaEvent,
+    "response.output_audio.done": InworldAudioDoneEvent,
+    "response.output_audio_transcript.delta": InworldAudioTranscriptDeltaEvent,
+    "response.output_audio_transcript.done": InworldAudioTranscriptDoneEvent,
+    "response.output_text.delta": InworldOutputTextDeltaEvent,
+    "response.output_text.done": InworldOutputTextDoneEvent,
+    "response.function_call_arguments.delta": InworldFunctionCallArgumentsDeltaEvent,
+    "response.function_call_arguments.done": InworldFunctionCallArgumentsDoneEvent,
+    "error": InworldErrorEvent,
+}
+
+
+def parse_inworld_event(data: Dict[str, Any]) -> InworldEvent:
+    """Parse a raw Inworld WebSocket message into a typed event."""
+    event_type = data.get("type", "unknown")
+
+    log_data = data.copy()
+    if "delta" in log_data and event_type == "response.output_audio.delta":
+        delta = log_data.get("delta", "")
+        log_data["delta"] = f"<{len(delta)} base64 chars>"
+    logger.debug(f"Inworld event: {event_type} - {log_data}")
+
+    event_class = _EVENT_TYPE_MAP.get(event_type)
+    if event_class:
+        try:
+            return event_class(**data)
+        except Exception as e:
+            logger.warning(f"Failed to parse Inworld event {event_type}: {e}")
+            return InworldUnknownEvent(type=event_type, raw=data)
+    logger.debug(f"Unknown Inworld event type: {event_type}")
+    return InworldUnknownEvent(type=event_type, raw=data)

--- a/src/tau2/voice/audio_native/inworld/provider.py
+++ b/src/tau2/voice/audio_native/inworld/provider.py
@@ -1,0 +1,354 @@
+"""Inworld Realtime API provider for real-time voice processing.
+
+Uses WebSocket for bidirectional audio streaming with the Inworld Realtime API.
+The wire protocol is OpenAI-Realtime-compatible with three notable differences:
+
+1. **Auth:** ``Authorization: Basic <api_key>`` (the key is already base64-encoded
+   from the Inworld Portal; do NOT base64-encode it again).
+2. **URL:** ``wss://api.inworld.ai/api/v1/realtime/session`` with required query
+   params ``key=voice-<timestamp_ms>`` and ``protocol=realtime``.
+3. **Audio:** PCM16 at 24 kHz only. ``audio/pcmu`` requests are silently
+   coerced to PCM. Conversion from telephony μ-law is done by the adapter.
+
+Session config places audio settings under nested input/output objects, with
+``semantic_vad`` turn detection (``eagerness``) and TTS engine + voice
+selected under ``audio.output``.
+
+Reference: https://docs.inworld.ai/api-reference/realtimeAPI/realtime/realtime-websocket
+"""
+
+import asyncio
+import base64
+import json
+import os
+import time
+from enum import Enum
+from typing import AsyncGenerator, Dict, List, Optional
+
+import websockets
+from dotenv import load_dotenv
+from loguru import logger
+from pydantic import BaseModel
+
+from tau2.config import (
+    DEFAULT_INWORLD_EAGERNESS,
+    DEFAULT_INWORLD_MODEL,
+    DEFAULT_INWORLD_OUTPUT_SAMPLE_RATE,
+    DEFAULT_INWORLD_REALTIME_URL,
+    DEFAULT_INWORLD_TTS_MODEL,
+    DEFAULT_INWORLD_VOICE,
+)
+from tau2.environment.tool import Tool
+from tau2.utils.retry import websocket_retry
+from tau2.voice.audio_native.inworld.events import (
+    BaseInworldEvent,
+    InworldTimeoutEvent,
+    InworldUnknownEvent,
+    parse_inworld_event,
+)
+
+load_dotenv()
+
+# Inworld output format (PCM16 mono @ 24 kHz) — 48000 bytes/sec
+INWORLD_OUTPUT_BYTES_PER_SECOND = DEFAULT_INWORLD_OUTPUT_SAMPLE_RATE * 2
+
+
+class InworldEagerness(str, Enum):
+    """Semantic VAD eagerness levels for Inworld Realtime API."""
+
+    AUTO = "auto"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class InworldVADConfig(BaseModel):
+    """Configuration for Inworld's semantic Voice Activity Detection.
+
+    Attributes:
+        eagerness: How aggressively the server detects end-of-turn. Higher
+            eagerness → faster turn-taking but more interruptions.
+        create_response: Auto-create a response when VAD detects end-of-turn.
+        interrupt_response: Allow user audio to interrupt agent response.
+    """
+
+    eagerness: InworldEagerness = InworldEagerness.HIGH
+    create_response: bool = True
+    interrupt_response: bool = True
+
+
+class InworldRealtimeProvider:
+    """Inworld Realtime API provider with WebSocket-based communication.
+
+    This provider manages a persistent WebSocket connection to Inworld's
+    Realtime API, enabling real-time bidirectional voice agent interaction.
+
+    Attributes:
+        api_key: The Inworld API key (already base64-encoded from the portal).
+        model: LLM backbone identifier (e.g., ``openai/gpt-4.1-mini``).
+        voice: TTS voice name (e.g., ``Clive``).
+        tts_model: TTS engine (e.g., ``inworld-tts-1.5-mini``).
+        ws: The active WebSocket connection, or None if disconnected.
+    """
+
+    BASE_URL = DEFAULT_INWORLD_REALTIME_URL
+    DEFAULT_MODEL = DEFAULT_INWORLD_MODEL
+    DEFAULT_VOICE = DEFAULT_INWORLD_VOICE
+    DEFAULT_TTS_MODEL = DEFAULT_INWORLD_TTS_MODEL
+    DEFAULT_EAGERNESS = DEFAULT_INWORLD_EAGERNESS
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        voice: Optional[str] = None,
+        tts_model: Optional[str] = None,
+        sample_rate: int = DEFAULT_INWORLD_OUTPUT_SAMPLE_RATE,
+    ):
+        """Initialize the Inworld Realtime provider.
+
+        Args:
+            api_key: Inworld API key. If not provided, reads ``INWORLD_API_KEY``
+                from the environment.
+            model: LLM backbone (e.g., ``openai/gpt-4.1-mini``). Reads
+                ``INWORLD_MODEL`` env var if not provided.
+            voice: TTS voice name. Reads ``INWORLD_VOICE`` env var if not
+                provided.
+            tts_model: TTS engine name. Reads ``INWORLD_TTS_MODEL`` env var if
+                not provided.
+            sample_rate: PCM sample rate (24000 — Inworld's only supported
+                rate at present).
+
+        Raises:
+            ValueError: If no API key is provided or found in environment.
+        """
+        self.api_key = api_key or os.environ.get("INWORLD_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Inworld API key not provided. Set INWORLD_API_KEY env var."
+            )
+
+        self.model = model or os.environ.get("INWORLD_MODEL") or self.DEFAULT_MODEL
+        self.voice = voice or os.environ.get("INWORLD_VOICE") or self.DEFAULT_VOICE
+        self.tts_model = (
+            tts_model or os.environ.get("INWORLD_TTS_MODEL") or self.DEFAULT_TTS_MODEL
+        )
+        self.sample_rate = sample_rate
+        self.ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._current_vad_config: Optional[InworldVADConfig] = None
+        self.session_id: Optional[str] = None
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if the WebSocket connection is active."""
+        if self.ws is None:
+            return False
+        from websockets.protocol import State
+
+        return self.ws.state == State.OPEN
+
+    @websocket_retry
+    async def connect(self) -> None:
+        """Establish a WebSocket connection to the Inworld Realtime API.
+
+        Raises:
+            RuntimeError: If the initial handshake fails.
+        """
+        if self.is_connected:
+            return
+
+        headers = {"Authorization": f"Basic {self.api_key}"}
+        url = f"{self.BASE_URL}?key=voice-{int(time.time() * 1000)}&protocol=realtime"
+
+        logger.info(f"Inworld Realtime API: Connecting to {self.BASE_URL}")
+        self.ws = await websockets.connect(url, additional_headers=headers)
+
+        # Wait for session.created event
+        response = await self.ws.recv()
+        data = json.loads(response)
+        if data.get("type") != "session.created":
+            raise RuntimeError(f"Expected session.created, got {data.get('type')}")
+
+        session = data.get("session", {})
+        self.session_id = session.get("id") or data.get("event_id")
+        logger.info(f"Inworld Realtime API: Connected (session_id={self.session_id})")
+
+    async def disconnect(self) -> None:
+        """Close the WebSocket connection."""
+        if self.ws:
+            logger.info("Inworld Realtime API: Disconnecting")
+            await self.ws.close()
+            self.ws = None
+            logger.info("Inworld Realtime API: Disconnected")
+
+    def _format_tools_for_api(self, tools: List[Tool]) -> List[Dict]:
+        """Format tools for the Inworld API (OpenAI-compatible schema)."""
+        formatted_tools = []
+        for tool in tools:
+            schema = tool.openai_schema
+            formatted_tools.append(
+                {
+                    "type": "function",
+                    "name": schema["function"]["name"],
+                    "description": schema["function"]["description"],
+                    "parameters": schema["function"]["parameters"],
+                }
+            )
+        return formatted_tools
+
+    def _build_turn_detection_config(self, vad_config: InworldVADConfig) -> Dict:
+        """Build the semantic VAD turn-detection config."""
+        return {
+            "type": "semantic_vad",
+            "eagerness": vad_config.eagerness.value
+            if hasattr(vad_config.eagerness, "value")
+            else vad_config.eagerness,
+            "create_response": vad_config.create_response,
+            "interrupt_response": vad_config.interrupt_response,
+        }
+
+    async def configure_session(
+        self,
+        system_prompt: str,
+        tools: List[Tool],
+        vad_config: InworldVADConfig,
+        modality: str = "audio",
+    ) -> None:
+        """Configure the realtime session with instructions, tools, and audio.
+
+        Args:
+            system_prompt: The system instructions for the assistant.
+            tools: List of tools available for the assistant to use.
+            vad_config: Voice Activity Detection configuration.
+            modality: "audio" or "text" (Inworld only supports audio in practice).
+
+        Raises:
+            RuntimeError: If not connected or if session configuration fails.
+        """
+        if not self.is_connected:
+            raise RuntimeError("Not connected to API. Call connect() first.")
+
+        if modality == "audio":
+            output_modalities = ["audio"]
+        elif modality == "text":
+            output_modalities = ["text"]
+        else:
+            output_modalities = ["audio"]
+
+        session_config = {
+            "type": "session.update",
+            "session": {
+                "type": "realtime",
+                "model": self.model,
+                "instructions": system_prompt,
+                "output_modalities": output_modalities,
+                "audio": {
+                    "input": {
+                        "format": {
+                            "type": "audio/pcm",
+                            "rate": self.sample_rate,
+                        },
+                        "turn_detection": self._build_turn_detection_config(vad_config),
+                    },
+                    "output": {
+                        "format": {
+                            "type": "audio/pcm",
+                            "rate": self.sample_rate,
+                        },
+                        "model": self.tts_model,
+                        "voice": self.voice,
+                    },
+                },
+                "tools": self._format_tools_for_api(tools),
+            },
+        }
+
+        logger.debug(f"Inworld session config: {json.dumps(session_config, indent=2)}")
+        await self.ws.send(json.dumps(session_config))
+
+        while True:
+            response = await self.ws.recv()
+            data = json.loads(response)
+            event_type = data.get("type", "")
+            if event_type == "session.updated":
+                self._current_vad_config = vad_config
+                logger.info("Inworld Realtime API: Session configured")
+                return
+            if event_type == "error":
+                error = data.get("error", {})
+                error_msg = error.get("message", str(error))
+                raise RuntimeError(f"Session configuration failed: {error_msg}")
+
+    async def send_audio(self, audio_data: bytes) -> None:
+        """Append PCM16 audio bytes to the input audio buffer (base64-encoded)."""
+        if not self.is_connected:
+            raise RuntimeError("Not connected to API")
+        audio_b64 = base64.b64encode(audio_data).decode("utf-8")
+        await self.ws.send(
+            json.dumps({"type": "input_audio_buffer.append", "audio": audio_b64})
+        )
+
+    async def cancel_response(self) -> None:
+        """Cancel the in-flight assistant response (used for barge-in)."""
+        if not self.is_connected:
+            return
+        await self.ws.send(json.dumps({"type": "response.cancel"}))
+
+    async def send_tool_result(
+        self, call_id: str, result: str, request_response: bool = True
+    ) -> None:
+        """Send a tool result and optionally request a continuation."""
+        if not self.is_connected:
+            raise RuntimeError("Not connected to API")
+
+        item_create = {
+            "type": "conversation.item.create",
+            "item": {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": result,
+            },
+        }
+        await self.ws.send(json.dumps(item_create))
+
+        if request_response:
+            await self.ws.send(json.dumps({"type": "response.create"}))
+
+    async def receive_events(self) -> AsyncGenerator[BaseInworldEvent, None]:
+        """Receive and yield events from the WebSocket connection."""
+        if not self.is_connected:
+            raise RuntimeError("Not connected to API")
+
+        while self.is_connected:
+            try:
+                raw_message = await asyncio.wait_for(self.ws.recv(), timeout=0.01)
+                data = json.loads(raw_message)
+                yield parse_inworld_event(data)
+            except asyncio.TimeoutError:
+                yield InworldTimeoutEvent(type="timeout")
+            except websockets.ConnectionClosed as e:
+                logger.error(
+                    f"Inworld Realtime API: WebSocket closed "
+                    f"(code={e.code}, reason='{e.reason or 'no reason'}')"
+                )
+                raise RuntimeError(
+                    f"WebSocket connection closed unexpectedly "
+                    f"(code={e.code}, reason='{e.reason or 'no reason'}')"
+                ) from e
+            except Exception as e:
+                logger.error(f"Inworld Realtime API: Error receiving event: {e}")
+                yield InworldUnknownEvent(type="error", raw={"error": str(e)})
+
+    async def receive_events_for_duration(
+        self, duration_seconds: float
+    ) -> List[BaseInworldEvent]:
+        """Receive events for the specified duration (tick-based polling)."""
+        events: List[BaseInworldEvent] = []
+        end_time = asyncio.get_event_loop().time() + duration_seconds
+
+        async for event in self.receive_events():
+            if not isinstance(event, InworldTimeoutEvent):
+                events.append(event)
+            if asyncio.get_event_loop().time() >= end_time:
+                break
+        return events

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -125,6 +125,13 @@ PROVIDERS = [
             reason="XAI_API_KEY not set",
         ),
     ),
+    pytest.param(
+        "inworld",
+        marks=pytest.mark.skipif(
+            not os.environ.get("INWORLD_API_KEY"),
+            reason="INWORLD_API_KEY not set",
+        ),
+    ),
 ]
 
 SYSTEM_PROMPT = "You are a helpful assistant. Keep responses brief."


### PR DESCRIPTION
Adds Inworld Realtime API as a seventh audio-native provider alongside openai/gemini/xai/nova/qwen/livekit, runnable end-to-end via `tau2 run --audio-native --audio-native-provider inworld`.

Implementation in src/tau2/voice/audio_native/inworld/:
- provider.py: OpenAI-Realtime-compatible WebSocket client with Basic auth, semantic_vad turn detection, configurable LLM backbone + TTS engine + voice via env vars.
- events.py: Pydantic models for all observed event types plus a parse_inworld_event() dispatcher.
- discrete_time_adapter.py: handles telephony<->PCM16 24 kHz conversion, caches function-call name from response.output_item.added (Inworld puts it there, not on the .done event), and barge-in via response.cancel.

Wire-up: config defaults, CLI choices, factory branch, agent default VAD config, AudioNativeProvider Literal, VADConfig Union, and the parametrized provider test suite.

AGENTS.md expanded with pyenv/uv shim troubleshooting, complete API key expectations (Inworld/Gemini/xAI/Anthropic), Inworld provider quirks, and voice eval timing/quota gotchas.

Validated:
- Full provider test suite: 8/11 passing (the 3 fails are inherent VAD sensitivity on <1s audio, same pattern xAI exhibits, plus one model nondeterminism flake).
- Two 50-task airline benchmarks: 40.0% Pass^1 with default openai/gpt-4.1-mini + inworld-tts-1.5-mini, 52.0% Pass^1 with gpt-5.4
  + inworld-tts-2 + Sarah. Zero hallucinations flagged by the reviewer in either run.