### PR TITLE
fix: fail submission validation on metric mismatches

### DIFF
--- a/src/tau2/scripts/leaderboard/prepare_submission.py
+++ b/src/tau2/scripts/leaderboard/prepare_submission.py
@@ -182,11 +182,14 @@ def validate_submission(
         return
 
     verify_trajectories(submission_data.trajectory_files, mode=mode)
-    console.print("✅ Submission validation successful!", style="green")
     console.print("📋 Validating submission metrics...", style="bold")
-    validate_submission_metrics(
+    valid_metrics = validate_submission_metrics(
         submission_data.submission, submission_data.results, console
     )
+    if not valid_metrics:
+        console.print("❌ Submission validation failed: metric mismatch", style="red")
+        raise SystemExit(1)
+    console.print("✅ Submission validation successful!", style="green")
 
 
 def get_metrics(
@@ -240,10 +243,11 @@ def get_metrics(
 
 def validate_submission_metrics(
     submission: Submission, submitted_results: list[TrajectoryResults], console: Console
-) -> None:
+) -> bool:
     """
     Validate the submission metrics.
     """
+    errors = []
     warnings = []
     _, computed_domain_results, default_model, default_user_simulator = get_metrics(
         submitted_results
@@ -262,36 +266,42 @@ def validate_submission_metrics(
     for domain, computed_results in computed_domain_results.items():
         domain_results = submission.results.get_domain_results(domain)
         if domain_results is None:
-            warnings.append(
+            errors.append(
                 f"Domain {domain} found in trajectories but missing from submission.json"
             )
             continue
         if domain_results.pass_1 != computed_results.pass_1:
-            warnings.append(
+            errors.append(
                 f"Pass^1 for {domain} does not match computed results {computed_results.pass_1}"
             )
         if domain_results.pass_2 != computed_results.pass_2:
-            warnings.append(
+            errors.append(
                 f"Pass^2 for {domain} does not match computed results {computed_results.pass_2}"
             )
         if domain_results.pass_3 != computed_results.pass_3:
-            warnings.append(
+            errors.append(
                 f"Pass^3 for {domain} does not match computed results {computed_results.pass_3}"
             )
         if domain_results.pass_4 != computed_results.pass_4:
-            warnings.append(
+            errors.append(
                 f"Pass^4 for {domain} does not match computed results {computed_results.pass_4}"
             )
         if domain_results.cost != computed_results.cost:
-            warnings.append(
+            errors.append(
                 f"Cost for {domain} does not match computed results {computed_results.cost}"
             )
     if warnings:
-        console.print(f"❌ {len(warnings)} warning(s) found", style="red")
+        console.print(f"⚠️  {len(warnings)} warning(s) found", style="yellow")
         for warning in warnings:
-            console.print(f"  • {warning}", style="red")
-    else:
-        console.print("✅ Submission metrics validation successful!", style="green")
+            console.print(f"  • {warning}", style="yellow")
+    if errors:
+        console.print(f"❌ {len(errors)} error(s) found", style="red")
+        for error in errors:
+            console.print(f"  • {error}", style="red")
+        return False
+
+    console.print("✅ Submission metrics validation successful!", style="green")
+    return True
 
 
 def _copy_voice_experiment_trimmed(

--- a/tests/test_leaderboard_submission_validation.py
+++ b/tests/test_leaderboard_submission_validation.py
@@ -1,0 +1,199 @@
+from datetime import date
+
+import pytest
+from rich.console import Console
+
+from tau2.data_model.simulation import (
+    AgentInfo,
+    Info,
+    Results as TrajectoryResults,
+    RewardInfo,
+    SimulationRun,
+    TerminationReason,
+    UserInfo,
+)
+from tau2.data_model.tasks import EvaluationCriteria, Task, UserScenario
+from tau2.environment.environment import EnvironmentInfo
+from tau2.scripts.leaderboard.prepare_submission import (
+    validate_submission,
+    validate_submission_metrics,
+)
+from tau2.scripts.leaderboard.submission import (
+    ContactInfo,
+    DomainResults,
+    Methodology,
+    Results,
+    Submission,
+    SubmissionData,
+)
+
+
+def _make_trajectory_results() -> TrajectoryResults:
+    tasks = [
+        Task(
+            id="task_1",
+            user_scenario=UserScenario(instructions="Complete task 1"),
+            evaluation_criteria=EvaluationCriteria(),
+        ),
+        Task(
+            id="task_2",
+            user_scenario=UserScenario(instructions="Complete task 2"),
+            evaluation_criteria=EvaluationCriteria(),
+        ),
+    ]
+    simulations = [
+        SimulationRun(
+            id="sim_task_1",
+            task_id="task_1",
+            start_time="2026-01-01T00:00:00",
+            end_time="2026-01-01T00:01:00",
+            duration=60.0,
+            termination_reason=TerminationReason.USER_STOP,
+            agent_cost=1.0,
+            reward_info=RewardInfo(reward=1.0),
+            messages=[],
+            trial=0,
+            seed=1,
+        ),
+        SimulationRun(
+            id="sim_task_2",
+            task_id="task_2",
+            start_time="2026-01-01T00:00:00",
+            end_time="2026-01-01T00:01:00",
+            duration=60.0,
+            termination_reason=TerminationReason.USER_STOP,
+            agent_cost=3.0,
+            reward_info=RewardInfo(reward=0.0),
+            messages=[],
+            trial=0,
+            seed=2,
+        ),
+    ]
+    return TrajectoryResults(
+        info=Info(
+            git_commit="abc123",
+            num_trials=1,
+            max_steps=100,
+            max_errors=10,
+            user_info=UserInfo(implementation="user_simulator", llm="user-model"),
+            agent_info=AgentInfo(implementation="llm_agent", llm="agent-model"),
+            environment_info=EnvironmentInfo(domain_name="retail", policy="policy"),
+        ),
+        tasks=tasks,
+        simulations=simulations,
+    )
+
+
+def _make_submission(
+    *,
+    retail_results: DomainResults | None = None,
+    model_name: str = "agent-model",
+    user_simulator: str = "user-model",
+) -> Submission:
+    return Submission(
+        model_name=model_name,
+        model_organization="Org",
+        submitting_organization="Org",
+        submission_date=date(2026, 1, 1),
+        contact_info=ContactInfo(email="test@example.com"),
+        results=Results(retail=retail_results),
+        methodology=Methodology(user_simulator=user_simulator),
+    )
+
+
+def test_validate_submission_metrics_accepts_matching_metrics():
+    trajectory_results = _make_trajectory_results()
+    submission = _make_submission(
+        retail_results=DomainResults(pass_1=50.0, cost=2.0)
+    )
+
+    assert (
+        validate_submission_metrics(
+            submission, [trajectory_results], Console(record=True)
+        )
+        is True
+    )
+
+
+def test_validate_submission_metrics_rejects_pass_metric_mismatch():
+    trajectory_results = _make_trajectory_results()
+    submission = _make_submission(
+        retail_results=DomainResults(pass_1=100.0, cost=2.0)
+    )
+
+    assert (
+        validate_submission_metrics(
+            submission, [trajectory_results], Console(record=True)
+        )
+        is False
+    )
+
+
+def test_validate_submission_metrics_rejects_cost_mismatch():
+    trajectory_results = _make_trajectory_results()
+    submission = _make_submission(
+        retail_results=DomainResults(pass_1=50.0, cost=99.0)
+    )
+
+    assert (
+        validate_submission_metrics(
+            submission, [trajectory_results], Console(record=True)
+        )
+        is False
+    )
+
+
+def test_validate_submission_metrics_rejects_missing_domain_results():
+    trajectory_results = _make_trajectory_results()
+    submission = _make_submission(retail_results=None)
+
+    assert (
+        validate_submission_metrics(
+            submission, [trajectory_results], Console(record=True)
+        )
+        is False
+    )
+
+
+def test_validate_submission_metrics_keeps_metadata_mismatches_as_warnings():
+    trajectory_results = _make_trajectory_results()
+    submission = _make_submission(
+        retail_results=DomainResults(pass_1=50.0, cost=2.0),
+        model_name="display-name",
+        user_simulator="display-user",
+    )
+
+    assert (
+        validate_submission_metrics(
+            submission, [trajectory_results], Console(record=True)
+        )
+        is True
+    )
+
+
+def test_validate_submission_exits_nonzero_on_metric_mismatch(monkeypatch, tmp_path):
+    trajectory_results = _make_trajectory_results()
+    submission = _make_submission(
+        retail_results=DomainResults(pass_1=100.0, cost=2.0)
+    )
+    submission_data = SubmissionData(
+        submission_dir=str(tmp_path),
+        submission_file=str(tmp_path / "submission.json"),
+        trajectory_files=[str(tmp_path / "trajectories" / "retail.json")],
+        submission=submission,
+        results=[trajectory_results],
+    )
+
+    monkeypatch.setattr(
+        "tau2.scripts.leaderboard.prepare_submission.check_and_load_submission_data",
+        lambda submission_dir: (True, "", submission_data),
+    )
+    monkeypatch.setattr(
+        "tau2.scripts.leaderboard.prepare_submission.verify_trajectories",
+        lambda paths, mode: None,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_submission(str(tmp_path))
+
+    assert exc_info.value.code == 1

--- a/tests/test_leaderboard_submission_validation.py
+++ b/tests/test_leaderboard_submission_validation.py
@@ -6,11 +6,13 @@ from rich.console import Console
 from tau2.data_model.simulation import (
     AgentInfo,
     Info,
-    Results as TrajectoryResults,
     RewardInfo,
     SimulationRun,
     TerminationReason,
     UserInfo,
+)
+from tau2.data_model.simulation import (
+    Results as TrajectoryResults,
 )
 from tau2.data_model.tasks import EvaluationCriteria, Task, UserScenario
 from tau2.environment.environment import EnvironmentInfo
@@ -103,9 +105,7 @@ def _make_submission(
 
 def test_validate_submission_metrics_accepts_matching_metrics():
     trajectory_results = _make_trajectory_results()
-    submission = _make_submission(
-        retail_results=DomainResults(pass_1=50.0, cost=2.0)
-    )
+    submission = _make_submission(retail_results=DomainResults(pass_1=50.0, cost=2.0))
 
     assert (
         validate_submission_metrics(
@@ -117,9 +117,7 @@ def test_validate_submission_metrics_accepts_matching_metrics():
 
 def test_validate_submission_metrics_rejects_pass_metric_mismatch():
     trajectory_results = _make_trajectory_results()
-    submission = _make_submission(
-        retail_results=DomainResults(pass_1=100.0, cost=2.0)
-    )
+    submission = _make_submission(retail_results=DomainResults(pass_1=100.0, cost=2.0))
 
     assert (
         validate_submission_metrics(
@@ -131,9 +129,7 @@ def test_validate_submission_metrics_rejects_pass_metric_mismatch():
 
 def test_validate_submission_metrics_rejects_cost_mismatch():
     trajectory_results = _make_trajectory_results()
-    submission = _make_submission(
-        retail_results=DomainResults(pass_1=50.0, cost=99.0)
-    )
+    submission = _make_submission(retail_results=DomainResults(pass_1=50.0, cost=99.0))
 
     assert (
         validate_submission_metrics(
@@ -173,9 +169,7 @@ def test_validate_submission_metrics_keeps_metadata_mismatches_as_warnings():
 
 def test_validate_submission_exits_nonzero_on_metric_mismatch(monkeypatch, tmp_path):
     trajectory_results = _make_trajectory_results()
-    submission = _make_submission(
-        retail_results=DomainResults(pass_1=100.0, cost=2.0)
-    )
+    submission = _make_submission(retail_results=DomainResults(pass_1=100.0, cost=2.0))
     submission_data = SubmissionData(
         submission_dir=str(tmp_path),
         submission_file=str(tmp_path / "submission.json"),


### PR DESCRIPTION
## Summary

Make `tau2 submit validate` fail when leaderboard metrics in `submission.json` do not match the metrics recomputed from the submitted trajectory files.

## Changes Made

- Treat missing domain results and pass^k / cost mismatches as validation errors instead of warnings.
- Keep model name and user simulator metadata mismatches as warnings.
- Move the final submission success message until after metric validation succeeds.
- Add regression tests for matching metrics, mismatched pass/cost metrics, missing domain results, metadata-only warnings, and the non-zero validation exit path.

## Testing

- `uv run pytest tests/test_leaderboard_submission_validation.py -q` ✅
- `make check-all` ✅
- `make test` ⚠️ attempted; the new leaderboard tests passed, but the existing full core suite failed on pre-existing LLM/API-dependent tests because this local environment has no `OPENAI_API_KEY` configured. Representative failures were `litellm.AuthenticationError: The api_key client option must be set...` in `tests/test_agent.py`, `tests/test_llm_utils.py`, `tests/test_orchestrator.py`, `tests/test_run.py`, and `tests/test_user.py`.

## Documentation

No docs changed. This aligns `tau2 submit validate` with the submission guide's documented metric validation behavior.
