### PR TITLE
leaderboard: add LiveKit cascaded voice submission

### DIFF
--- a/web/leaderboard/public/submissions/livekit-cascaded_livekit_2026-05-19/submission.json
+++ b/web/leaderboard/public/submissions/livekit-cascaded_livekit_2026-05-19/submission.json
@@ -1,0 +1,54 @@
+{
+  "model_name": "livekit-cascaded",
+  "model_organization": "LiveKit",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-05-19",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "victor@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 28.947368421052634
+    },
+    "airline": {
+      "pass_1": 48.0
+    },
+    "telecom": {
+      "pass_1": 16.666666666666664
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_regular_livekit",
+    "retail": "retail_regular_livekit",
+    "telecom": "telecom_regular_livekit"
+  },
+  "methodology": {
+    "evaluation_date": "2026-04-20",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "v1.0",
+    "notes": "LiveKit cascaded STT-LLM-TTS pipeline using the default audio_native provider config (Deepgram nova-3 STT, OpenAI gpt-4.1 LLM, Deepgram aura-asteria-en TTS). Full-duplex audio-native evaluation using regular speech complexity (realistic audio conditions). 1 trial per task.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "LiveKit",
+    "model": "cascaded-default",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "references": [
+    {
+      "title": "LiveKit Agents Framework",
+      "url": "https://docs.livekit.io/agents/",
+      "type": "documentation"
+    }
+  ]
+}

--- a/web/leaderboard/public/submissions/livekit-cascaded_livekit_2026-05-19/submission.json
+++ b/web/leaderboard/public/submissions/livekit-cascaded_livekit_2026-05-19/submission.json
@@ -44,6 +44,11 @@
     "max_steps_seconds": 1200.0,
     "user_tts_provider": "elevenlabs/eleven_v3"
   },
+  "model_release": {
+    "release_date": "2025-04-11",
+    "announcement_url": "https://blog.livekit.io/livekits-series-b/",
+    "announcement_title": "LiveKit Agents 1.0"
+  },
   "references": [
     {
       "title": "LiveKit Agents Framework",

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -27,7 +27,8 @@
     "grok-voice-think-fast-1-0_xai_2026-04-21",
     "gemini-3-1-flash-live-preview-thinking-high_google_2026-04-02",
     "gemini-3-1-flash-live-preview-thinking-minimal_google_2026-04-13",
-    "gpt-realtime-1-0_openai_2026-04-13"
+    "gpt-realtime-1-0_openai_2026-04-13",
+    "livekit-cascaded_livekit_2026-05-19"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",


### PR DESCRIPTION
## Summary

Adds a new voice submission for the **LiveKit cascaded STT-LLM-TTS pipeline** (provider `livekit`, `audio_native` config preset `default`):

- **STT:** Deepgram `nova-3`
- **LLM:** OpenAI `gpt-4.1`
- **TTS:** Deepgram `aura-asteria-en`
- **User simulator:** voice-user-sim `v1.0`
- **Speech complexity:** regular, 1 trial per task

## Results (Pass^1)

| Domain | Pass^1 | n |
| --- | --- | --- |
| airline | 48.0% | 50 |
| retail  | 28.9% | 114 |
| telecom | 16.7% | 114 |

## Files

- `web/leaderboard/public/submissions/livekit-cascaded_livekit_2026-05-19/submission.json`
- `web/leaderboard/public/submissions/manifest.json` (append to `voice_submissions`)

Generated locally with `tau2 submit prepare --voice` and verified with `tau2 submit validate`.