### PR TITLE
Make review model configurable

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -53,6 +53,7 @@ tau2 run \
 | `--auto-resume` | Automatically resume from existing save file without prompting |
 | `--auto-review` | Automatically run LLM conversation review after each simulation |
 | `--review-mode` | Review mode when `--auto-review` is on: `full` or `user` (default: `full`) |
+| `--review-model` | LLM model to use for review calls (default: `claude-opus-4-5`) |
 | `--hallucination-retries` | Max retries when user simulator hallucination is detected (full-duplex only, default: `3`). Set to `0` to disable |
 | `--timeout` | Maximum wallclock time in seconds per simulation (no timeout by default) |
 | `--audio-native` | Enable audio native mode (voice full-duplex) |
@@ -217,6 +218,7 @@ tau2 review <path>
 | `--limit` | Limit review to first N simulations |
 | `--task-ids` | Only review simulations for these task IDs |
 | `--log-llm` | Log LLM request/response for each review call |
+| `--review-model` | LLM model to use for review calls (default: `claude-opus-4-5`) |
 
 ---
 

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -8,6 +8,7 @@ from tau2.config import (
     DEFAULT_INTEGRATION_DURATION_SECONDS,
     DEFAULT_INTERRUPTION_CHECK_INTERVAL_SECONDS,
     DEFAULT_LLM_AGENT,
+    DEFAULT_LLM_EVAL_USER_SIMULATOR,
     DEFAULT_LLM_LOG_MODE,
     DEFAULT_LLM_TEMPERATURE_AGENT,
     DEFAULT_LLM_TEMPERATURE_USER,
@@ -413,6 +414,12 @@ def add_run_args(parser):
         help="Review mode when --auto-review is enabled: 'full' (agent+user errors, default) or 'user' (user simulator only).",
     )
     parser.add_argument(
+        "--review-model",
+        type=str,
+        default=DEFAULT_LLM_EVAL_USER_SIMULATOR,
+        help=f"LLM model to use for review calls. Default is {DEFAULT_LLM_EVAL_USER_SIMULATOR}.",
+    )
+    parser.add_argument(
         "--hallucination-retries",
         type=int,
         default=3,
@@ -648,6 +655,7 @@ def main():
             auto_resume=args.auto_resume,
             auto_review=args.auto_review,
             review_mode=args.review_mode,
+            review_model=args.review_model,
             hallucination_retries=args.hallucination_retries,
             retrieval_config=args.retrieval_config,
             retrieval_config_kwargs=args.retrieval_config_kwargs,
@@ -809,6 +817,12 @@ def main():
         "--log-llm",
         action="store_true",
         help="Log LLM request/response for each review call",
+    )
+    review_parser.add_argument(
+        "--review-model",
+        type=str,
+        default=DEFAULT_LLM_EVAL_USER_SIMULATOR,
+        help=f"LLM model to use for review calls. Default is {DEFAULT_LLM_EVAL_USER_SIMULATOR}.",
     )
     review_parser.set_defaults(func=lambda args: run_review(args))
 
@@ -1037,6 +1051,7 @@ def run_review(args):
             limit=args.limit,
             task_ids=args.task_ids,
             log_llm=args.log_llm,
+            review_model=args.review_model,
         )
 
 

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -25,6 +25,7 @@ from tau2.config import (
     DEFAULT_LLM_AGENT,
     DEFAULT_LLM_ARGS_AGENT,
     DEFAULT_LLM_ARGS_USER,
+    DEFAULT_LLM_EVAL_USER_SIMULATOR,
     DEFAULT_LLM_USER,
     DEFAULT_LOG_LEVEL,
     DEFAULT_MAX_CONCURRENCY,
@@ -417,6 +418,13 @@ class BaseRunConfig(BaseModel):
         Field(
             description="Review mode when auto_review is enabled: 'full' (agent+user errors, default) or 'user' (user simulator only).",
             default="full",
+        ),
+    ]
+    review_model: Annotated[
+        str,
+        Field(
+            description="LLM model to use for review calls when auto_review is enabled.",
+            default=DEFAULT_LLM_EVAL_USER_SIMULATOR,
         ),
     ]
     hallucination_retries: Annotated[

--- a/src/tau2/evaluator/review_llm_judge.py
+++ b/src/tau2/evaluator/review_llm_judge.py
@@ -420,6 +420,7 @@ class ConversationReviewer:
         task: Task,
         full_trajectory: list,
         policy: str,
+        review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     ) -> Review:
         """
         Review whether both the user simulator and the agent behaved correctly.
@@ -429,6 +430,7 @@ class ConversationReviewer:
             task: The task containing user scenario and evaluation criteria.
             full_trajectory: List of messages from the conversation.
             policy: The policy the agent must follow.
+            review_model: LLM model to use for review.
 
         Returns:
             Review with any error found.
@@ -454,6 +456,7 @@ class ConversationReviewer:
             example_action_trajectory=example_action_trajectory,
             natural_language_assertions=nl_assertions,
             full_trajectory=full_trajectory,
+            review_model=review_model,
         )
 
     @classmethod
@@ -472,6 +475,7 @@ class ConversationReviewer:
         example_action_trajectory: str,
         natural_language_assertions: str,
         full_trajectory: list,
+        review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     ) -> Review:
         """
         Review whether the conversation proceeded correctly.
@@ -483,6 +487,7 @@ class ConversationReviewer:
             example_action_trajectory: An example sequence of actions that could complete the task.
             natural_language_assertions: Assertions the agent must satisfy.
             full_trajectory: List of messages from the conversation.
+            review_model: LLM model to use for review.
 
         Returns:
             Review with any error found.
@@ -505,7 +510,7 @@ class ConversationReviewer:
         ]
 
         assistant_message = generate(
-            model=DEFAULT_LLM_EVAL_USER_SIMULATOR,
+            model=review_model,
             messages=messages,
             call_name="llm_judge_review",
         )
@@ -565,6 +570,7 @@ class FullDuplexConversationReviewer:
         full_trajectory: list[Tick],
         policy: str,
         interruption_enabled: bool = False,
+        review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     ) -> Review:
         """
         Review whether both the user simulator and the agent behaved correctly.
@@ -577,6 +583,7 @@ class FullDuplexConversationReviewer:
             full_trajectory: List of Tick objects from full-duplex simulation.
             policy: The policy the agent must follow.
             interruption_enabled: Whether the user simulator was configured to interrupt.
+            review_model: LLM model to use for review.
 
         Returns:
             Review with any error found.
@@ -616,7 +623,7 @@ class FullDuplexConversationReviewer:
         ]
 
         assistant_message = generate(
-            model=DEFAULT_LLM_EVAL_USER_SIMULATOR,
+            model=review_model,
             messages=llm_messages,
             call_name="llm_judge_streaming_review",
         )

--- a/src/tau2/evaluator/review_llm_judge_user_only.py
+++ b/src/tau2/evaluator/review_llm_judge_user_only.py
@@ -317,6 +317,7 @@ class UserOnlyReviewer:
         user_info: UserInfo,
         task: Task,
         full_trajectory: list[Message],
+        review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     ) -> UserOnlyReview:
         """
         Review whether the user simulator behaved according to the task instructions.
@@ -325,6 +326,7 @@ class UserOnlyReviewer:
             user_info: Information about the user simulator configuration.
             task: The task containing user scenario instructions.
             full_trajectory: List of messages from the conversation.
+            review_model: LLM model to use for review.
 
         Returns:
             UserOnlyReview with any errors found.
@@ -342,6 +344,7 @@ class UserOnlyReviewer:
             user_guidelines=user_guidelines,
             user_instructions=user_instructions,
             full_trajectory=full_trajectory,
+            review_model=review_model,
         )
 
     @classmethod
@@ -390,6 +393,7 @@ class UserOnlyReviewer:
         user_guidelines: str,
         user_instructions: str,
         full_trajectory: list[Message],
+        review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     ) -> UserOnlyReview:
         """
         Review whether the user simulator behaved according to the task instructions.
@@ -398,6 +402,7 @@ class UserOnlyReviewer:
             user_guidelines: The global user simulator guidelines.
             user_instructions: The specific user instructions for this task.
             full_trajectory: List of messages from the conversation.
+            review_model: LLM model to use for review.
 
         Returns:
             UserOnlyReview with any errors found.
@@ -416,7 +421,7 @@ class UserOnlyReviewer:
         ]
 
         assistant_message = generate(
-            model=DEFAULT_LLM_EVAL_USER_SIMULATOR,
+            model=review_model,
             messages=messages,
             call_name="llm_judge_user_only_review",
         )
@@ -469,6 +474,7 @@ class FullDuplexUserOnlyReviewer:
         task: Task,
         full_trajectory: list[Tick],
         interruption_enabled: bool = False,
+        review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     ) -> UserOnlyReview:
         """
         Review whether the user simulator behaved according to the task instructions.
@@ -480,6 +486,7 @@ class FullDuplexUserOnlyReviewer:
             task: The task containing user scenario instructions.
             full_trajectory: List of Tick objects from full-duplex simulation.
             interruption_enabled: Whether the user simulator was configured to interrupt.
+            review_model: LLM model to use for review.
 
         Returns:
             UserOnlyReview with any errors found.
@@ -513,7 +520,7 @@ class FullDuplexUserOnlyReviewer:
         ]
 
         assistant_message = generate(
-            model=DEFAULT_LLM_EVAL_USER_SIMULATOR,
+            model=review_model,
             messages=llm_messages,
             call_name="llm_judge_user_only_streaming_review",
         )

--- a/src/tau2/evaluator/reviewer.py
+++ b/src/tau2/evaluator/reviewer.py
@@ -35,6 +35,7 @@ Usage:
 from enum import Enum
 from typing import Optional, Union
 
+from tau2.config import DEFAULT_LLM_EVAL_USER_SIMULATOR
 from tau2.data_model.simulation import (
     AuthenticationClassification,
     HallucinationCheck,
@@ -78,6 +79,7 @@ def review_simulation(
     user_info: UserInfo,
     policy: Optional[str] = None,
     interruption_enabled: bool = False,
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
 ) -> tuple[Union[Review, UserOnlyReview], Optional[AuthenticationClassification]]:
     """
     Review a single simulation for conversation errors.
@@ -89,6 +91,7 @@ def review_simulation(
         user_info: User info containing simulation guidelines.
         policy: The policy the agent must follow (required for FULL mode).
         interruption_enabled: Whether interruption was enabled (for full-duplex).
+        review_model: LLM model to use for review and auth classification.
 
     Returns:
         Tuple of (review_result, auth_classification).
@@ -108,9 +111,11 @@ def review_simulation(
                 full_trajectory=simulation.ticks,
                 policy=policy,
                 interruption_enabled=interruption_enabled,
+                review_model=review_model,
             )
             auth_classification = FullDuplexAuthenticationClassifier.classify(
                 ticks=simulation.ticks,
+                model=review_model,
             )
         else:
             review = ConversationReviewer.review(
@@ -118,9 +123,11 @@ def review_simulation(
                 task=task,
                 full_trajectory=simulation.messages,
                 policy=policy,
+                review_model=review_model,
             )
             auth_classification = AuthenticationClassifier.classify(
                 messages=simulation.messages,
+                model=review_model,
             )
         return review, auth_classification
 
@@ -132,12 +139,14 @@ def review_simulation(
                 task=task,
                 full_trajectory=simulation.ticks,
                 interruption_enabled=interruption_enabled,
+                review_model=review_model,
             )
         else:
             review = UserOnlyReviewer.review(
                 user_info=user_info,
                 task=task,
                 full_trajectory=simulation.messages,
+                review_model=review_model,
             )
         return review, None
 

--- a/src/tau2/run.py
+++ b/src/tau2/run.py
@@ -30,6 +30,7 @@ import warnings
 from pathlib import Path
 from typing import Optional
 
+from tau2.config import DEFAULT_LLM_EVAL_USER_SIMULATOR
 from tau2.data_model.persona import PersonaConfig
 from tau2.data_model.simulation import (
     AudioNativeConfig,
@@ -94,6 +95,7 @@ def run_task(
     audio_taps: bool = False,
     auto_review: bool = False,
     review_mode: str = "full",
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     solo_mode: bool = False,
     hallucination_feedback: Optional[str] = None,
     retrieval_config: Optional[str] = None,
@@ -119,6 +121,7 @@ def run_task(
             audio_taps=audio_taps,
             auto_review=auto_review,
             review_mode=review_mode,
+            review_model=review_model,
             verbose_logs=verbose_logs,
             retrieval_config=retrieval_config,
             retrieval_config_kwargs=retrieval_config_kwargs,
@@ -138,6 +141,7 @@ def run_task(
             enforce_communication_protocol=enforce_communication_protocol,
             auto_review=auto_review,
             review_mode=review_mode,
+            review_model=review_model,
             verbose_logs=verbose_logs,
             retrieval_config=retrieval_config,
             retrieval_config_kwargs=retrieval_config_kwargs,
@@ -155,6 +159,7 @@ def run_task(
         audio_taps=audio_taps,
         auto_review=auto_review,
         review_mode=review_mode,
+        review_model=review_model,
         hallucination_feedback=hallucination_feedback,
     )
 
@@ -189,6 +194,7 @@ def run_tasks(
     auto_resume: bool = False,
     auto_review: bool = False,
     review_mode: str = "full",
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     solo_mode: bool = False,
     hallucination_retries: int = 0,
     retrieval_config: Optional[str] = None,
@@ -221,6 +227,7 @@ def run_tasks(
             auto_resume=auto_resume,
             auto_review=auto_review,
             review_mode=review_mode,
+            review_model=review_model,
             hallucination_retries=hallucination_retries,
             verbose_logs=verbose_logs,
             retrieval_config=retrieval_config,
@@ -247,6 +254,7 @@ def run_tasks(
             auto_resume=auto_resume,
             auto_review=auto_review,
             review_mode=review_mode,
+            review_model=review_model,
             hallucination_retries=hallucination_retries,
             verbose_logs=verbose_logs,
             retrieval_config=retrieval_config,

--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -132,6 +132,7 @@ def run_auto_review(
     simulation: SimulationRun,
     task: Task,
     review_mode: str,
+    review_model: str,
     user: str,
     llm_user: Optional[str],
     llm_args_user: Optional[dict],
@@ -146,6 +147,7 @@ def run_auto_review(
         simulation: The completed simulation to review.
         task: The task specification.
         review_mode: "full" (agent+user) or "user" (user only).
+        review_model: LLM model to use for review and auth classification.
         user: User implementation name.
         llm_user: LLM used by user simulator.
         llm_args_user: LLM args for user simulator.
@@ -181,6 +183,7 @@ def run_auto_review(
         user_info=review_user_info,
         policy=policy,
         interruption_enabled=is_audio_native,
+        review_model=review_model,
     )
 
     if review_mode == "full":
@@ -349,6 +352,7 @@ def run_single_task(
     audio_taps: bool = False,
     auto_review: bool = False,
     review_mode: str = "full",
+    review_model: Optional[str] = None,
     hallucination_feedback: Optional[str] = None,
 ) -> SimulationRun:
     """Run a single task simulation with logging and optional side effects.
@@ -372,6 +376,7 @@ def run_single_task(
         audio_debug: Enable audio debug analysis.
         auto_review: Run LLM conversation review after simulation.
         review_mode: Review mode ("full" or "user").
+        review_model: LLM model to use for review and auth classification.
 
     Returns:
         The completed SimulationRun with reward_info attached.
@@ -421,6 +426,7 @@ def run_single_task(
                 simulation=simulation,
                 task=task,
                 review_mode=review_mode,
+                review_model=review_model or config.review_model,
                 user=config.effective_user,
                 llm_user=config.llm_user,
                 llm_args_user=config.llm_args_user,
@@ -662,6 +668,7 @@ def run_tasks(
                 audio_taps=config.audio_taps if is_voice else False,
                 auto_review=config.auto_review,
                 review_mode=config.review_mode,
+                review_model=config.review_model,
                 hallucination_feedback=hallucination_feedback,
             )
 

--- a/src/tau2/scripts/review_conversation.py
+++ b/src/tau2/scripts/review_conversation.py
@@ -18,6 +18,9 @@ Usage:
 
     # With custom output path
     python -m tau2.scripts.review_conversation results.json -o review.json
+
+    # With a custom LiteLLM-compatible review model
+    python -m tau2.scripts.review_conversation results.json --review-model gpt-4.1
 """
 
 import argparse
@@ -35,6 +38,7 @@ from rich.markdown import Markdown
 from rich.progress import Progress
 from rich.table import Table
 
+from tau2.config import DEFAULT_LLM_EVAL_USER_SIMULATOR
 from tau2.data_model.simulation import (
     AuthenticationClassification,
     Results,
@@ -190,6 +194,7 @@ def review_simulation_full(
     task: Task,
     results: Results,
     interruption_enabled: bool = False,
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
 ) -> tuple[Review, AuthenticationClassification, str]:
     """
     Review a single simulation for both agent and user errors, plus auth classification.
@@ -213,6 +218,7 @@ def review_simulation_full(
         user_info=user_info,
         policy=policy,
         interruption_enabled=interruption_enabled,
+        review_model=review_model,
     )
 
     # review_simulation returns Review for FULL mode, auth_classification is not None
@@ -228,6 +234,7 @@ def run_full_review(
     interruption_enabled: bool = False,
     show_details: bool = False,
     max_concurrency: int = 32,
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     console: Optional[Console] = None,
 ) -> FullReviewOutput:
     """Run full review (agent + user) for all simulations."""
@@ -249,7 +256,7 @@ def run_full_review(
     total_cost = 0.0
 
     console.print(
-        f"\n🔍 Reviewing {len(results.simulations)} simulation(s) [mode: full, concurrency: {max_concurrency}]...",
+        f"\n🔍 Reviewing {len(results.simulations)} simulation(s) [mode: full, model: {review_model}, concurrency: {max_concurrency}]...",
         style="bold",
     )
 
@@ -270,6 +277,7 @@ def run_full_review(
                 task=task,
                 results=results,
                 interruption_enabled=interruption_enabled,
+                review_model=review_model,
             )
 
             # Determine trial number
@@ -414,6 +422,7 @@ def review_simulation_user(
     task: Task,
     results: Results,
     interruption_enabled: bool = False,
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
 ) -> tuple[UserOnlyReview, str]:
     """
     Review a single simulation for user simulator errors only.
@@ -433,6 +442,7 @@ def review_simulation_user(
         mode=ReviewMode.USER,
         user_info=user_info,
         interruption_enabled=interruption_enabled,
+        review_model=review_model,
     )
 
     # review_simulation returns UserOnlyReview for USER mode
@@ -447,6 +457,7 @@ def run_user_review(
     interruption_enabled: bool = False,
     show_details: bool = False,
     max_concurrency: int = 32,
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     console: Optional[Console] = None,
 ) -> UserReviewOutput:
     """Run user simulator review for all simulations."""
@@ -461,7 +472,7 @@ def run_user_review(
     total_cost = 0.0
 
     console.print(
-        f"\n🔍 Reviewing {len(results.simulations)} simulation(s) [mode: user, concurrency: {max_concurrency}]...",
+        f"\n🔍 Reviewing {len(results.simulations)} simulation(s) [mode: user, model: {review_model}, concurrency: {max_concurrency}]...",
         style="bold",
     )
 
@@ -482,6 +493,7 @@ def run_user_review(
                 task=task,
                 results=results,
                 interruption_enabled=interruption_enabled,
+                review_model=review_model,
             )
 
             # Determine trial number
@@ -597,6 +609,7 @@ def review(
     limit: Optional[int] = None,
     task_ids: Optional[list[str]] = None,
     log_llm: bool = False,
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
 ) -> Optional[Union[FullReviewOutput, UserReviewOutput]]:
     """
     Review conversation trajectories for all simulations in a results file.
@@ -611,6 +624,7 @@ def review(
         limit: Optional limit on number of simulations to review.
         task_ids: Optional list of task IDs to filter simulations.
         log_llm: Whether to log LLM request/response.
+        review_model: LLM model to use for review calls.
 
     Returns:
         FullReviewOutput or UserReviewOutput depending on mode, or None if aborted.
@@ -672,6 +686,7 @@ def review(
             interruption_enabled=interruption_enabled,
             show_details=show_details,
             max_concurrency=max_concurrency,
+            review_model=review_model,
             console=console,
         )
     else:
@@ -681,6 +696,7 @@ def review(
             interruption_enabled=interruption_enabled,
             show_details=show_details,
             max_concurrency=max_concurrency,
+            review_model=review_model,
             console=console,
         )
         _ = "_user_review.json"
@@ -1017,6 +1033,9 @@ Examples:
 
   # For full-duplex simulations with interruption
   python -m tau2.scripts.review_conversation run results.json --interruption-enabled
+
+  # Use a different LiteLLM-compatible review model
+  python -m tau2.scripts.review_conversation run results.json --review-model gpt-4.1
         """,
     )
     run_parser.add_argument(
@@ -1061,6 +1080,12 @@ Examples:
         "--verbose",
         action="store_true",
         help="Enable verbose logging.",
+    )
+    run_parser.add_argument(
+        "--review-model",
+        type=str,
+        default=DEFAULT_LLM_EVAL_USER_SIMULATOR,
+        help=f"LLM model to use for review calls. Default is {DEFAULT_LLM_EVAL_USER_SIMULATOR}.",
     )
 
     # Display subcommand
@@ -1197,6 +1222,7 @@ def main():
                 interruption_enabled=args.interruption_enabled,
                 show_details=args.show_details,
                 max_concurrency=args.max_concurrency,
+                review_model=args.review_model,
             )
 
     elif args.command == "display":

--- a/tests/test_review_model.py
+++ b/tests/test_review_model.py
@@ -1,0 +1,220 @@
+from types import SimpleNamespace
+
+from tau2.evaluator import reviewer
+from tau2.runner import batch
+
+
+def test_review_simulation_uses_custom_model_for_full_turn_based(monkeypatch):
+    captured = {}
+    expected_review = object()
+    expected_auth = object()
+    review_model = "gpt-4.1"
+
+    def fake_review(**kwargs):
+        captured["review_model"] = kwargs["review_model"]
+        captured["full_trajectory"] = kwargs["full_trajectory"]
+        return expected_review
+
+    def fake_classify(**kwargs):
+        captured["auth_model"] = kwargs["model"]
+        captured["auth_messages"] = kwargs["messages"]
+        return expected_auth
+
+    monkeypatch.setattr(
+        reviewer.ConversationReviewer,
+        "review",
+        staticmethod(fake_review),
+    )
+    monkeypatch.setattr(
+        reviewer.AuthenticationClassifier,
+        "classify",
+        staticmethod(fake_classify),
+    )
+
+    simulation = SimpleNamespace(messages=["message"], ticks=None)
+
+    review, auth = reviewer.review_simulation(
+        simulation=simulation,
+        task=object(),
+        mode=reviewer.ReviewMode.FULL,
+        user_info=object(),
+        policy="policy",
+        review_model=review_model,
+    )
+
+    assert review is expected_review
+    assert auth is expected_auth
+    assert captured == {
+        "review_model": review_model,
+        "full_trajectory": ["message"],
+        "auth_model": review_model,
+        "auth_messages": ["message"],
+    }
+
+
+def test_review_simulation_uses_custom_model_for_full_duplex(monkeypatch):
+    captured = {}
+    expected_review = object()
+    expected_auth = object()
+    review_model = "openrouter/anthropic/claude-sonnet-4"
+
+    def fake_review(**kwargs):
+        captured["review_model"] = kwargs["review_model"]
+        captured["full_trajectory"] = kwargs["full_trajectory"]
+        captured["interruption_enabled"] = kwargs["interruption_enabled"]
+        return expected_review
+
+    def fake_classify(**kwargs):
+        captured["auth_model"] = kwargs["model"]
+        captured["auth_ticks"] = kwargs["ticks"]
+        return expected_auth
+
+    monkeypatch.setattr(
+        reviewer.FullDuplexConversationReviewer,
+        "review",
+        staticmethod(fake_review),
+    )
+    monkeypatch.setattr(
+        reviewer.FullDuplexAuthenticationClassifier,
+        "classify",
+        staticmethod(fake_classify),
+    )
+
+    simulation = SimpleNamespace(messages=[], ticks=["tick"])
+
+    review, auth = reviewer.review_simulation(
+        simulation=simulation,
+        task=object(),
+        mode=reviewer.ReviewMode.FULL,
+        user_info=object(),
+        policy="policy",
+        interruption_enabled=True,
+        review_model=review_model,
+    )
+
+    assert review is expected_review
+    assert auth is expected_auth
+    assert captured == {
+        "review_model": review_model,
+        "full_trajectory": ["tick"],
+        "interruption_enabled": True,
+        "auth_model": review_model,
+        "auth_ticks": ["tick"],
+    }
+
+
+def test_review_simulation_uses_custom_model_for_user_only_turn_based(
+    monkeypatch,
+):
+    captured = {}
+    expected_review = object()
+    review_model = "gemini/gemini-2.5-pro"
+
+    def fake_review(**kwargs):
+        captured["review_model"] = kwargs["review_model"]
+        captured["full_trajectory"] = kwargs["full_trajectory"]
+        return expected_review
+
+    monkeypatch.setattr(
+        reviewer.UserOnlyReviewer,
+        "review",
+        staticmethod(fake_review),
+    )
+
+    simulation = SimpleNamespace(messages=["message"], ticks=None)
+
+    review, auth = reviewer.review_simulation(
+        simulation=simulation,
+        task=object(),
+        mode=reviewer.ReviewMode.USER,
+        user_info=object(),
+        review_model=review_model,
+    )
+
+    assert review is expected_review
+    assert auth is None
+    assert captured == {
+        "review_model": review_model,
+        "full_trajectory": ["message"],
+    }
+
+
+def test_review_simulation_uses_custom_model_for_user_only_full_duplex(
+    monkeypatch,
+):
+    captured = {}
+    expected_review = object()
+    review_model = "anthropic/claude-sonnet-4-5"
+
+    def fake_review(**kwargs):
+        captured["review_model"] = kwargs["review_model"]
+        captured["full_trajectory"] = kwargs["full_trajectory"]
+        captured["interruption_enabled"] = kwargs["interruption_enabled"]
+        return expected_review
+
+    monkeypatch.setattr(
+        reviewer.FullDuplexUserOnlyReviewer,
+        "review",
+        staticmethod(fake_review),
+    )
+
+    simulation = SimpleNamespace(messages=[], ticks=["tick"])
+
+    review, auth = reviewer.review_simulation(
+        simulation=simulation,
+        task=object(),
+        mode=reviewer.ReviewMode.USER,
+        user_info=object(),
+        interruption_enabled=True,
+        review_model=review_model,
+    )
+
+    assert review is expected_review
+    assert auth is None
+    assert captured == {
+        "review_model": review_model,
+        "full_trajectory": ["tick"],
+        "interruption_enabled": True,
+    }
+
+
+def test_auto_review_uses_custom_review_model(monkeypatch):
+    captured = {}
+    expected_review = SimpleNamespace(has_errors=False)
+    expected_auth = object()
+    review_model = "gpt-4.1-mini"
+
+    def fake_review_simulation(**kwargs):
+        captured["review_model"] = kwargs["review_model"]
+        captured["mode"] = kwargs["mode"]
+        return expected_review, expected_auth
+
+    monkeypatch.setattr(
+        reviewer,
+        "review_simulation",
+        fake_review_simulation,
+    )
+
+    simulation = SimpleNamespace()
+    task = SimpleNamespace(id="task-1")
+
+    batch.run_auto_review(
+        simulation=simulation,
+        task=task,
+        review_mode="full",
+        review_model=review_model,
+        user="user_simulator",
+        llm_user="gpt-4.1",
+        llm_args_user={},
+        user_persona_config=None,
+        user_voice_settings=None,
+        policy="policy",
+        is_audio_native=False,
+    )
+
+    assert simulation.review is expected_review
+    assert simulation.auth_classification is expected_auth
+    assert captured == {
+        "review_model": review_model,
+        "mode": reviewer.ReviewMode.FULL,
+    }


### PR DESCRIPTION
## Summary

Adds a configurable review model for LLM-based conversation reviews.

- Adds `--review-model` to `tau2 run` for `--auto-review`
- Adds `--review-model` to `tau2 review`
- Adds the same option to `python -m tau2.scripts.review_conversation run`
- Threads the selected model through full review, user-only review, full-duplex review, auto-review, and authentication classification
- Keeps the existing default of `claude-opus-4-5`
- Documents the flag in the CLI reference
- Adds unit coverage for the model plumbing across turn-based, full-duplex, and auto-review paths

Closes #341.

## Validation

- `uv run pytest tests/test_review_model.py`
- `make check-all`
- `uv run tau2 run --help`
- `uv run tau2 review --help`
- `uv run python -m tau2.scripts.review_conversation run --help`