### PR TITLE
docs: clarify that EvaluationCriteria.actions is a reference trajectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Results are saved to `data/simulations/`. Use `tau2 view` to browse them.
 | [Agent Developer Guide](src/tau2/agent/README.md) | Build and evaluate your own agent |
 | [Domains](src/tau2/domains/README.md) | Domain structure, data format, and available domains |
 | [Orchestrator & Communication Modes](src/tau2/orchestrator/README.md) | Half-duplex and full-duplex orchestration |
+| [Task Schema & Evaluation](docs/evaluation.md) | What `evaluation_criteria.actions` means, how `reward_basis` gates the reward, and how to inspect action correctness |
 
 ### Knowledge Retrieval
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,196 @@
+# Task Schema and Evaluation
+
+This page explains how a task is scored in τ-bench and — most importantly —
+**what `evaluation_criteria.actions` actually does**. If you have looked at
+`data/tau2/domains/airline/tasks.json` and assumed those listed actions are
+required of the agent, this page is for you.
+
+## TL;DR
+
+- A task's final reward is the **product** of the components listed in
+  `evaluation_criteria.reward_basis`.
+- The default `reward_basis` for the airline, retail, and telecom domains
+  is `["DB", "COMMUNICATE"]` — matching the original τ-bench paper.
+- `evaluation_criteria.actions` is **one reference trajectory** that
+  solves the task — not the only correct one. It is replayed on a fresh
+  "gold" environment to derive a target DB end state, which is then
+  compared (by hash) to the predicted environment's DB end state. The
+  agent is **not** required to take this specific path; any sequence of
+  tool calls that produces an equivalent DB end state passes the DB
+  check.
+- The agent is required to match `actions` *only* when `RewardType.ACTION`
+  is in `reward_basis` (used in a small subset of `banking_knowledge`
+  tasks; **not used at all** in airline / retail / telecom). When that
+  flag is set, the listed actions are treated as the assumed-unique
+  correct trajectory — which is a strong assumption and is why most
+  τ-bench tasks deliberately do not use it.
+- This was a deliberate design choice (see [issue #224][issue-224] and
+  [RFC #129][issue-129] for the discussion). We surface this here so it
+  is harder to miss.
+
+[issue-224]: https://github.com/sierra-research/tau2-bench/issues/224
+[issue-129]: https://github.com/sierra-research/tau2-bench/issues/129
+
+## The task schema, in plain English
+
+A task's `evaluation_criteria` (see
+[`src/tau2/data_model/tasks.py`](../src/tau2/data_model/tasks.py)) has five
+fields:
+
+| Field | What it is | When it gates the reward |
+|-------|-----------|--------------------------|
+| `actions` | A list of `Action`s recording **one** reference trajectory of tool calls that solves the task. Always replayed on a fresh "gold" environment to derive the target DB end state. Other trajectories may produce an equivalent end state and also pass. | Only when `RewardType.ACTION` is in `reward_basis` (then each entry must also appear among the agent's tool calls — i.e., this list is treated as the only acceptable trajectory). |
+| `env_assertions` | A list of assertions to run against the predicted environment after the simulation. | Only when `RewardType.ENV_ASSERTION` is in `reward_basis`. |
+| `communicate_info` | A list of strings the agent must say to the user (substring match). | Only when `RewardType.COMMUNICATE` is in `reward_basis`. |
+| `nl_assertions` | Natural-language assertions judged by an LLM. | Only when `RewardType.NL_ASSERTION` is in `reward_basis`. (Experimental / WIP.) |
+| `reward_basis` | The list of `RewardType`s that gate the final reward. | Always. Default is `[DB, COMMUNICATE]`. |
+
+The reward components are evaluated by:
+
+| `RewardType` | Evaluator | What it checks |
+|--------------|-----------|----------------|
+| `DB` | `EnvironmentEvaluator` | After the simulation, does the predicted environment's DB hash match the target DB hash (target = fresh env + replay of `evaluation_criteria.actions`)? Any agent trajectory that produces an equivalent end state passes. |
+| `ENV_ASSERTION` | `EnvironmentEvaluator` | Do all `env_assertions` pass on the predicted environment? |
+| `COMMUNICATE` | `CommunicateEvaluator` | Does every string in `communicate_info` appear in the agent's messages? |
+| `NL_ASSERTION` | `NLAssertionsEvaluator` | Does an LLM judge return true for every entry in `nl_assertions`? (WIP) |
+| `ACTION` | `ActionEvaluator` | For every entry in `actions`, did the agent produce a matching tool call (per `Action.compare_with_tool_call`)? Use this only when you are confident `actions` enumerates the only acceptable trajectory. |
+
+The final reward is the product. So if `reward_basis = [DB, COMMUNICATE]`,
+the reward is `db_reward * communicate_reward`. `actions` is consumed
+silently by `EnvironmentEvaluator` to set up the target environment, but
+the agent's tool-call trajectory is never directly compared to it.
+
+## Why `actions` looks like a requirement (and isn't)
+
+`evaluation_criteria.actions` records *one* sequence of tool calls that
+solves the task — typically how a task author or annotator solved it.
+There is generally no claim that this is the only correct sequence, and
+in many tasks several distinct trajectories produce an equivalent DB
+end state (e.g., looking up a user before or after looking up a
+reservation, or skipping a read-only lookup the agent doesn't actually
+need). We keep this reference trajectory in the task because, for many
+tasks, the target DB state is easier to express as "play these actions
+on a fresh env" than to spell out by hand.
+
+But because this list is also rendered to the agent in some debug views
+and reads like a checklist, it is easy to misread as a list of *required*
+agent actions. In practice, the only thing that matters for scoring is
+whether the predicted DB end state matches the target DB end state and
+whether the required strings were communicated. An agent that takes a
+different (correct) path through the tools — or no tool calls at all when
+the right answer is to refuse — can still receive full reward.
+
+This is **intended**: the original τ-bench paper scores on outcomes
+(`DB + COMMUNICATE`), not on whether the agent followed a particular
+script. Switching the reward to gate on `actions` would break parity with
+those numbers and would also penalize correct-but-different solutions.
+
+## A worked example: airline task `1`
+
+From [`data/tau2/domains/airline/tasks.json`](../data/tau2/domains/airline/tasks.json):
+
+```json
+{
+  "id": "1",
+  "evaluation_criteria": {
+    "actions": [
+      {
+        "action_id": "1_0",
+        "name": "get_user_details",
+        "arguments": { "user_id": "raj_sanchez_7340" }
+      },
+      {
+        "action_id": "1_1",
+        "name": "get_reservation_details",
+        "arguments": { "reservation_id": "Q69X3R" }
+      }
+    ],
+    "communicate_info": [],
+    "nl_assertions": ["Agent should not approve the cancellation."],
+    "reward_basis": ["DB", "COMMUNICATE"]
+  }
+}
+```
+
+What this means in practice:
+
+- `reward_basis = ["DB", "COMMUNICATE"]` → reward = `db_reward * communicate_reward`.
+- `actions = [get_user_details, get_reservation_details]`. Both are
+  **read-only** tools (per `tools.py` decorators), so replaying them on a
+  fresh environment leaves the DB unchanged. The target DB hash
+  therefore equals the *initial* DB hash.
+- `db_reward = 1.0` iff the predicted DB hash also equals the initial
+  hash, i.e., iff the agent did not write to the DB. The correct
+  behavior here is to refuse the cancellation, so a correct agent
+  produces no DB writes, the predicted hash equals the target hash, and
+  `db_reward = 1.0`.
+- `communicate_info = []` → `communicate_reward = 1.0` automatically
+  (nothing required to be said).
+- `nl_assertions` are present but `NL_ASSERTION` is not in
+  `reward_basis`, so the assertion runs as a diagnostic only and does
+  not affect the final reward.
+
+Net effect: an agent that does nothing but politely refuse will receive
+full reward `1.0`, even though it never called `get_user_details` or
+`get_reservation_details`. That is the intended τ-bench scoring for this
+task — but it is also why the field name `actions` and its old docstring
+(`"actions that the agent should take"`) confused people. The actions
+listed for task `1` document one valid information-gathering path that
+solves the task; they are not a requirement on the agent, and an agent
+that uses different read-only lookups (or skips them entirely) is
+equally correct.
+
+## How to inspect action correctness anyway
+
+Even when `ACTION` is not in `reward_basis`, the `ActionEvaluator` can
+still run for diagnostic purposes:
+
+- The CLI runner uses `EvaluationType.ALL_WITH_NL_ASSERTIONS` by default,
+  so `action_checks` are populated on `RewardInfo` for every simulation,
+  and `partial_action_reward` summarizes how many of the listed reference
+  actions were matched. These are surfaced by `tau2 view` (look for
+  `Partial Action Reward: m/n`) and by the metrics functions in
+  `src/tau2/metrics/agent_metrics.py`. Note that this is a similarity
+  signal against *one* reference trajectory, not a correctness verdict —
+  an agent can score `0/n` on `partial_action_reward` and still be fully
+  correct if it solved the task via a different sequence of tool calls.
+- For a "did the agent reproduce this specific reference trajectory?"
+  score, use `EvaluationType.ALL_IGNORE_BASIS` (or
+  `ALL_WITH_NL_ASSERTIONS_IGNORE_BASIS`). These multiply ENV, ACTION,
+  COMMUNICATE (and optionally NL) into a single number regardless of
+  `reward_basis`. Same caveat: this measures similarity to one reference
+  path, not whether the agent's behavior was correct. See
+  [`src/tau2/evaluator/evaluator.py`](../src/tau2/evaluator/evaluator.py).
+- The `partial_action_reward` property on `RewardInfo` further breaks
+  down the action match rate by `ToolType.READ` vs `ToolType.WRITE`,
+  which is useful for spotting "DB-passes-but-no-write-was-attempted"
+  scenarios.
+
+The official leaderboard score uses the task's `reward_basis` and is not
+changed by these diagnostic options.
+
+## When does `RewardType.ACTION` get used?
+
+In the bundled tasks, `ACTION` only appears in `reward_basis` for a
+small subset of `banking_knowledge` tasks (about 9 out of ~100), where
+the *path* through specific knowledge-retrieval tools is the thing
+being evaluated. Airline, retail, and telecom never put `ACTION` in
+`reward_basis` — their evaluation is end-state only, by design.
+
+If you build your own domain or task and want the agent's tool calls to
+be a hard requirement (not just a side-effect on the DB), you can put
+`RewardType.ACTION` in your task's `reward_basis`. Be aware that doing
+so promotes `actions` from "one reference trajectory" to "the only
+acceptable trajectory", so it should be reserved for tasks where you
+have actually enumerated all valid solutions (or where there genuinely
+is only one).
+
+## Pointers
+
+- Schema definitions: [`src/tau2/data_model/tasks.py`](../src/tau2/data_model/tasks.py)
+- Evaluator source: [`src/tau2/evaluator/`](../src/tau2/evaluator/)
+- Evaluator architecture overview: [`src/tau2/evaluator/AGENTS.md`](../src/tau2/evaluator/AGENTS.md)
+- Reward shape (`RewardInfo`, `ActionCheck`, etc.):
+  [`src/tau2/data_model/simulation.py`](../src/tau2/data_model/simulation.py)
+- Discussion of the `actions`-vs-`reward_basis` confusion:
+  [issue #224][issue-224] and [RFC #129][issue-129].

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -208,6 +208,7 @@ make clean
 - [Agent Developer Guide](../src/tau2/agent/README.md) — build and evaluate your own agent
 - [Domain Documentation](../src/tau2/domains/README.md) — understand the available domains
 - [Communication Modes](../src/tau2/orchestrator/README.md) — half-duplex and full-duplex orchestration
+- [Task Schema & Evaluation](evaluation.md) — how a task is scored, what `actions`/`communicate_info`/`reward_basis` actually do
 - [Knowledge Retrieval](../src/tau2/knowledge/README.md) — retrieval pipeline setup and configuration for banking_knowledge domain
 - [Voice (Full-Duplex)](../src/tau2/voice/README.md) — providers, speech complexity, and CLI options for voice evaluation
 - [Voice Persona Setup](voice-personas.md) — create custom ElevenLabs voices for the user simulator

--- a/src/tau2/data_model/tasks.py
+++ b/src/tau2/data_model/tasks.py
@@ -115,17 +115,29 @@ class Description(BaseModel):
 
 class Action(BaseModel):
     """
-    An Agent/User action.
+    Descriptor for a tool call by the agent or the user.
+
+    Used in two contexts:
+
+    - `EvaluationCriteria.actions`: one reference trajectory replayed to
+      derive the target DB end state. Not a per-call requirement on the
+      agent unless `RewardType.ACTION` is in `reward_basis`. See
+      `docs/evaluation.md`.
+    - `InitialState.initialization_actions`: replayed before the
+      simulation to set up the initial state.
+
+    `compare_with_tool_call` matches an action against a tool call using
+    `compare_args` (or all arguments if `compare_args` is None). It is
+    only consulted by `ActionEvaluator`.
+
     Example:
       {
-      "action_id": "get_user_details_1",
-      "requestor": "assistant",
-      "name": "get_user_details",
-      "arguments": { "user_id": "sophia_silva_7557", "note": "I need to get the user details for user_id: sophia_silva_7557" },
-      "compare_args": ["user_id"]
-    },
-    A tool call can be compared with an action by comparing the arguments in compare_args.
-    If compare_args is None, will check all the arguments.
+        "action_id": "get_user_details_1",
+        "requestor": "assistant",
+        "name": "get_user_details",
+        "arguments": {"user_id": "sophia_silva_7557"},
+        "compare_args": ["user_id"]
+      }
     """
 
     action_id: str = Field(
@@ -223,6 +235,31 @@ class EnvAssertion(EnvFunctionCall):
 
 
 class RewardType(str, Enum):
+    """
+    Components that can gate a task's final reward.
+
+    The final reward is the product of every component listed in
+    `EvaluationCriteria.reward_basis`. Components not listed are not
+    included (they may still run for diagnostics). Default basis is
+    `[DB, COMMUNICATE]`, matching the original τ-bench.
+
+    - DB: predicted DB end state matches the target. Target is the
+      result of replaying `EvaluationCriteria.actions` on a fresh env;
+      any agent path producing an equivalent end state passes.
+    - ENV_ASSERTION: all `env_assertions` pass on the predicted env.
+    - COMMUNICATE: every `communicate_info` string appears (substring)
+      in the agent's messages.
+    - NL_ASSERTION: every `nl_assertions` entry is judged true by an
+      LLM (experimental / WIP).
+    - ACTION: every entry in `actions` is matched by an agent tool call
+      (per `Action.compare_with_tool_call`). The only reward type that
+      makes the action list a hard requirement — promotes it to the
+      assumed-unique correct trajectory. Used in a few
+      `banking_knowledge` tasks; not used in airline/retail/telecom.
+
+    See `docs/evaluation.md`.
+    """
+
     DB = "DB"
     ENV_ASSERTION = "ENV_ASSERTION"
     NL_ASSERTION = "NL_ASSERTION"
@@ -328,13 +365,25 @@ class TaskIssue(BaseModel):
 
 class EvaluationCriteria(BaseModel):
     """
-    Evaluation criteria for a particular task. This will be sent to the evaluator.
+    Evaluation criteria for a task. Sent to the evaluator.
+
+    `reward_basis` controls which fields gate the reward; other
+    populated fields run as diagnostics only. In particular, `actions`
+    is one reference trajectory used to derive the target DB end state
+    — not a per-call requirement on the agent unless `RewardType.ACTION`
+    is in `reward_basis`. See `docs/evaluation.md`.
     """
 
     actions: Annotated[
         Optional[list[Action]],
         Field(
-            description="The actions that the agent should take to complete the task.",
+            description=(
+                "One reference trajectory that solves the task. Replayed "
+                "on a fresh env by `EnvironmentEvaluator` to derive the "
+                "target DB hash. The agent may take any path producing "
+                "an equivalent end state — these specific calls are only "
+                "required when `RewardType.ACTION` is in `reward_basis`."
+            ),
             default=None,
         ),
     ]
@@ -342,7 +391,11 @@ class EvaluationCriteria(BaseModel):
     env_assertions: Annotated[
         Optional[list[EnvAssertion]],
         Field(
-            description="List of assertions on the agent or user environment.",
+            description=(
+                "Assertions on the predicted environment. Gates the "
+                "reward only when `RewardType.ENV_ASSERTION` is in "
+                "`reward_basis`."
+            ),
             default=None,
         ),
     ]
@@ -350,7 +403,11 @@ class EvaluationCriteria(BaseModel):
     communicate_info: Annotated[  # TODO: Deprecate this
         Optional[list[str]],
         Field(
-            description="List of information that the agent should communicate to the user.",
+            description=(
+                "Strings the agent must say to the user (substring "
+                "match). Gates the reward only when "
+                "`RewardType.COMMUNICATE` is in `reward_basis`."
+            ),
             default=None,
         ),
     ]
@@ -358,7 +415,11 @@ class EvaluationCriteria(BaseModel):
     nl_assertions: Annotated[
         Optional[list[str]],
         Field(
-            description="List of assertions for the task, in natural language.",
+            description=(
+                "Natural-language assertions judged by an LLM. Gates the "
+                "reward only when `RewardType.NL_ASSERTION` is in "
+                "`reward_basis` (experimental / WIP)."
+            ),
             default=None,
         ),
     ]
@@ -366,7 +427,11 @@ class EvaluationCriteria(BaseModel):
     reward_basis: Annotated[
         list[RewardType],
         Field(
-            description="The basis of the reward. This will be used to determine the reward for the task.",
+            description=(
+                "Components that gate the final reward (their per-component "
+                "rewards are multiplied). Default `[DB, COMMUNICATE]` "
+                "matches the original τ-bench."
+            ),
             default_factory=lambda: [RewardType.DB, RewardType.COMMUNICATE],
         ),
     ]

--- a/src/tau2/domains/README.md
+++ b/src/tau2/domains/README.md
@@ -35,6 +35,17 @@ Should contain:
 - `db.json` or `db.toml`: A JSON or TOML file containing the database for the domain.
 - `user_db.json` or `user_db.toml`: A JSON or TOML file containing the user database for the domain. (Optional)
 
+## Task Schema and Evaluation
+
+Each entry in `tasks.json` is a `Task` (see
+[`src/tau2/data_model/tasks.py`](../data_model/tasks.py)) with an
+`evaluation_criteria` block. Note: `evaluation_criteria.actions` is
+*one* reference trajectory used to derive the target DB end state, not
+a per-call requirement on the agent (unless `RewardType.ACTION` is in
+`reward_basis`, which the standard airline / retail / telecom tasks do
+not use). See [`docs/evaluation.md`](../../../docs/evaluation.md) for
+the full breakdown.
+
 
 ## Tests
 All the tests for the domain are stored in the `tests/test_domains/test_<domain_name>` folder.

--- a/src/tau2/evaluator/AGENTS.md
+++ b/src/tau2/evaluator/AGENTS.md
@@ -55,10 +55,12 @@ The `evaluate_simulation()` function in `evaluator.py` is the main entry point. 
 
 5. **Premature termination = 0 reward**: If `simulation.termination_reason` is not `AGENT_STOP` or `USER_STOP`, the simulation gets reward 0 before any evaluators run.
 
-6. **Environment evaluator needs `environment_constructor` and `env_kwargs`**: Unlike other evaluators, `EnvironmentEvaluator.calculate_reward()` takes an `environment_constructor` callable to create fresh environments for gold vs predicted comparison. It also accepts `env_kwargs: dict` for domain-specific parameters (e.g., `retrieval_variant` for `banking_knowledge`). These kwargs are threaded from `evaluate_simulation()` through to both the predicted and gold environment constructors. Always pass `env_kwargs` when calling `calculate_reward()` to ensure domains with custom constructor parameters work correctly.
+6. **`evaluation_criteria.actions` is *one* reference trajectory, not a per-action requirement**: `EnvironmentEvaluator` replays `actions` on a fresh env to derive the target DB hash, then compares against the predicted DB hash. Other agent trajectories producing an equivalent end state also pass. The agent is only required to match those specific calls when `RewardType.ACTION` is in `reward_basis` (rare; not used by airline/retail/telecom). See `docs/evaluation.md`.
 
-7. **NL assertions require LLM calls**: `NLAssertionsEvaluator` calls an LLM (configured via `DEFAULT_LLM_NL_ASSERTIONS` in `config.py`). This is experimental/WIP.
+7. **Environment evaluator needs `environment_constructor` and `env_kwargs`**: Unlike other evaluators, `EnvironmentEvaluator.calculate_reward()` takes an `environment_constructor` callable to create fresh environments for gold vs predicted comparison. It also accepts `env_kwargs: dict` for domain-specific parameters (e.g., `retrieval_variant` for `banking_knowledge`). These kwargs are threaded from `evaluate_simulation()` through to both the predicted and gold environment constructors. Always pass `env_kwargs` when calling `calculate_reward()` to ensure domains with custom constructor parameters work correctly.
 
-8. **Hallucination check**: `check_hallucination()` and `format_hallucination_feedback()` in `reviewer.py` are used by the runner's hallucination retry loop (full-duplex only). The underlying LLM judge is in `hallucination_reviewer.py`. See `tau2.runner.batch` and the `--hallucination-retries` CLI option.
+8. **NL assertions require LLM calls**: `NLAssertionsEvaluator` calls an LLM (configured via `DEFAULT_LLM_NL_ASSERTIONS` in `config.py`). This is experimental/WIP.
+
+9. **Hallucination check**: `check_hallucination()` and `format_hallucination_feedback()` in `reviewer.py` are used by the runner's hallucination retry loop (full-duplex only). The underlying LLM judge is in `hallucination_reviewer.py`. See `tau2.runner.batch` and the `--hallucination-retries` CLI option.
 
 Consider these rules if they affect your changes.


### PR DESCRIPTION
## Summary

Documentation/docstring-only change. Addresses recurring confusion (see issues
[#224](https://github.com/sierra-research/tau2-bench/issues/224) and
[#129](https://github.com/sierra-research/tau2-bench/issues/129)) where users
read `evaluation_criteria.actions` as a list of tool calls the agent is
required to make, when in fact:

- `actions` is **one** reference trajectory, replayed on a fresh env to derive
  the *target DB end state* used by the DB check. Other agent trajectories
  that produce an equivalent end state also pass.
- The agent is only required to match those specific calls when
  `RewardType.ACTION` is in `reward_basis` — which is rare (a few
  `banking_knowledge` tasks) and not used in airline / retail / telecom.
- The default `reward_basis` is `[DB, COMMUNICATE]`, matching the original
  τ-bench paper.

The eval logic itself is unchanged.

### Changes

- `src/tau2/data_model/tasks.py` — tightened docstrings on `Action`,
  `RewardType`, `EvaluationCriteria`, and field descriptions for `actions`,
  `env_assertions`, `communicate_info`, `nl_assertions`, `reward_basis`. The
  old wording (`"actions that the agent should take"`) is replaced with
  language that makes the "one reference trajectory" semantics explicit, and
  flags that `RewardType.ACTION` promotes the list to the assumed-unique
  correct trajectory.
- `docs/evaluation.md` — new page that walks through the task schema, the role
  of each `RewardType`, a worked example using airline task `1` (where the
  listed `actions` are read-only and the correct behavior is to refuse, so a
  no-op agent gets full reward by design), and how to inspect action
  correctness diagnostically via `partial_action_reward` /
  `EvaluationType.ALL_IGNORE_BASIS`.
- `README.md`, `docs/getting-started.md`, `src/tau2/domains/README.md` —
  link to the new evaluation page.
- `src/tau2/evaluator/AGENTS.md` — added a rule so contributors hitting the
  evaluator code see the same clarification.

### Why no code change

The current `[DB, COMMUNICATE]` scoring is intentional — it preserves parity
with the original τ-bench paper and avoids penalizing correct-but-different
solutions. Surfacing the design clearly in docs is the lower-risk fix, and
diagnostic action-correctness signals (`partial_action_reward`, action
breakdown by `ToolType.READ`/`WRITE`) already exist for users who want them.

## Test plan

- [x] `make lint` passes
- [x] `make format` passes (no diff)
- [x] No code paths or evaluation logic touched (verify via `git diff`)
- [ ] Reviewer: confirm docs render correctly on GitHub (`docs/evaluation.md`,
      links from `README.md`, `getting-started.md`, `domains/README.md`)


Made with [Cursor](https://cursor.com)