### PR TITLE
Remove text leaderboard overall

### DIFF
--- a/docs/leaderboard-submission.md
+++ b/docs/leaderboard-submission.md
@@ -15,7 +15,7 @@ Both modalities share the same [validation](#step-3-validate-your-submission), [
 
 Your submission should meet these constraints:
 
-1. **Domain coverage** — we recommend including results for all three core domains (`retail`, `airline`, `telecom`). You may submit results for a single domain, but the leaderboard's "Overall" column only appears when all four domains (including `banking_knowledge`) have Pass^1 scores
+1. **Domain coverage** — we recommend including results for all current text domains (`banking_knowledge`, `retail`, `airline`, `telecom`). You may submit results for a single domain; the leaderboard ranks submissions per domain.
 2. **Consistent model configuration** — all trajectory files must use the same agent model and user simulator with identical arguments across all domains
 3. **One result per domain** — each domain should appear exactly once
 4. **All tasks completed** — run evaluation on all tasks within each domain (don't use `--task-ids` or `--num-tasks` filters)

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -19,6 +19,19 @@ const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
   || `${import.meta.env.BASE_URL}submissions`
 
 const NO_CACHE = { cache: 'no-cache' }
+const TEXT_DEFAULT_DOMAIN = 'banking_knowledge'
+const TEXT_DOMAINS = [
+  { key: 'banking_knowledge', label: '🏦 Banking' },
+  { key: 'retail', label: '🛍️ Retail' },
+  { key: 'airline', label: '✈️ Airline' },
+  { key: 'telecom', label: '📱 Telecom' },
+]
+const VOICE_DOMAINS = [
+  { key: 'overall', label: '📊 Overall' },
+  { key: 'retail', label: '🛍️ Retail' },
+  { key: 'airline', label: '✈️ Airline' },
+  { key: 'telecom', label: '📱 Telecom' },
+]
 
 const Leaderboard = () => {
   // Benchmark selector: 'text' (τ-bench) or 'voice' (τ-voice)
@@ -31,7 +44,12 @@ const Leaderboard = () => {
   })
   // Add unified domain selection state with localStorage persistence
   const [domain, setDomain] = useState(() => {
-    return localStorage.getItem('domain') || 'overall'
+    const storedBenchmark = localStorage.getItem('benchmark')
+    const storedDomain = localStorage.getItem('domain')
+    const validDomains = storedBenchmark === 'voice' ? VOICE_DOMAINS : TEXT_DOMAINS
+    return validDomains.some(({ key }) => key === storedDomain)
+      ? storedDomain
+      : (storedBenchmark === 'voice' ? 'overall' : TEXT_DEFAULT_DOMAIN)
   })
   // Selected pass^k metric (1-4) with localStorage persistence
   const [selectedPassK, setSelectedPassK] = useState(() => {
@@ -289,6 +307,13 @@ const Leaderboard = () => {
   }, [domain])
 
   useEffect(() => {
+    const domainsForBenchmark = benchmark === 'voice' ? VOICE_DOMAINS : TEXT_DOMAINS
+    if (!domainsForBenchmark.some(({ key }) => key === domain)) {
+      setDomain(benchmark === 'voice' ? 'overall' : TEXT_DEFAULT_DOMAIN)
+    }
+  }, [benchmark, domain])
+
+  useEffect(() => {
     localStorage.setItem('selectedPassK', selectedPassK)
   }, [selectedPassK])
 
@@ -331,6 +356,8 @@ const Leaderboard = () => {
       }
       // Voice only has pass^1
       setSelectedPassK(1)
+    } else if (domain === 'overall') {
+      setDomain(TEXT_DEFAULT_DOMAIN)
     }
   }
 
@@ -413,20 +440,7 @@ const Leaderboard = () => {
 
   // Determine domains available for current benchmark
   const isVoice = benchmark === 'voice'
-  const availableDomains = isVoice
-    ? [
-        { key: 'overall', label: '📊 Overall' },
-        { key: 'retail', label: '🛍️ Retail' },
-        { key: 'airline', label: '✈️ Airline' },
-        { key: 'telecom', label: '📱 Telecom' },
-      ]
-    : [
-        { key: 'overall', label: '📊 Overall' },
-        { key: 'banking_knowledge', label: '🏦 Banking' },
-        { key: 'retail', label: '🛍️ Retail' },
-        { key: 'airline', label: '✈️ Airline' },
-        { key: 'telecom', label: '📱 Telecom' },
-      ]
+  const availableDomains = isVoice ? VOICE_DOMAINS : TEXT_DOMAINS
 
   // For voice overall, only average the 3 non-banking domains
   const voiceDomains = ['retail', 'airline', 'telecom']
@@ -599,7 +613,7 @@ const Leaderboard = () => {
               {(() => {
                 // Calculate domain-specific scores for ranking
                 const modelStats = Object.entries(passKData)
-                  .filter(([modelName, data]) => {
+                  .filter(([, data]) => {
                     // Filter by benchmark modality
                     if (data.modality !== benchmark) {
                       return false

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -9,7 +9,7 @@ const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
 const NO_CACHE = { cache: 'no-cache' }
 
 function LeaderboardPreview({ onViewFullLeaderboard }) {
-  const [textTop3, setTextTop3] = useState([])
+  const [bankingTop3, setBankingTop3] = useState([])
   const [voiceTop3, setVoiceTop3] = useState([])
   const [isLoading, setIsLoading] = useState(true)
 
@@ -26,7 +26,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
       const textDirs = [...(manifest.submissions || []), ...(manifest.legacy_submissions || [])]
       const voiceDirs = manifest.voice_submissions || []
 
-      // Load text submissions and compute overall pass^1
+      // Load text submissions and rank by banking pass^1.
       const textModels = []
       for (const dir of textDirs) {
         try {
@@ -38,26 +38,22 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
           if (sub.submission_type && sub.submission_type !== 'standard') continue
 
           const r = sub.results
-          const airline = r.airline?.pass_1
-          const retail = r.retail?.pass_1
-          const telecom = r.telecom?.pass_1
           const banking = r.banking_knowledge?.pass_1
 
-          if (airline != null && retail != null && telecom != null && banking != null) {
-            const overall = (airline + retail + telecom + banking) / 4
+          if (banking != null) {
             textModels.push({
               name: sub.model_name,
               org: sub.model_organization,
-              overall: overall,
+              score: banking,
             })
           }
         } catch { /* skip */ }
       }
 
-      textModels.sort((a, b) => b.overall - a.overall)
-      setTextTop3(textModels.slice(0, 3))
+      textModels.sort((a, b) => b.score - a.score)
+      setBankingTop3(textModels.slice(0, 3))
 
-      // Load voice submissions and compute overall pass^1
+      // Load voice submissions and compute overall pass^1.
       const voiceModels = []
       const voiceDomains = ['airline', 'retail', 'telecom']
       for (const dir of voiceDirs) {
@@ -74,17 +70,16 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
             .filter(v => v != null)
 
           if (values.length > 0) {
-            const overall = values.reduce((s, v) => s + v, 0) / values.length
             voiceModels.push({
               name: sub.model_name,
               org: sub.voice_config?.provider || sub.model_organization,
-              overall: overall,
+              score: values.reduce((s, v) => s + v, 0) / values.length,
             })
           }
         } catch { /* skip */ }
       }
 
-      voiceModels.sort((a, b) => b.overall - a.overall)
+      voiceModels.sort((a, b) => b.score - a.score)
       setVoiceTop3(voiceModels.slice(0, 3))
     } catch (err) {
       console.warn('Failed to load leaderboard preview:', err)
@@ -107,7 +102,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
         <div className="preview-table-wrapper">
           <h3 className="preview-table-title">
             <span className="preview-mode-badge text">Text</span>
-            Overall
+            Banking
           </h3>
           <table className="preview-table">
             <thead>
@@ -118,14 +113,14 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
               </tr>
             </thead>
             <tbody>
-              {textTop3.map((model, i) => (
+              {bankingTop3.map((model, i) => (
                 <tr key={i} className="preview-row">
                   <td className="preview-rank">{MEDAL_EMOJI[i]}</td>
                   <td className="preview-model">
                     <span className="preview-model-name">{model.name}</span>
                     <span className="preview-model-org">{model.org}</span>
                   </td>
-                  <td className="preview-score">{model.overall.toFixed(1)}%</td>
+                  <td className="preview-score">{model.score.toFixed(1)}%</td>
                 </tr>
               ))}
             </tbody>
@@ -153,7 +148,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
                     <span className="preview-model-name">{model.name}</span>
                     <span className="preview-model-org">{model.org}</span>
                   </td>
-                  <td className="preview-score">{model.overall.toFixed(1)}%</td>
+                  <td className="preview-score">{model.score.toFixed(1)}%</td>
                 </tr>
               ))}
             </tbody>

--- a/web/leaderboard/src/components/ProgressView.jsx
+++ b/web/leaderboard/src/components/ProgressView.jsx
@@ -606,7 +606,7 @@ const ProgressView = ({
         </div>
 
         <div className="progress-footnote">
-          Markers show each model's overall pass@1 plotted at its public release date.
+          Markers show each model's {domainLabel.toLowerCase()} pass@1 plotted at its public release date.
           Hover any marker for details. The dashed line tracks the running best.
           Submissions without a published <code>model_release.release_date</code> fall back
           to the evaluation date.


### PR DESCRIPTION
Remove Overall from text leaderboard and show Banking in text preview while keeping Voice Overall.\n\nChecks: npm run build; targeted ESLint.