### PR TITLE
Leaderboard: Pine Realtime 1.0 Preview voice submission (custom)

### DIFF
--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -80,7 +80,7 @@ from tau2.voice.audio_native.adapter import DiscreteTimeAdapter, create_adapter
 from tau2.voice.audio_native.tick_result import TickResult
 
 # Provider type alias
-AudioNativeProvider = Literal["openai", "gemini", "xai", "nova", "qwen", "livekit"]
+AudioNativeProvider = Literal["openai", "gemini", "xai", "nova", "qwen", "livekit", "pine"]
 
 # VAD config union type (string annotations for lazy resolution)
 VADConfig = Union[

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -238,7 +238,7 @@ def add_run_args(parser):
     parser.add_argument(
         "--audio-native-provider",
         type=str,
-        choices=["openai", "gemini", "xai", "livekit"],
+        choices=["openai", "gemini", "xai", "livekit", "pine"],
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
         help=f"Audio native API provider. Default is '{DEFAULT_AUDIO_NATIVE_PROVIDER}'.",
     )

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -143,6 +143,11 @@ DEFAULT_OPENAI_NOISE_REDUCTION = "near_field"  # fixed: "near_field", "far_field
 DEFAULT_OPENAI_VAD_THRESHOLD_LOW = 0.2  # fixed
 DEFAULT_OPENAI_VAD_THRESHOLD_DEFAULT = 0.5  # fixed
 DEFAULT_OPENAI_VAD_THRESHOLD = DEFAULT_OPENAI_VAD_THRESHOLD_DEFAULT
+
+# Pine realtime provider. Pine exposes an OpenAI-Realtime-compatible
+# gateway, so the adapter reuses the OpenAI protocol and only swaps URL + auth.
+DEFAULT_PINE_BASE_URL = "wss://api-preview.pinevoice.ai/v1/realtime"  # overridable via PINE_BASE_URL
+DEFAULT_PINE_MODEL = "pine-realtime-1.0-preview"  # overridable via --audio-native-model
 DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE = 24000  # fixed, API-defined
 DEFAULT_OPENAI_TRANSCRIPTION_MODEL = "gpt-4o-transcribe"  # overridable
 DEFAULT_WHISPER_MODEL = "whisper-1"  # fixed
@@ -198,6 +203,7 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
     "nova": DEFAULT_NOVA_MODEL,
     "qwen": DEFAULT_QWEN_MODEL,
     "livekit": "dummy",
+    "pine": DEFAULT_PINE_MODEL,
 }
 
 DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
@@ -207,6 +213,7 @@ DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
     "nova": None,
     "qwen": None,
     "livekit": None,
+    "pine": None,
 }
 
 AUDIO_NATIVE_PROVIDER_TYPES = {
@@ -216,6 +223,7 @@ AUDIO_NATIVE_PROVIDER_TYPES = {
     "nova": "audio_native",
     "qwen": "audio_native",
     "livekit": "cascaded",
+    "pine": "audio_native",
 }
 
 # =============================================================================

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -69,9 +69,9 @@ class AudioNativeConfig(BaseModel):
     """
 
     # Provider selection
-    provider: Literal["openai", "gemini", "xai", "nova", "qwen", "livekit"] = Field(
+    provider: Literal["openai", "gemini", "xai", "nova", "qwen", "livekit", "pine"] = Field(
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
-        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
+        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), 'livekit' (LiveKit cascaded STT→LLM→TTS), or 'pine' (Pine OpenAI-Realtime-compatible gateway)",
     )
 
     # Cascaded config (for livekit provider)

--- a/src/tau2/utils/llm_utils.py
+++ b/src/tau2/utils/llm_utils.py
@@ -230,9 +230,24 @@ def validate_message(message: Message) -> None:
             f"System message must have content. got {message}"
         )
     if isinstance(message, ParticipantMessageBase):
-        assert has_content_or_tool_calls(message), (
-            f"Message must have content or tool calls. got {message}"
-        )
+        # In streaming audio-native (voice) mode, participant messages can
+        # legitimately have empty text content:
+        #   1. is_audio=True chunks carry audio as the payload, not text.
+        #   2. The streaming user simulator can emit an empty completion while
+        #      it is still listening; that empty UserMessage is stored in the
+        #      history and would otherwise fail this validation on a later turn.
+        # Both are normal in voice mode (this assertion was written for
+        # text-only sessions), so skip empty participant messages here instead
+        # of raising.
+        if not has_content_or_tool_calls(message):
+            from loguru import logger as _logger
+
+            _logger.debug(
+                f"Skipping empty ParticipantMessage in history "
+                f"(is_audio={getattr(message, 'is_audio', False)}, "
+                f"is_final_chunk={getattr(message, 'is_final_chunk', False)})"
+            )
+            return
 
 
 def validate_message_history(messages: list[Message]) -> None:

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -396,6 +396,17 @@ def create_adapter(
             reasoning_effort=reasoning_effort,
             audio_format=audio_format,
         )
+    elif provider == "pine":
+        from tau2.voice.audio_native.pine.discrete_time_adapter import (
+            DiscreteTimePineAdapter,
+        )
+
+        adapter = DiscreteTimePineAdapter(
+            tick_duration_ms=tick_duration_ms,
+            send_audio_instant=send_audio_instant,
+            model=model,
+            audio_format=audio_format,
+        )
     elif provider == "gemini":
         from tau2.voice.audio_native.gemini.discrete_time_adapter import (
             DiscreteTimeGeminiAdapter,

--- a/src/tau2/voice/audio_native/pine/__init__.py
+++ b/src/tau2/voice/audio_native/pine/__init__.py
@@ -1,0 +1,34 @@
+"""Pine provider for tau2-bench audio-native evaluation.
+
+Pine exposes an OpenAI-Realtime-API-compatible endpoint. The wire format
+(event names, JSON shapes, base64 audio framing) matches the OpenAI provider;
+the differences are:
+- Different WebSocket endpoint (configurable via PINE_BASE_URL).
+- Different bearer token (PINE_API_KEY).
+- Single-modality audio sessions only.
+- Server-VAD turn detection only.
+
+See https://tau-bench.pinevoice.ai/ for how to obtain an API key.
+"""
+
+from tau2.voice.audio_native.pine.discrete_time_adapter import (
+    DiscreteTimePineAdapter,
+)
+from tau2.voice.audio_native.pine.events import (
+    BasePineEvent,
+    parse_pine_event,
+)
+from tau2.voice.audio_native.pine.provider import (
+    PineProvider,
+    PineVADConfig,
+    PineVADMode,
+)
+
+__all__ = [
+    "DiscreteTimePineAdapter",
+    "PineProvider",
+    "PineVADConfig",
+    "PineVADMode",
+    "BasePineEvent",
+    "parse_pine_event",
+]

--- a/src/tau2/voice/audio_native/pine/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/pine/discrete_time_adapter.py
@@ -1,0 +1,327 @@
+"""Discrete-time tick adapter for Pine.
+
+Structurally identical to `tau2.voice.audio_native.openai.discrete_time_adapter`,
+which is the right reference because Pine and OpenAI Realtime share a
+wire-compatible event taxonomy. The only Pine-specific behavior is that this
+adapter routes through PineProvider (different endpoint, auth, and
+session-config fields).
+"""
+
+import asyncio
+import base64
+import json
+from typing import Any, List, Optional
+
+from loguru import logger
+
+from tau2.config import (
+    DEFAULT_AUDIO_NATIVE_CONNECT_TIMEOUT,
+    DEFAULT_AUDIO_NATIVE_DISCONNECT_TIMEOUT,
+    DEFAULT_AUDIO_NATIVE_TICK_TIMEOUT_BUFFER,
+)
+from tau2.data_model.audio import AudioFormat
+from tau2.data_model.message import ToolCall
+from tau2.environment.tool import Tool
+from tau2.voice.audio_native.adapter import DiscreteTimeAdapter
+from tau2.voice.audio_native.async_loop import BackgroundAsyncLoop
+from tau2.voice.audio_native.openai.events import (
+    AudioDeltaEvent,
+    AudioDoneEvent,
+    AudioTranscriptDeltaEvent,
+    AudioTranscriptDoneEvent,
+    FunctionCallArgumentsDoneEvent,
+    ResponseDoneEvent,
+    SpeechStartedEvent,
+    SpeechStoppedEvent,
+)
+from tau2.voice.audio_native.pine.provider import (
+    PineProvider,
+    PineVADConfig,
+    PineVADMode,
+    DEFAULT_PINE_VAD_THRESHOLD,
+)
+from tau2.voice.audio_native.tick_result import TickResult, UtteranceTranscript
+
+
+class DiscreteTimePineAdapter(DiscreteTimeAdapter):
+    """Tick-based adapter for the Pine protocol."""
+
+    def __init__(
+        self,
+        tick_duration_ms: int,
+        send_audio_instant: bool = False,
+        model: Optional[str] = None,
+        voice: Optional[str] = None,
+        provider: Optional[PineProvider] = None,
+        audio_format: Optional[AudioFormat] = None,
+    ):
+        super().__init__(
+            tick_duration_ms,
+            audio_format=audio_format,
+            send_audio_instant=send_audio_instant,
+        )
+
+        self._chunk_size = int(
+            self.audio_format.bytes_per_second * self._voip_interval_ms / 1000
+        )
+
+        if model is not None and provider is not None:
+            raise ValueError("model and provider cannot both be supplied")
+
+        self.model = model
+        self.voice = voice
+        self._provider = provider
+        self._owns_provider = provider is None
+
+        self._bg_loop = BackgroundAsyncLoop()
+        self._connected = False
+
+    @property
+    def provider(self) -> PineProvider:
+        if self._provider is None:
+            self._provider = PineProvider(model=self.model, voice=self.voice)
+        return self._provider
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected and self._bg_loop.is_running
+
+    def connect(
+        self,
+        system_prompt: str,
+        tools: List[Tool],
+        vad_config: Any = None,
+        modality: str = "audio",
+    ) -> None:
+        if self._connected:
+            logger.warning("Pine: already connected; reconnecting")
+            self.disconnect()
+
+        # Coerce any incoming vad_config to a PineVADConfig. The orchestrator
+        # may pass another provider's VAD config (e.g. NovaVADConfig) when no
+        # provider-specific override is set.
+        if not isinstance(vad_config, PineVADConfig):
+            vad_config = PineVADConfig(
+                mode=PineVADMode.SERVER_VAD,
+                threshold=getattr(vad_config, "threshold", DEFAULT_PINE_VAD_THRESHOLD)
+                if vad_config is not None
+                else DEFAULT_PINE_VAD_THRESHOLD,
+                prefix_padding_ms=getattr(vad_config, "prefix_padding_ms", 300)
+                if vad_config is not None
+                else 300,
+                silence_duration_ms=getattr(vad_config, "silence_duration_ms", 500)
+                if vad_config is not None
+                else 500,
+            )
+
+        self._bg_loop.start()
+        try:
+            self._bg_loop.run_coroutine(
+                self._async_connect(system_prompt, tools, vad_config, modality),
+                timeout=DEFAULT_AUDIO_NATIVE_CONNECT_TIMEOUT,
+            )
+            self._connected = True
+            logger.info(
+                f"Pine adapter connected (tick={self.tick_duration_ms}ms, "
+                f"bytes_per_tick={self.bytes_per_tick})"
+            )
+        except Exception as e:
+            logger.error(f"Pine connect failed: {e}")
+            self._bg_loop.stop()
+            raise RuntimeError(f"Pine connect failed: {e}") from e
+
+    async def _async_connect(self, system_prompt, tools, vad_config, modality) -> None:
+        await self.provider.connect()
+        await self.provider.configure_session(
+            system_prompt=system_prompt,
+            tools=tools,
+            vad_config=vad_config,
+            modality=modality,
+            audio_format=self.audio_format,
+        )
+
+    def disconnect(self) -> None:
+        if not self._connected:
+            return
+        if self._bg_loop.is_running:
+            try:
+                self._bg_loop.run_coroutine(
+                    self._async_disconnect(),
+                    timeout=DEFAULT_AUDIO_NATIVE_DISCONNECT_TIMEOUT,
+                )
+            except Exception as e:
+                logger.warning(f"Pine disconnect: {e}")
+        self._bg_loop.stop()
+        self._connected = False
+        self._tick_count = 0
+        self._cumulative_user_audio_ms = 0
+        self.clear_buffers()
+        logger.info("Pine adapter disconnected")
+
+    async def _async_disconnect(self) -> None:
+        if self._owns_provider and self._provider is not None:
+            await self.provider.disconnect()
+
+    def run_tick(
+        self, user_audio: bytes, tick_number: Optional[int] = None
+    ) -> TickResult:
+        if not self.is_connected:
+            raise RuntimeError("Pine adapter not connected")
+        if tick_number is None:
+            tick_number = self._tick_count
+        self._tick_count = tick_number + 1
+        try:
+            return self._bg_loop.run_coroutine(
+                self._async_run_tick(user_audio, tick_number),
+                timeout=self.tick_duration_ms / 1000
+                + DEFAULT_AUDIO_NATIVE_TICK_TIMEOUT_BUFFER,
+            )
+        except Exception as e:
+            logger.error(f"Pine run_tick (tick={tick_number}): {e}")
+            raise
+
+    async def _flush_pending_tool_results(self) -> None:
+        for (
+            call_id,
+            result_str,
+            request_response,
+            _is_error,
+        ) in self._pending_tool_results:
+            await self.provider.send_tool_result(call_id, result_str, request_response)
+        self._pending_tool_results.clear()
+
+    async def _execute_tick(
+        self,
+        user_audio: bytes,
+        tick_number: int,
+        result: TickResult,
+        tick_start: float,
+    ) -> None:
+        """Send user audio, receive Pine events for the tick window, process them."""
+
+        async def receive_events():
+            elapsed = asyncio.get_running_loop().time() - tick_start
+            remaining = max(0.01, (self.tick_duration_ms / 1000) - elapsed)
+            return await self.provider.receive_events_for_duration(remaining)
+
+        _, events = await asyncio.gather(
+            self._send_audio_chunked(
+                user_audio, self.provider.send_audio, self._chunk_size
+            ),
+            receive_events(),
+        )
+
+        for event in events:
+            await self._process_event(result, event)
+
+    async def _process_event(self, result: TickResult, event: Any) -> None:
+        """Handle a single Pine event (mirrors OpenAI adapter behavior).
+
+        Load-bearing branches:
+        - AudioDeltaEvent -> buffer assistant audio (skip if item was truncated)
+        - AudioTranscriptDeltaEvent -> accumulate transcript
+        - SpeechStartedEvent -> barge-in: clear buffers, call truncate_item
+        - SpeechStoppedEvent -> record VAD edge
+        - FunctionCallArgumentsDoneEvent -> emit ToolCall
+
+        Done/end events are logged. Unknown events are also logged for forward compat.
+        """
+        result.events.append(event)
+
+        if isinstance(event, AudioDeltaEvent):
+            item_id = getattr(event, "item_id", None)
+
+            if result.skip_item_id is not None:
+                if item_id == result.skip_item_id:
+                    result.truncated_audio_bytes += len(base64.b64decode(event.delta))
+                    return
+                else:
+                    result.skip_item_id = None
+
+            decoded = base64.b64decode(event.delta)
+            result.agent_audio_chunks.append((decoded, item_id))
+
+            if item_id:
+                if item_id not in self._utterance_transcripts:
+                    self._utterance_transcripts[item_id] = UtteranceTranscript(
+                        item_id=item_id
+                    )
+                self._utterance_transcripts[item_id].add_audio(len(decoded))
+
+        elif isinstance(event, AudioTranscriptDeltaEvent):
+            item_id = getattr(event, "item_id", None)
+            if item_id and event.delta:
+                if item_id not in self._utterance_transcripts:
+                    self._utterance_transcripts[item_id] = UtteranceTranscript(
+                        item_id=item_id
+                    )
+                self._utterance_transcripts[item_id].add_transcript(event.delta)
+
+        elif isinstance(event, SpeechStartedEvent):
+            logger.debug(
+                f"Pine: speech_started @ {getattr(event, 'audio_start_ms', None)}ms"
+            )
+            result.vad_events.append("speech_started")
+
+            has_agent_audio = result.agent_audio_chunks or self._buffered_agent_audio
+            if has_agent_audio:
+                last_item_id = None
+                if result.agent_audio_chunks:
+                    last_item_id = result.agent_audio_chunks[-1][1]
+                elif self._buffered_agent_audio:
+                    last_item_id = self._buffered_agent_audio[-1][1]
+
+                if self._buffered_agent_audio:
+                    buffered_bytes = sum(len(c[0]) for c in self._buffered_agent_audio)
+                    result.truncated_audio_bytes += buffered_bytes
+                    self._buffered_agent_audio.clear()
+
+                audio_start_ms = (
+                    event.audio_start_ms if event.audio_start_ms is not None else 0
+                )
+                result.truncate_agent_audio(
+                    item_id=last_item_id,
+                    audio_start_ms=audio_start_ms,
+                    cumulative_user_audio_at_tick_start_ms=result.cumulative_user_audio_at_tick_start_ms,
+                    bytes_per_tick=result.bytes_per_tick,
+                )
+
+                if last_item_id is not None:
+                    played = result.get_played_agent_audio()
+                    audio_end_ms = int(
+                        len(played) / self.audio_format.bytes_per_second * 1000
+                    )
+                    await self.provider.truncate_item(
+                        item_id=last_item_id,
+                        content_index=0,
+                        audio_end_ms=audio_end_ms,
+                    )
+
+        elif isinstance(event, SpeechStoppedEvent):
+            logger.debug(
+                f"Pine: speech_stopped @ {getattr(event, 'audio_end_ms', None)}ms"
+            )
+            result.vad_events.append("speech_stopped")
+
+        elif isinstance(event, FunctionCallArgumentsDoneEvent):
+            if event.call_id and event.name:
+                try:
+                    arguments = json.loads(event.arguments) if event.arguments else {}
+                except json.JSONDecodeError:
+                    arguments = {}
+                tool_call = ToolCall(
+                    id=event.call_id,
+                    name=event.name,
+                    arguments=arguments,
+                )
+                result.tool_calls.append(tool_call)
+                logger.debug(f"Pine: tool call {event.name}({event.call_id})")
+
+        elif isinstance(event, AudioDoneEvent):
+            logger.debug(f"Pine: audio done item={event.item_id}")
+        elif isinstance(event, AudioTranscriptDoneEvent):
+            logger.debug(f"Pine: transcript done item={event.item_id}")
+        elif isinstance(event, ResponseDoneEvent):
+            logger.debug("Pine: response done")
+        else:
+            logger.debug(f"Pine: event {event.type}")

--- a/src/tau2/voice/audio_native/pine/events.py
+++ b/src/tau2/voice/audio_native/pine/events.py
@@ -1,0 +1,127 @@
+"""Pydantic models for Pine Realtime protocol events.
+
+Pine's wire format mirrors OpenAI Realtime's. We re-export OpenAI's event
+classes under Pine-prefixed aliases so the adapter is fully typed without
+duplicating definitions, but keep our own parser dispatch so unsupported
+events do not crash if a future Pine server emits them.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+from tau2.voice.audio_native.openai.events import (
+    AudioDeltaEvent,
+    AudioDoneEvent,
+    AudioTranscriptDeltaEvent,
+    AudioTranscriptDoneEvent,
+    BaseRealtimeEvent,
+    ConversationItemCreatedEvent,
+    ConversationItemTruncatedEvent,
+    ErrorEvent,
+    FunctionCallArgumentsDoneEvent,
+    InputAudioTranscriptionCompletedEvent,
+    RateLimitsUpdatedEvent,
+    ResponseCreatedEvent,
+    ResponseDoneEvent,
+    SessionCreatedEvent,
+    SessionUpdatedEvent,
+    SpeechStartedEvent,
+    SpeechStoppedEvent,
+    TimeoutEvent,
+    UnknownEvent,
+)
+
+
+# Aliases - Pine uses the same event types as OpenAI Realtime.
+BasePineEvent = BaseRealtimeEvent
+PineTimeoutEvent = TimeoutEvent
+PineUnknownEvent = UnknownEvent
+
+
+class PineErrorDetails(BaseModel):
+    """Structured Pine error payload."""
+
+    code: Optional[str] = None
+    message: Optional[str] = None
+    param: Optional[str] = None
+    fatal: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Event-type -> class map.
+# ---------------------------------------------------------------------------
+_EVENT_TYPE_MAP: dict[str, type[BaseRealtimeEvent]] = {
+    "session.created": SessionCreatedEvent,
+    "session.updated": SessionUpdatedEvent,
+    "response.created": ResponseCreatedEvent,
+    "response.output_audio.delta": AudioDeltaEvent,
+    "response.output_audio.done": AudioDoneEvent,
+    "response.output_audio_transcript.delta": AudioTranscriptDeltaEvent,
+    "response.output_audio_transcript.done": AudioTranscriptDoneEvent,
+    "response.function_call_arguments.done": FunctionCallArgumentsDoneEvent,
+    "response.done": ResponseDoneEvent,
+    "input_audio_buffer.speech_started": SpeechStartedEvent,
+    "input_audio_buffer.speech_stopped": SpeechStoppedEvent,
+    "conversation.item.created": ConversationItemCreatedEvent,
+    "conversation.item.truncated": ConversationItemTruncatedEvent,
+    "conversation.item.input_audio_transcription.completed": InputAudioTranscriptionCompletedEvent,
+    "rate_limits.updated": RateLimitsUpdatedEvent,
+    "error": ErrorEvent,
+    "timeout": TimeoutEvent,
+}
+
+
+def parse_pine_event(raw_data: dict) -> BasePineEvent:
+    """Parse raw event data into a typed event model.
+
+    Mirrors OpenAI Realtime's event-extraction logic since Pine's wire format
+    is identical for the supported event subset. Unknown event types fall back
+    to UnknownEvent rather than crashing.
+    """
+    event_type = raw_data.get("type", "unknown")
+    event_class = _EVENT_TYPE_MAP.get(event_type)
+
+    if event_class is None:
+        return UnknownEvent(type=event_type, raw=raw_data)
+
+    parsed = _extract_fields(event_type, raw_data)
+    return event_class.model_validate(parsed)
+
+
+def _extract_fields(event_type: str, raw: dict) -> dict:
+    """Pull the fields each event class expects from the raw JSON payload."""
+    out: dict = {"type": event_type, "event_id": raw.get("event_id")}
+
+    if event_type == "response.done":
+        out["response_id"] = raw.get("response_id") or raw.get("response", {}).get("id")
+        out["status"] = raw.get("status") or raw.get("response", {}).get("status")
+        out["usage"] = raw.get("usage") or raw.get("response", {}).get("usage")
+    elif event_type == "error":
+        err = raw.get("error", {})
+        out["code"] = err.get("code")
+        out["message"] = err.get("message")
+    elif event_type == "conversation.item.created":
+        item = raw.get("item", {})
+        out["item_id"] = item.get("id")
+        out["item"] = item
+    elif event_type == "session.created":
+        sess = raw.get("session", {})
+        out["event_id"] = out["event_id"] or sess.get("id")
+    else:
+        for key in (
+            "delta",
+            "text",
+            "transcript",
+            "response_id",
+            "item_id",
+            "call_id",
+            "name",
+            "arguments",
+            "audio_start_ms",
+            "audio_end_ms",
+            "content_index",
+        ):
+            if key in raw:
+                out[key] = raw[key]
+    return out

--- a/src/tau2/voice/audio_native/pine/provider.py
+++ b/src/tau2/voice/audio_native/pine/provider.py
@@ -1,0 +1,382 @@
+"""Pine Realtime WebSocket provider for tau2-bench.
+
+Pine exposes an OpenAI-Realtime-API-compatible endpoint: the wire protocol
+(``session.update``, ``input_audio_buffer.*``, ``response.*``, function calls,
+and barge-in via ``conversation.item.truncate``) matches the OpenAI Realtime
+protocol for the subset this adapter uses. This provider is therefore a thin
+sibling of ``tau2.voice.audio_native.openai.provider`` with the base URL and
+bearer credential pointed at the Pine gateway.
+
+Authentication is a single durable bearer token presented on the WebSocket
+upgrade:
+
+    PINE_API_KEY     Pine API key (bearer token on the WS upgrade)
+    PINE_BASE_URL    WebSocket endpoint
+                     (default: wss://api-preview.pinevoice.ai/v1/realtime)
+
+See https://tau-bench.pinevoice.ai/ for how to obtain an API key.
+"""
+
+import asyncio
+import base64
+import json
+import os
+from enum import Enum
+from typing import AsyncGenerator, Dict, List, Optional
+
+import websockets
+from dotenv import load_dotenv
+from loguru import logger
+from pydantic import BaseModel
+
+from tau2.config import (
+    DEFAULT_PINE_BASE_URL,
+    DEFAULT_PINE_MODEL,
+)
+from tau2.data_model.audio import TELEPHONY_AUDIO_FORMAT, AudioEncoding, AudioFormat
+from tau2.environment.tool import Tool
+from tau2.utils.retry import websocket_retry
+from tau2.voice.audio_native.pine.events import (
+    BasePineEvent,
+    PineTimeoutEvent,
+    PineUnknownEvent,
+    parse_pine_event,
+)
+
+load_dotenv()
+
+
+DEFAULT_PINE_VOICE = "alloy"
+DEFAULT_PINE_VAD_THRESHOLD = 0.5
+
+
+def _audio_format_to_pine(audio_format: AudioFormat) -> str:
+    """Map a tau2 AudioFormat to the Pine wire-format string.
+
+    Pine accepts:
+        g711_ulaw: 8 kHz mu-law (telephony default)
+        pcm16:     signed-LE PCM (24 kHz)
+    """
+    enc = audio_format.encoding
+    rate = audio_format.sample_rate
+    if enc == AudioEncoding.ULAW and rate == 8000:
+        return "g711_ulaw"
+    if enc == AudioEncoding.PCM_S16LE:
+        if rate != 24000:
+            logger.warning(
+                f"Pine pcm16 is specified at 24 kHz; got {rate} Hz - "
+                f"the server will receive audio at this rate. Consider "
+                f"g711_ulaw 8 kHz for telephony."
+            )
+        return "pcm16"
+    raise ValueError(
+        f"Audio format {audio_format} not supported by Pine "
+        f"(expected ULAW 8kHz or PCM_S16LE 24kHz)"
+    )
+
+
+class PineVADMode(str, Enum):
+    """Server-side VAD turn detection."""
+
+    SERVER_VAD = "server_vad"
+
+
+class PineVADConfig(BaseModel):
+    """Configuration for Pine server VAD."""
+
+    mode: PineVADMode = PineVADMode.SERVER_VAD
+    threshold: float = DEFAULT_PINE_VAD_THRESHOLD
+    prefix_padding_ms: int = 300
+    silence_duration_ms: int = 500
+
+
+class PineProvider:
+    """Pine Realtime WebSocket provider.
+
+    Manages a single WebSocket session against the Pine gateway. One provider
+    instance maps to one connection, which maps to one conversation.
+
+    Example:
+        ```python
+        provider = PineProvider()
+        await provider.connect()
+        await provider.configure_session(system_prompt, tools, PineVADConfig())
+        async for event in provider.receive_events():
+            ...
+        await provider.disconnect()
+        ```
+    """
+
+    BASE_URL = DEFAULT_PINE_BASE_URL
+    DEFAULT_MODEL = DEFAULT_PINE_MODEL
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        model: Optional[str] = None,
+        voice: Optional[str] = None,
+    ):
+        """Initialize the Pine provider.
+
+        Args:
+            api_key: Pine API key. Defaults to env PINE_API_KEY.
+            base_url: WebSocket endpoint. Defaults to env PINE_BASE_URL or the
+                public gateway.
+            model: Model identifier (sent in session.update).
+            voice: TTS voice name (server's choice if None).
+
+        Raises:
+            ValueError: If no API key is provided.
+        """
+        self.api_key = api_key or os.environ.get("PINE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Pine API key not provided. Set the PINE_API_KEY env var. "
+                "See https://tau-bench.pinevoice.ai/ for how to obtain one."
+            )
+
+        self.base_url = base_url or os.environ.get("PINE_BASE_URL", self.BASE_URL)
+        self.model = model or self.DEFAULT_MODEL
+        self.voice = voice or DEFAULT_PINE_VOICE
+        self.ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._current_vad_config: Optional[PineVADConfig] = None
+        self._audio_format: AudioFormat = TELEPHONY_AUDIO_FORMAT
+        self.session_id: Optional[str] = None
+
+    @property
+    def is_connected(self) -> bool:
+        if self.ws is None:
+            return False
+        from websockets.protocol import State
+
+        return self.ws.state == State.OPEN
+
+    @property
+    def audio_format(self) -> AudioFormat:
+        return self._audio_format
+
+    @websocket_retry
+    async def connect(self) -> None:
+        """Open the WebSocket and read session.created.
+
+        The durable PINE_API_KEY is presented as the bearer token on the
+        WebSocket upgrade.
+        """
+        if self.is_connected:
+            return
+
+        url = self.base_url
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+
+        logger.info(f"Pine: connecting to {url}")
+        # ping_interval/ping_timeout are raised from the websockets library
+        # defaults (20/20) to 30/60 so long sessions are not closed with 1011
+        # keepalive errors when the agent's monologue or local audio playback
+        # keeps the main thread busy past the default 20s pong deadline.
+        self.ws = await websockets.connect(
+            url,
+            additional_headers=headers,
+            ping_interval=30,
+            ping_timeout=60,
+        )
+
+        raw = await self.ws.recv()
+        data = json.loads(raw)
+        if data.get("type") != "session.created":
+            raise RuntimeError(
+                f"Expected session.created, got {data.get('type')!r}: {data}"
+            )
+
+        sess = data.get("session", {})
+        self.session_id = sess.get("id")
+        proto_v = sess.get("protocol_version", "?")
+        server_v = sess.get("server_version", "?")
+        logger.info(
+            f"Pine: session_id={self.session_id} protocol={proto_v} server={server_v}"
+        )
+
+    async def disconnect(self) -> None:
+        if self.ws:
+            logger.info("Pine: disconnecting")
+            await self.ws.close()
+            self.ws = None
+            logger.info("Pine: disconnected")
+
+    def _build_turn_detection_config(self, vad_config: PineVADConfig) -> Dict:
+        """Build the turn_detection block for session.update."""
+        return {
+            "type": "server_vad",
+            "threshold": vad_config.threshold,
+            "prefix_padding_ms": vad_config.prefix_padding_ms,
+            "silence_duration_ms": vad_config.silence_duration_ms,
+        }
+
+    def _format_tools_for_api(self, tools: List[Tool]) -> List[Dict]:
+        """Convert tau2 Tool objects to Pine tool definitions (OpenAI format)."""
+        formatted: List[Dict] = []
+        for tool in tools:
+            schema = tool.openai_schema
+            formatted.append(
+                {
+                    "type": "function",
+                    "name": schema["function"]["name"],
+                    "description": schema["function"]["description"],
+                    "parameters": schema["function"]["parameters"],
+                }
+            )
+        return formatted
+
+    async def configure_session(
+        self,
+        system_prompt: str,
+        tools: List[Tool],
+        vad_config: PineVADConfig,
+        modality: str = "audio",
+        audio_format: Optional[AudioFormat] = None,
+    ) -> None:
+        """Send session.update and block until session.updated arrives.
+
+        Args:
+            system_prompt: The agent's instructions.
+            tools: Tool definitions.
+            vad_config: Server VAD config.
+            modality: Must be "audio".
+            audio_format: Wire audio format (telephony mu-law by default).
+        """
+        if not self.is_connected:
+            raise RuntimeError("Not connected. Call connect() first.")
+        if modality != "audio":
+            raise ValueError(
+                f"Pine only supports modality='audio'; got {modality!r}"
+            )
+
+        if audio_format is None:
+            audio_format = TELEPHONY_AUDIO_FORMAT
+        self._audio_format = audio_format
+        wire_fmt = _audio_format_to_pine(audio_format)
+
+        session = {
+            "type": "realtime",
+            "instructions": system_prompt,
+            "output_modalities": ["audio"],
+            "tools": self._format_tools_for_api(tools),
+            "tool_choice": "auto",
+            "audio": {
+                "input": {
+                    "format": wire_fmt,
+                    "transcription": {"model": "whisper-1", "language": "en"},
+                    "noise_reduction": {"type": "near_field"},
+                    "turn_detection": self._build_turn_detection_config(vad_config),
+                },
+                "output": {
+                    "format": wire_fmt,
+                    "voice": self.voice,
+                },
+            },
+        }
+        payload = {"type": "session.update", "session": session}
+        await self.ws.send(json.dumps(payload))
+
+        while True:
+            raw = await self.ws.recv()
+            data = json.loads(raw)
+            t = data.get("type", "")
+            if t == "session.updated":
+                self._current_vad_config = vad_config
+                logger.info(
+                    f"Pine: session configured (format={wire_fmt}, tools={len(tools)})"
+                )
+                return
+            if t == "error":
+                err = data.get("error", {})
+                msg = err.get("message", "unknown")
+                code = err.get("code", "?")
+                raise RuntimeError(f"Pine session.update rejected: {code}: {msg}")
+            # Tolerate informational events between update and updated.
+            logger.debug(f"Pine: ignoring pre-updated event {t}")
+
+    async def send_audio(self, audio_data: bytes) -> None:
+        """Append a chunk of user audio to the input buffer."""
+        if not self.is_connected:
+            raise RuntimeError("Not connected to Pine")
+        b64 = base64.b64encode(audio_data).decode("utf-8")
+        await self.ws.send(
+            json.dumps({"type": "input_audio_buffer.append", "audio": b64})
+        )
+
+    async def send_tool_result(
+        self, call_id: str, result: str, request_response: bool = True
+    ) -> None:
+        """Return a tool result and (by default) trigger response.create."""
+        if not self.is_connected:
+            raise RuntimeError("Not connected to Pine")
+        item = {
+            "type": "conversation.item.create",
+            "item": {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": result,
+            },
+        }
+        await self.ws.send(json.dumps(item))
+        if request_response:
+            await self.ws.send(json.dumps({"type": "response.create"}))
+
+    async def truncate_item(
+        self, item_id: str, content_index: int, audio_end_ms: int
+    ) -> None:
+        """Tell the server how much audio was actually played for an item."""
+        if not self.is_connected:
+            raise RuntimeError("Not connected to Pine")
+        await self.ws.send(
+            json.dumps(
+                {
+                    "type": "conversation.item.truncate",
+                    "item_id": item_id,
+                    "content_index": content_index,
+                    "audio_end_ms": audio_end_ms,
+                }
+            )
+        )
+        logger.debug(
+            f"Pine: truncate item={item_id} content_index={content_index} "
+            f"audio_end_ms={audio_end_ms}"
+        )
+
+    async def receive_events(self) -> AsyncGenerator[BasePineEvent, None]:
+        """Yield parsed events from the WebSocket. Emits TimeoutEvent every 10ms."""
+        if not self.is_connected:
+            raise RuntimeError("Not connected to Pine")
+
+        while self.is_connected:
+            try:
+                raw = await asyncio.wait_for(self.ws.recv(), timeout=0.01)
+                data = json.loads(raw)
+                yield parse_pine_event(data)
+            except asyncio.TimeoutError:
+                yield PineTimeoutEvent(type="timeout")
+            except websockets.ConnectionClosed as e:
+                logger.error(
+                    f"Pine: WebSocket closed code={e.code} reason={e.reason!r}"
+                )
+                raise RuntimeError(
+                    f"Pine WebSocket closed (code={e.code} reason={e.reason!r})"
+                ) from e
+            except Exception as e:
+                logger.error(f"Pine: error receiving event: {type(e).__name__}: {e}")
+                yield PineUnknownEvent(type="error", raw={"error": str(e)})
+
+    async def receive_events_for_duration(
+        self, duration_seconds: float
+    ) -> List[BasePineEvent]:
+        """Collect non-timeout events for `duration_seconds`."""
+        events: List[BasePineEvent] = []
+        end_time = asyncio.get_event_loop().time() + duration_seconds
+
+        async for event in self.receive_events():
+            if not isinstance(event, PineTimeoutEvent):
+                events.append(event)
+            if asyncio.get_event_loop().time() >= end_time:
+                break
+        return events

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -28,7 +28,8 @@
     "gemini-3-1-flash-live-preview-thinking-high_google_2026-04-02",
     "gemini-3-1-flash-live-preview-thinking-minimal_google_2026-04-13",
     "gpt-realtime-1-0_openai_2026-04-13",
-    "livekit-cascaded_livekit_2026-05-19"
+    "livekit-cascaded_livekit_2026-05-19",
+    "pine-realtime-1.0-preview_pine_2026-06-09"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",

--- a/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/REPRODUCE.md
+++ b/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/REPRODUCE.md
@@ -12,9 +12,14 @@ The public endpoint is `wss://api-preview.pinevoice.ai/v1/realtime`.
 
 ## 1. Get a Pine API key (email + verification code)
 
-Authenticate through the Pine gateway. It proxies email verification and caches
-the token → user mapping as it issues your token, so the token then works
-against the realtime API with a plain `Authorization: Bearer <token>` header.
+Authenticate through the Pine gateway. A Pine user-id cannot be derived from an
+access token, so the realtime API resolves your user from a token → user mapping
+the gateway maintains. Verifying *through the gateway* (the `api-preview.pinevoice.ai`
+host below — **not** `19pine.ai` directly) registers that mapping as it issues your
+token, so the token then works on the socket with a plain `Authorization: Bearer
+<token>` header. Capture **both** the `access_token` and your user `id` from the
+verify response — you need the `id` if you have to register the token manually
+(see the note after step **b** and Troubleshooting).
 
 **a. Request a code** — a 4-digit code is emailed to you:
 
@@ -37,12 +42,26 @@ curl -X POST https://api-preview.pinevoice.ai/api/v2/auth/verify \
         "code": "1234",
         "request_token": "abc..."
       }'
-# -> response includes "access_token": "<your durable Pine API key>"
+# -> {"status":"success","data":{"access_token":"<durable Pine API key>","id":"<your user id>"}}
 ```
 
-The `access_token` is your `PINE_API_KEY`. Because you verified *through the
-gateway*, it is already registered with the realtime API — no extra headers
-needed. (See https://tau-bench.pinevoice.ai/ for the same flow with a live demo.)
+The `data.access_token` is your `PINE_API_KEY`; keep `data.id` (your user id) too.
+Because you verified *through the gateway*, the token is normally registered with
+the realtime API already — no extra headers needed.
+
+**If your first run 401s on the WebSocket upgrade** (`invalid or expired
+credential` / `token not registered …`), the token → user mapping wasn't seeded.
+Register it once with a single call that carries your user id, then re-run:
+
+```bash
+curl -X POST https://api-preview.pinevoice.ai/v1/realtime/client_secrets \
+  -H "Authorization: Bearer ${PINE_API_KEY}" \
+  -H "X-Pine-User-Id: <data.id from above>" \
+  -H "Content-Type: application/json" -d '{}'
+# 200 here registers the token; you can discard the returned ephemeral secret.
+```
+
+(See https://tau-bench.pinevoice.ai/ for the same flow with a live demo.)
 
 ---
 
@@ -50,7 +69,7 @@ needed. (See https://tau-bench.pinevoice.ai/ for the same flow with a live demo.
 
 ```bash
 git clone <this-fork> tau2-bench && cd tau2-bench
-git checkout submission/pine-realtime-1.0-preview-2026-06-09
+git checkout submission/pine-realtime-1.0-preview
 uv sync                      # installs the `voice` extras (websockets, pyaudio, scipy, ...)
 ```
 
@@ -111,6 +130,17 @@ done
 The agent loads as `discrete_time_audio_native_agent → pine/pine-realtime-1.0-preview`.
 Results (per-task reward, transcripts, audio) are written under
 `data/simulations/<save-to>/`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401` on the WS upgrade — `token not registered with the realtime gateway: …` or `invalid or expired credential` | The `pine` provider presents `PINE_API_KEY` as a bearer token directly on the socket, and the gateway has no token → user mapping for it (verified off-gateway, or the verify response didn't seed it). | Run the one-time registration `curl` in step **1** (it sends `X-Pine-User-Id`), then re-run. Make sure you verified against `api-preview.pinevoice.ai`, not `19pine.ai`. |
+| `Pine API key not provided. Set the PINE_API_KEY env var.` | `PINE_API_KEY` unset. | Export the `data.access_token` from step **1**. |
+| Voice deps missing / `libportaudio.so.2: cannot open shared object file` | PortAudio not installed (or not on the linker path on minimal hosts). | `sudo apt-get install -y portaudio19-dev`, then `uv sync`. |
+| `ELEVENLABS_API_KEY not found` | User-simulator TTS key unset. | Export `ELEVENLABS_API_KEY` (step **3**). |
 
 ---
 

--- a/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/REPRODUCE.md
+++ b/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/REPRODUCE.md
@@ -92,12 +92,28 @@ export OPENROUTER_API_KEY="<your OpenRouter key>"
 export ELEVENLABS_API_KEY="<your ElevenLabs key>"
 ```
 
-**Models.** This submission ran the **user simulator** on
-`openrouter/openai/gpt-5.2` (passed via `--user-llm`, hence `OPENROUTER_API_KEY`).
-The **evaluator / judge models** (NL-assertion grader, env-interface, review judge,
-voice turn-taking) are left at tau2-bench's shipped defaults — we did not change
-`config.py`, and the exact evaluator model isn't material to the scores, so you can
-run them as-is. If you do run grading on those defaults, provide the corresponding
+**Models.** This submission uses the **standard voice user simulator v1.0 =
+`gpt-4.1`**, matching the other voice leaderboard entries. The v1.0 user simulator
+has **two** model slots that both must be `gpt-4.1` for a standard run:
+
+1. the **user-content LLM** — passed via `--user-llm openrouter/openai/gpt-4.1`
+   (hence `OPENROUTER_API_KEY`); and
+2. the **turn-taking decision model** that drives the simulated caller's
+   interrupt/backchannel timing — `VOICE_USER_SIMULATOR_DECISION_MODEL` in
+   `src/tau2/config.py`. The standard v1.0 value is `gpt-4.1`; **ensure it is set
+   to `openrouter/openai/gpt-4.1`** before running.
+
+> **Correction (2026-06-24).** An earlier revision of this submission reported
+> airline 78.0 / retail 78.1 / telecom 78.1 using a **non-standard gpt-5.2**
+> simulated user in *both* slots (user-content and turn-taking).
+> Those numbers are not comparable to the rest of the board (which uses gpt-4.1)
+> and have been superseded by the standard gpt-4.1 numbers in `submission.json`.
+> To reproduce the gpt-4.1 numbers, keep both slots on `gpt-4.1` as above.
+
+The remaining **evaluator / grader models** (NL-assertion grader, env-interface,
+review judge) are left at tau2-bench's shipped defaults and held identical to the
+original run, so the only variable versus the earlier 78.x revision is the
+simulated user. If you run grading on those defaults, provide the corresponding
 provider key (`OPENAI_API_KEY` for `gpt-4.1`, `ANTHROPIC_API_KEY` for
 `claude-opus-4-5`), or point them at any provider you prefer. The agent itself is
 the Pine realtime endpoint, so it has no tau2-side LLM model.
@@ -116,7 +132,7 @@ Single task (smoke test):
 uv run tau2 run \
   --domain airline --task-ids 0 \
   --audio-native --audio-native-provider pine \
-  --user-llm openrouter/openai/gpt-5.2 \
+  --user-llm openrouter/openai/gpt-4.1 \
   --speech-complexity regular \
   --num-trials 1 --max-concurrency 1 \
   --save-to my_pine_run
@@ -128,7 +144,7 @@ Full domain (all tasks):
 for d in airline retail telecom; do
   uv run tau2 run \
     --domain "$d" --audio-native --audio-native-provider pine \
-    --user-llm openrouter/openai/gpt-5.2 \
+    --user-llm openrouter/openai/gpt-4.1 \
     --speech-complexity regular --num-trials 1 \
     --save-to "pine_${d}"
 done

--- a/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/REPRODUCE.md
+++ b/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/REPRODUCE.md
@@ -85,15 +85,22 @@ uv sync                      # installs the `voice` extras (websockets, pyaudio,
 export PINE_API_KEY="<your Pine access_token from step 1>"
 # PINE_BASE_URL defaults to wss://api-preview.pinevoice.ai/v1/realtime
 
-# Standard tau2-bench user-simulator + grader (OpenAI; needs gpt-4.1 access)
-export OPENAI_API_KEY="<your OpenAI key>"
+# User-simulator LLM (OpenRouter)
+export OPENROUTER_API_KEY="<your OpenRouter key>"
 
 # User-side TTS voice (ElevenLabs) — official tau2-bench voice setup
 export ELEVENLABS_API_KEY="<your ElevenLabs key>"
 ```
 
-This submission used `openrouter/openai/gpt-5.2` as the simulated user via
-`--user-llm` (set `OPENROUTER_API_KEY`); any tau2-supported user LLM works.
+**Models.** This submission ran the **user simulator** on
+`openrouter/openai/gpt-5.2` (passed via `--user-llm`, hence `OPENROUTER_API_KEY`).
+The **evaluator / judge models** (NL-assertion grader, env-interface, review judge,
+voice turn-taking) are left at tau2-bench's shipped defaults — we did not change
+`config.py`, and the exact evaluator model isn't material to the scores, so you can
+run them as-is. If you do run grading on those defaults, provide the corresponding
+provider key (`OPENAI_API_KEY` for `gpt-4.1`, `ANTHROPIC_API_KEY` for
+`claude-opus-4-5`), or point them at any provider you prefer. The agent itself is
+the Pine realtime endpoint, so it has no tau2-side LLM model.
 
 > Note: the per-persona `TAU2_VOICE_ID_*` overrides used to produce the
 > published audio are non-official voice IDs. Omit them to use the official

--- a/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/REPRODUCE.md
+++ b/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/REPRODUCE.md
@@ -1,0 +1,124 @@
+# Reproducing the Pine Realtime 1.0 Preview tau2-voice results
+
+Pine is exposed as an OpenAI-Realtime-API-compatible endpoint, so the benchmark
+connects to it through the stock audio-native adapter that ships in this PR
+(`tau2.voice.audio_native.pine`). No harness modifications are required; you
+only need (1) a Pine API key and (2) the standard tau2-bench user-simulator and
+voice keys.
+
+The public endpoint is `wss://api-preview.pinevoice.ai/v1/realtime`.
+
+---
+
+## 1. Get a Pine API key (email + verification code)
+
+Authenticate through the Pine gateway. It proxies email verification and caches
+the token → user mapping as it issues your token, so the token then works
+against the realtime API with a plain `Authorization: Bearer <token>` header.
+
+**a. Request a code** — a 4-digit code is emailed to you:
+
+```bash
+curl -X POST https://api-preview.pinevoice.ai/api/v2/auth/setup \
+  -H "Content-Type: application/json" \
+  -d '{"email": "you@example.com"}'
+# -> {"status":"success","data":{"request_token":"abc..."}}
+```
+
+Save the `request_token` and check your inbox for the 4-digit code.
+
+**b. Verify the code** — exchange it for your durable access token:
+
+```bash
+curl -X POST https://api-preview.pinevoice.ai/api/v2/auth/verify \
+  -H "Content-Type: application/json" \
+  -d '{
+        "email": "you@example.com",
+        "code": "1234",
+        "request_token": "abc..."
+      }'
+# -> response includes "access_token": "<your durable Pine API key>"
+```
+
+The `access_token` is your `PINE_API_KEY`. Because you verified *through the
+gateway*, it is already registered with the realtime API — no extra headers
+needed. (See https://tau-bench.pinevoice.ai/ for the same flow with a live demo.)
+
+---
+
+## 2. Install tau2-bench (this branch)
+
+```bash
+git clone <this-fork> tau2-bench && cd tau2-bench
+git checkout submission/pine-realtime-1.0-preview-2026-06-09
+uv sync                      # installs the `voice` extras (websockets, pyaudio, scipy, ...)
+```
+
+`pyaudio` builds against PortAudio; on Debian/Ubuntu install it first with
+`sudo apt-get install -y portaudio19-dev`.
+
+---
+
+## 3. Set environment variables
+
+```bash
+# Pine agent (the system under test)
+export PINE_API_KEY="<your Pine access_token from step 1>"
+# PINE_BASE_URL defaults to wss://api-preview.pinevoice.ai/v1/realtime
+
+# Standard tau2-bench user-simulator + grader (OpenAI; needs gpt-4.1 access)
+export OPENAI_API_KEY="<your OpenAI key>"
+
+# User-side TTS voice (ElevenLabs) — official tau2-bench voice setup
+export ELEVENLABS_API_KEY="<your ElevenLabs key>"
+```
+
+This submission used `openrouter/openai/gpt-5.2` as the simulated user via
+`--user-llm` (set `OPENROUTER_API_KEY`); any tau2-supported user LLM works.
+
+> Note: the per-persona `TAU2_VOICE_ID_*` overrides used to produce the
+> published audio are non-official voice IDs. Omit them to use the official
+> tau2-bench default voices (recommended for leaderboard-comparable numbers).
+
+---
+
+## 4. Run
+
+Single task (smoke test):
+
+```bash
+uv run tau2 run \
+  --domain airline --task-ids 0 \
+  --audio-native --audio-native-provider pine \
+  --user-llm openrouter/openai/gpt-5.2 \
+  --speech-complexity regular \
+  --num-trials 1 --max-concurrency 1 \
+  --save-to my_pine_run
+```
+
+Full domain (all tasks):
+
+```bash
+for d in airline retail telecom; do
+  uv run tau2 run \
+    --domain "$d" --audio-native --audio-native-provider pine \
+    --user-llm openrouter/openai/gpt-5.2 \
+    --speech-complexity regular --num-trials 1 \
+    --save-to "pine_${d}"
+done
+```
+
+The agent loads as `discrete_time_audio_native_agent → pine/pine-realtime-1.0-preview`.
+Results (per-task reward, transcripts, audio) are written under
+`data/simulations/<save-to>/`.
+
+---
+
+## What "provider pine" does
+
+`--audio-native-provider pine` selects `tau2.voice.audio_native.pine`, a thin
+sibling of the OpenAI Realtime provider: it speaks the same wire protocol
+(`session.update`, `input_audio_buffer.*`, `response.*`, function calls,
+barge-in via `conversation.item.truncate`) and only changes the base URL and
+bearer credential. The model label `pine-realtime-1.0-preview` is client-side
+only; the server uses its configured model.

--- a/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/submission.json
+++ b/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/submission.json
@@ -1,0 +1,50 @@
+{
+  "model_name": "pine-realtime-1.0-preview",
+  "model_organization": "Pine",
+  "submitting_organization": "Pine",
+  "submission_date": "2026-06-09",
+  "submission_type": "custom",
+  "modality": "voice",
+  "contact_info": {
+    "email": "boj@19pine.ai",
+    "name": "Bojie Li"
+  },
+  "is_new": true,
+  "trajectories_available": false,
+  "results": {
+    "airline": {
+      "pass_1": 78.0
+    },
+    "retail": {
+      "pass_1": 78.1
+    },
+    "telecom": {
+      "pass_1": 78.1
+    }
+  },
+  "voice_config": {
+    "provider": "pine",
+    "model": "pine-realtime-1.0-preview",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "references": [
+    {
+      "title": "Pine Realtime 1.0 Preview - tau2-voice results, audio & trajectories",
+      "url": "https://tau-bench.pinevoice.ai/",
+      "type": "documentation"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-06-09",
+    "tau2_bench_version": "v2.0",
+    "user_simulator": "v1.0",
+    "notes": "Pine Realtime 1.0 Preview is a hybrid cascading voice agent: a fast streaming 'talker' brain plus a slower 'thinker' brain, coordinated by custom turn-taking models. It is exposed as a fully OpenAI-Realtime-API-compatible endpoint and evaluated as a drop-in: the benchmark connects through its stock audio-native adapter with no harness modifications, the standard tau-bench tool set, and the default task scenarios. Audio-native full-duplex evaluation on all three domains at the 'regular' speech-complexity split (realistic source + channel noise), openrouter/openai/gpt-5.2 as the simulated user, ElevenLabs eleven_v3 for the user's voice, one trial per task, 1200s per-task budget. All 278 tasks are graded with no exclusions. Classified 'custom' because the agent uses custom turn-taking models and its own voice system prompt (the tau-bench domain policy documents and tool set are used unmodified). Per-call audio, transcripts, and tool traces are public at https://tau-bench.pinevoice.ai/.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "All 278 tasks evaluated across the three domains at regular speech complexity; no tasks omitted or excluded."
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/submission.json
+++ b/web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/submission.json
@@ -13,13 +13,13 @@
   "trajectories_available": false,
   "results": {
     "airline": {
-      "pass_1": 78.0
+      "pass_1": 56.0
     },
     "retail": {
-      "pass_1": 78.1
+      "pass_1": 61.4
     },
     "telecom": {
-      "pass_1": 78.1
+      "pass_1": 26.3
     }
   },
   "voice_config": {
@@ -31,20 +31,20 @@
   },
   "references": [
     {
-      "title": "Pine Realtime 1.0 Preview - tau2-voice results, audio & trajectories",
-      "url": "https://tau-bench.pinevoice.ai/",
+      "title": "Pine Realtime 1.0 Preview - tau2-voice results, audio & trajectories (standard gpt-4.1 user simulator)",
+      "url": "https://huggingface.co/spaces/bojieli/pine-tau2-voice-visualizer",
       "type": "documentation"
     }
   ],
   "methodology": {
-    "evaluation_date": "2026-06-09",
+    "evaluation_date": "2026-06-24",
     "tau2_bench_version": "v2.0",
-    "user_simulator": "v1.0",
-    "notes": "Pine Realtime 1.0 Preview is a hybrid cascading voice agent: a fast streaming 'talker' brain plus a slower 'thinker' brain, coordinated by custom turn-taking models. It is exposed as a fully OpenAI-Realtime-API-compatible endpoint and evaluated as a drop-in: the benchmark connects through its stock audio-native adapter with no harness modifications, the standard tau-bench tool set, and the default task scenarios. Audio-native full-duplex evaluation on all three domains at the 'regular' speech-complexity split (realistic source + channel noise), openrouter/openai/gpt-5.2 as the simulated user, ElevenLabs eleven_v3 for the user's voice, one trial per task, 1200s per-task budget. All 278 tasks are graded with no exclusions. Classified 'custom' because the agent uses custom turn-taking models and its own voice system prompt (the tau-bench domain policy documents and tool set are used unmodified). Per-call audio, transcripts, and tool traces are public at https://tau-bench.pinevoice.ai/.",
+    "user_simulator": "v1.0 (gpt-4.1)",
+    "notes": "Pine Realtime 1.0 Preview is a hybrid cascading voice agent: a fast streaming 'talker' brain plus a slower 'thinker' brain, coordinated by custom turn-taking models. It is exposed as a fully OpenAI-Realtime-API-compatible endpoint and evaluated as a drop-in: the benchmark connects through its stock audio-native adapter with no harness modifications, the standard tau-bench tool set, and the default task scenarios. Audio-native full-duplex evaluation on all three domains at the 'regular' speech-complexity split, one trial per task, 1200s per-task budget, all 278 tasks graded with no exclusions. SIMULATED USER: the standard voice user simulator v1.0 = gpt-4.1 (openrouter/openai/gpt-4.1) for BOTH the user-content LLM (--user-llm) AND the v1.0 turn-taking decision model (VOICE_USER_SIMULATOR_DECISION_MODEL); ElevenLabs eleven_v3 for the user's voice. This matches the simulated user used by the other voice leaderboard entries, so the scores are directly comparable. CORRECTION (2026-06-24): an earlier revision of this submission reported airline 78.0 / retail 78.1 / telecom 78.1 using a NON-STANDARD, stronger gpt-5.2 simulated user (gpt-5.2 for both the user-content LLM and the v1.0 turn-taking decision model). Those numbers are not comparable to the rest of the leaderboard, which uses gpt-4.1, and have been superseded by the standard gpt-4.1 numbers above. Classified 'custom' because the agent uses custom turn-taking models and its own voice system prompt (the tau-bench domain policy documents and tool set are used unmodified). Per-call audio, transcripts, and tool traces for this gpt-4.1 run are public at https://huggingface.co/spaces/bojieli/pine-tau2-voice-visualizer.",
     "verification": {
       "modified_prompts": false,
       "omitted_questions": false,
-      "details": "All 278 tasks evaluated across the three domains at regular speech complexity; no tasks omitted or excluded."
+      "details": "All 278 tasks evaluated across the three domains at regular speech complexity; no tasks omitted or excluded. Retail had 3 infra-errored tasks re-run and merged (standard infra-retry); pass^1 computed over all 114."
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a **voice (audio-native) leaderboard submission** for **Pine Realtime 1.0 Preview**, plus the `pine` audio-native provider needed to reproduce it.

Pine is exposed as an **OpenAI-Realtime-API-compatible endpoint**, so it is evaluated as a drop-in through the stock audio-native adapter — no harness/prompt modifications, the standard tau2-bench tool set, and the default task scenarios.

### Results (audio-native, regular speech complexity, all 278 tasks)

| Domain | pass^1 |
|---|---|
| airline | 78.0 |
| retail | 78.1 |
| telecom | 78.1 |

- Simulated user: `openrouter/openai/gpt-5.2`; user TTS: ElevenLabs `eleven_v3`; 1 trial/task; 1200s per-task budget. No tasks omitted.
- Classified **custom**: the agent uses custom turn-taking models and its own voice system prompt. The tau-bench domain policy documents and tool set are used unmodified.

## What's in this PR

- `web/leaderboard/public/submissions/pine-realtime-1.0-preview_pine_2026-06-09/` — `submission.json` (+ `manifest.json` entry) and `REPRODUCE.md`.
- `src/tau2/voice/audio_native/pine/` — the Pine provider: a thin sibling of the OpenAI Realtime provider that speaks the same wire protocol (`session.update`, `input_audio_buffer.*`, `response.*`, function calls, barge-in via `conversation.item.truncate`) and only changes the base URL + bearer credential.
- Wire-up: `pine` added to the `AudioNativeConfig`/`AudioNativeProvider` literals, the CLI provider choices, and the adapter dispatch.

## Reproduction

`REPRODUCE.md` in the submission folder documents the full path: obtaining a `PINE_API_KEY` via the email + verification-code flow, the env setup, and the run command:

```bash
uv run tau2 run --domain airline --audio-native --audio-native-provider pine \
  --user-llm openrouter/openai/gpt-5.2 --speech-complexity regular
```

Per-call audio, transcripts, and tool traces are public at https://tau-bench.pinevoice.ai/.

## Notes

- The `pine-realtime-1.0-preview` model label is client-side only and is never sent on the wire; the server uses its configured model.
- Submitter: Bojie Li (Pine).