### PR TITLE
feat: LanguagePack registry foundation for multilingual user simulation (PR1)

### DIFF
--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -227,6 +227,14 @@ def add_run_args(parser):
         '\'{"verbosity": {"minimal": 0.8, "standard": 0.2}}\'. '
         "If not provided, uses default behavior (standard verbosity).",
     )
+    parser.add_argument(
+        "--user-persona-id",
+        type=str,
+        default=None,
+        help="Force a specific user persona by id for audio-native runs, e.g. a "
+        "language-pack persona like 'priya_hindi_v1' (see tau2.multilingual). "
+        "Bypasses per-task persona sampling. Requires --audio-native.",
+    )
 
     # Audio-native mode arguments
     parser.add_argument(
@@ -668,8 +676,13 @@ def main():
                 speech_complexity=args.speech_complexity,
                 audio_debug=getattr(args, "audio_debug", False),
                 audio_taps=getattr(args, "audio_taps", False),
+                user_persona_id=args.user_persona_id,
             )
         else:
+            if args.user_persona_id:
+                raise ValueError(
+                    "--user-persona-id requires --audio-native (voice mode)."
+                )
             config = TextRunConfig(
                 **shared_kwargs,
                 agent=args.agent,

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -648,6 +648,15 @@ class VoiceRunConfig(BaseRunConfig):
             default=False,
         ),
     ]
+    user_persona_id: Annotated[
+        Optional[str],
+        Field(
+            description="Force a specific user persona by id (e.g. a language-pack "
+            "persona like 'priya_hindi_v1'). None keeps the default per-task "
+            "persona sampling. See tau2.multilingual.",
+            default=None,
+        ),
+    ]
 
     # ---- Properties ----
 

--- a/src/tau2/data_model/voice.py
+++ b/src/tau2/data_model/voice.py
@@ -170,6 +170,20 @@ class SpeechEnvironment(BaseModel):
         default=None,
         description="The TTS voice ID actually used for synthesis.",
     )
+    language: Optional[str] = Field(
+        default=None,
+        description="ISO 639-1 language code when a language-pack persona is "
+        "active (see tau2.multilingual). None means English.",
+    )
+    locale: Optional[str] = Field(
+        default=None,
+        description="Region/locale tag of the active language-pack persona.",
+    )
+    persona_id: Optional[str] = Field(
+        default=None,
+        description="persona_id of the active language-pack persona. None for "
+        "plain English voice personas.",
+    )
     background_noise_file: Optional[str] = Field(default=None)
     burst_noise_files: list[str] = Field(
         default_factory=list,
@@ -271,10 +285,26 @@ class SampledVoiceConfig(BaseModel):
 
     def to_speech_environment(self, seed: int) -> "SpeechEnvironment":
         """Create a SpeechEnvironment from this sampled config."""
+        # Language-pack metadata (None for plain English personas).
+        from tau2.multilingual.registry import get_multilingual_persona
+
+        language = None
+        locale = None
+        persona_id = None
+        multilingual = get_multilingual_persona(self.persona_name)
+        if multilingual is not None:
+            pack, persona = multilingual
+            language = pack.language
+            locale = persona.locale
+            persona_id = persona.persona_id
+
         return SpeechEnvironment(
             voice_seed=seed,
             persona_name=self.persona_name,
             voice_id=get_elevenlabs_voice_id(self.persona_name),
+            language=language,
+            locale=locale,
+            persona_id=persona_id,
             background_noise_file=self.background_noise_file,
             burst_noise_files=self.burst_noise_files,
             environment=self.environment,

--- a/src/tau2/data_model/voice_personas.py
+++ b/src/tau2/data_model/voice_personas.py
@@ -62,6 +62,9 @@ class VoicePersona(BaseModel):
     short_description: str
     prompt: str
     complexity: PersonaComplexity
+    language: Optional[str] = None
+    """ISO 639-1 language code for non-English personas (set by language
+    packs, see tau2.multilingual). None means English."""
 
 
 MATT_DELANEY = VoicePersona(
@@ -154,6 +157,20 @@ ALL_PERSONA_NAMES: list[str] = list(ALL_PERSONAS.keys())
 CONTROL_PERSONA_NAMES: list[str] = [p.name for p in CONTROL_PERSONAS]
 REGULAR_PERSONA_NAMES: list[str] = [p.name for p in REGULAR_PERSONAS]
 DEFAULT_PERSONA_NAME = "matt_delaney"
+
+
+def register_voice_persona(persona: VoicePersona) -> None:
+    """Register an additional voice persona (used by language packs).
+
+    Registered personas become resolvable via ``get_elevenlabs_voice_id`` and
+    selectable by name, but are NOT added to the control/regular sampling
+    pools — they are only used when explicitly requested (e.g. via
+    ``--user-persona-id``), so default English runs are unaffected.
+    """
+    if persona.name in ALL_PERSONAS:
+        raise ValueError(f"Voice persona '{persona.name}' already registered")
+    ALL_PERSONAS[persona.name] = persona
+    ALL_PERSONA_NAMES.append(persona.name)
 
 
 def get_voice_id_overrides() -> list[str]:

--- a/src/tau2/multilingual/__init__.py
+++ b/src/tau2/multilingual/__init__.py
@@ -1,0 +1,44 @@
+# Copyright Sierra
+"""Language Pack registry for multilingual user simulation.
+
+A :class:`LanguagePack` bundles all language-specific *content* for one
+language: persona definitions, backchannel/side-talk repertoires, the
+localized guidelines file, acoustic-preset registrations, decision-prompt
+overrides, and default behavior parameters.
+
+Shared infra (this package) defines the pack interface, the registry, the
+loader, and the integration touchpoints. A language owner implements exactly
+one pack under ``tau2/multilingual/languages/<lang>/`` and edits zero shared
+code. English remains the default everywhere: with no pack registered (or no
+multilingual persona selected), behavior is byte-identical to before this
+package existed.
+
+See ``docs/multilingual/ADDING_A_LANGUAGE.md`` (authored in the final PR of
+the v1 milestone) for the language-owner playbook.
+"""
+
+from tau2.multilingual.registry import (
+    get_language_pack,
+    get_multilingual_persona,
+    list_language_packs,
+    register_language_pack,
+)
+from tau2.multilingual.schema import (
+    AcousticPreset,
+    BackchannelRepertoire,
+    LanguagePack,
+    MultilingualPersonaConfig,
+    SideTalkRepertoire,
+)
+
+__all__ = [
+    "AcousticPreset",
+    "BackchannelRepertoire",
+    "LanguagePack",
+    "MultilingualPersonaConfig",
+    "SideTalkRepertoire",
+    "get_language_pack",
+    "get_multilingual_persona",
+    "list_language_packs",
+    "register_language_pack",
+]

--- a/src/tau2/multilingual/languages/__init__.py
+++ b/src/tau2/multilingual/languages/__init__.py
@@ -1,0 +1,7 @@
+# Copyright Sierra
+"""Per-language pack subpackages.
+
+Each language gets one subpackage (e.g. ``hi/``, ``zh/``) that builds a
+``LanguagePack`` and calls ``register_language_pack`` at import time. See
+``docs/multilingual/ADDING_A_LANGUAGE.md`` for the authoring playbook.
+"""

--- a/src/tau2/multilingual/loader.py
+++ b/src/tau2/multilingual/loader.py
@@ -1,0 +1,34 @@
+# Copyright Sierra
+"""Discovery/loading of language packs.
+
+Each language lives in its own subpackage under
+``tau2/multilingual/languages/<lang>/`` whose ``__init__`` (or ``pack``
+module) calls ``register_language_pack`` at import time. This loader imports
+every subpackage exactly once; it is invoked lazily by the registry getters,
+so simply installing a pack directory makes it available everywhere.
+"""
+
+import importlib
+import pkgutil
+
+from loguru import logger
+
+_loaded = False
+
+
+def load_language_packs() -> None:
+    """Import all language subpackages (idempotent)."""
+    global _loaded
+    if _loaded:
+        return
+    _loaded = True
+
+    import tau2.multilingual.languages as languages_pkg
+
+    for module_info in pkgutil.iter_modules(languages_pkg.__path__):
+        module_name = f"{languages_pkg.__name__}.{module_info.name}"
+        try:
+            importlib.import_module(module_name)
+        except Exception:
+            logger.exception(f"Failed to load language pack module '{module_name}'")
+            raise

--- a/src/tau2/multilingual/registry.py
+++ b/src/tau2/multilingual/registry.py
@@ -1,0 +1,95 @@
+# Copyright Sierra
+"""Registry for Language Packs.
+
+Mirrors the pattern of ``tau2.registry`` (agents/domains/users): packs are
+registered into a module-level dict, and shared code looks them up by
+language code or persona id. Registration also makes each pack persona
+available as a ``VoicePersona`` so the existing TTS voice-id plumbing
+(``get_elevenlabs_voice_id``, speech generators) works unchanged.
+
+All getters lazily trigger pack discovery (``tau2.multilingual.loader``), so
+callers never need to import language packs explicitly. With no packs
+installed, every lookup is a cheap miss and English behavior is untouched.
+"""
+
+from typing import Optional
+
+from loguru import logger
+
+from tau2.data_model.voice_personas import (
+    VoicePersona,
+    _resolve_voice_id,
+    register_voice_persona,
+)
+from tau2.multilingual.schema import LanguagePack, MultilingualPersonaConfig
+
+_LANGUAGE_PACKS: dict[str, LanguagePack] = {}
+
+
+def register_language_pack(pack: LanguagePack) -> None:
+    """Register a language pack and its personas.
+
+    Each persona is also registered as a ``VoicePersona`` (name=persona_id) so
+    voice-id resolution and audio generation work through the existing
+    registries. Persona voice ids honor the ``TAU2_VOICE_ID_<PERSONA_ID>``
+    env-var override, like all other voice personas.
+
+    Raises:
+        ValueError: If the language or any persona_id is already registered.
+    """
+    if pack.language in _LANGUAGE_PACKS:
+        raise ValueError(f"Language pack '{pack.language}' already registered")
+
+    for persona in pack.personas.values():
+        voice_persona = VoicePersona(
+            elevenlabs_voice_id=_resolve_voice_id(
+                persona.persona_id, persona.voice_id or ""
+            ),
+            name=persona.persona_id,
+            display_name=persona.display_name,
+            short_description=persona.short_description,
+            prompt=persona.tts_voice_prompt,
+            complexity="regular",
+            language=pack.language,
+        )
+        register_voice_persona(voice_persona)
+
+    _LANGUAGE_PACKS[pack.language] = pack
+    logger.info(
+        f"Registered language pack '{pack.language}' "
+        f"({len(pack.personas)} personas: {sorted(pack.personas)})"
+    )
+
+
+def get_language_pack(language: str) -> Optional[LanguagePack]:
+    """Get the pack for a language code, or None (English has no pack)."""
+    _ensure_loaded()
+    return _LANGUAGE_PACKS.get(language)
+
+
+def list_language_packs() -> list[str]:
+    """List registered language codes."""
+    _ensure_loaded()
+    return sorted(_LANGUAGE_PACKS)
+
+
+def get_multilingual_persona(
+    persona_id: str,
+) -> Optional[tuple[LanguagePack, MultilingualPersonaConfig]]:
+    """Look up a persona across all packs by its persona_id.
+
+    Returns the (pack, persona) pair, or None if the id does not belong to
+    any language pack (e.g. it is a plain English voice persona).
+    """
+    _ensure_loaded()
+    for pack in _LANGUAGE_PACKS.values():
+        persona = pack.get_persona(persona_id)
+        if persona is not None:
+            return pack, persona
+    return None
+
+
+def _ensure_loaded() -> None:
+    from tau2.multilingual.loader import load_language_packs
+
+    load_language_packs()

--- a/src/tau2/multilingual/schema.py
+++ b/src/tau2/multilingual/schema.py
@@ -5,9 +5,12 @@ These models are the frozen interface between the shared infrastructure and
 per-language content owners. A language owner authors instances of these
 models (one ``LanguagePack`` per language) and never edits shared code.
 
-Field names are language-agnostic by design (``tv_form_default``, not
-``aap_default``; ``cultural_register`` is a free string) so that future
-languages (e.g. Mandarin) slot in without schema changes.
+The schema is deliberately small: typed fields exist only where code branches
+on them (registry keys, repertoire/voice/preset references) or where the
+research output reports them (``cs_density_target``, ``cultural_register``).
+All behavioral language content — register, code-switching, politeness,
+rituals — lives in author-written ``pragmatics_clauses``, because free text
+is the only representation that generalizes across languages.
 """
 
 from pathlib import Path
@@ -105,43 +108,36 @@ class MultilingualPersonaConfig(PersonaConfig):
     )
     language: str = Field(description="ISO 639-1 language code, e.g. 'hi'")
     locale: Optional[str] = Field(
-        default=None, description="Region/locale tag, e.g. 'IN-MH'"
+        default=None,
+        description="ISO 3166-2 subdivision code, e.g. 'IN-MH' (Maharashtra), "
+        "'IN-TG' (Telangana). Trajectory-tagging metadata only.",
     )
     script: Optional[str] = Field(
         default=None, description="ISO 15924 script code for the matrix language, "
         "e.g. 'deva'"
-    )
-    matrix_language: Optional[str] = Field(
-        default=None,
-        description="The grammatical matrix language when code-switching, if "
-        "different from `language`",
     )
     cs_density_target: Optional[float] = Field(
         default=None,
         ge=0.0,
         le=1.0,
         description="Target fraction of embedded-language (e.g. English) insertions. "
-        "Prompt-authoring target only; nothing measures it post-hoc.",
-    )
-    tv_form_default: Optional[str] = Field(
-        default=None,
-        description="Default T-V politeness form toward the agent, e.g. 'aap'",
+        "Metadata for reporting/analysis only — never injected into prompts and "
+        "never measured post-hoc. The author expresses code-switching behavior "
+        "natively in pragmatics_clauses.",
     )
     cultural_register: Optional[str] = Field(
         default=None,
         description="Free-text cultural/religious register, e.g. 'hindu_neutral', "
-        "'muslim'",
+        "'muslim'. Metadata for reporting/analysis only — never injected into "
+        "prompts.",
     )
     pragmatics_clauses: list[str] = Field(
         default_factory=list,
-        description="Freeform prompt-injectable clauses describing pragmatics: "
-        "indirect-refusal patterns, code-switch triggers, frustration patterns, "
-        "greeting/closing rituals.",
-    )
-    agent_capability_expectation: Optional[str] = Field(
-        default=None,
-        description="The persona's prior on the agent's fluency in their language, "
-        "and how they react when it is not met.",
+        description="Freeform prompt-injected clauses, authored natively by the "
+        "language owner. This is where ALL behavioral language content lives: "
+        "register, code-switching behavior, politeness forms, greeting/closing "
+        "rituals, indirect-refusal patterns, frustration patterns, and the "
+        "persona's expectation of the agent's language fluency.",
     )
     backchannel_repertoire_id: Optional[str] = Field(
         default=None,
@@ -170,47 +166,25 @@ class MultilingualPersonaConfig(PersonaConfig):
     def to_guidelines_text(self) -> Optional[str]:
         """Persona guidelines for the ``<PERSONA_GUIDELINES>`` system-prompt slot.
 
-        Extends the base PersonaConfig guidelines (verbosity etc.) with a
-        language/identity block assembled from this persona's fields.
+        Extends the base PersonaConfig guidelines (verbosity etc.) with the
+        author's verbatim persona content: the speaker-identity prompt and the
+        pragmatics clauses. No prose is generated from metadata fields — the
+        language owner controls all language/register phrasing natively.
         """
         sections: list[str] = []
         base = super().to_guidelines_text()
         if base:
             sections.append(base)
 
-        lines: list[str] = ["## PERSONA AND LANGUAGE"]
+        lines: list[str] = []
         if self.tts_voice_prompt:
             lines.append(self.tts_voice_prompt.strip())
-        lang_bits = [f"You speak {self.language}"]
-        if self.matrix_language:
-            lang_bits.append(f"with {self.matrix_language} as your matrix language")
-        if self.script:
-            lang_bits.append(f"written in the '{self.script}' script")
-        lines.append(" ".join(lang_bits) + ".")
-        if self.cs_density_target is not None:
-            lines.append(
-                f"Roughly {round(self.cs_density_target * 100)}% of your words are "
-                "English insertions (code-switching); the rest stay in your "
-                "language. Code-switch the way a real speaker of your profile "
-                "does — never translate whole sentences."
-            )
-        if self.tv_form_default:
-            lines.append(
-                f"You default to the '{self.tv_form_default}' politeness form when "
-                "addressing the agent."
-            )
-        if self.cultural_register:
-            lines.append(
-                f"Your cultural register is '{self.cultural_register}'; greetings, "
-                "exclamations, and religious phrasing follow it naturally."
-            )
-        if self.agent_capability_expectation:
-            lines.append(self.agent_capability_expectation.strip())
         for clause in self.pragmatics_clauses:
             lines.append(clause.strip())
+        if lines:
+            sections.append("\n\n".join(["## PERSONA AND LANGUAGE"] + lines))
 
-        sections.append("\n\n".join(lines))
-        return "\n\n".join(sections)
+        return "\n\n".join(sections) if sections else None
 
 
 class LanguagePack(BaseModel):

--- a/src/tau2/multilingual/schema.py
+++ b/src/tau2/multilingual/schema.py
@@ -1,0 +1,331 @@
+# Copyright Sierra
+"""Schema for Language Packs and multilingual personas.
+
+These models are the frozen interface between the shared infrastructure and
+per-language content owners. A language owner authors instances of these
+models (one ``LanguagePack`` per language) and never edits shared code.
+
+Field names are language-agnostic by design (``tv_form_default``, not
+``aap_default``; ``cultural_register`` is a free string) so that future
+languages (e.g. Mandarin) slot in without schema changes.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from tau2.data_model.persona import PersonaConfig
+
+
+class BackchannelRepertoire(BaseModel):
+    """Language/persona-specific backchannel phrases and firing behavior.
+
+    Consumed by the streaming user simulator's backchannel subsystem (the
+    parameterization of that subsystem lands separately; this schema is the
+    contract). When no repertoire is active, the simulator uses the English
+    module-global defaults in ``voice_config.py``.
+    """
+
+    id: str = Field(description="Unique repertoire id within the pack")
+    phrases: list[str] = Field(
+        description="Backchannel continuer phrases, in the pack's language/script"
+    )
+    decision_prompt: Optional[str] = Field(
+        default=None,
+        description="Override for the LLM backchannel decision prompt. None falls "
+        "back to the pack-level override, then to the English default.",
+    )
+    poisson_rate: Optional[float] = Field(
+        default=None,
+        description="Override for the Poisson backchannel rate (events/sec of agent "
+        "speech). None falls back to the global default.",
+    )
+
+
+class SideTalkRepertoire(BaseModel):
+    """Language/persona-specific out-of-turn (side-talk) phrases.
+
+    Localizes ``NON_DIRECTED_PHRASES`` (e.g. speaking to family or a driver,
+    not to the agent).
+    """
+
+    id: str = Field(description="Unique repertoire id within the pack")
+    phrases: list[str] = Field(
+        description="Non-directed speech phrases, in the pack's language/script"
+    )
+    events_per_minute: Optional[float] = Field(
+        default=None,
+        description="Override for out-of-turn speech rate. None falls back to the "
+        "global default.",
+    )
+
+
+class AcousticPreset(BaseModel):
+    """A locale-specific acoustic environment (background + burst noise files).
+
+    File names are relative to the verified background-noise data directories,
+    and may include a subdirectory (e.g. ``india/india_outdoor_traffic.wav``).
+    Audio files themselves are language-owner deliverables.
+    """
+
+    id: str = Field(description="Unique preset id within the pack")
+    display_name: str = Field(description="Human-readable name for visualizations")
+    background_noise_files: list[str] = Field(
+        default_factory=list,
+        description="Continuous background noise files (relative to the continuous "
+        "noise dir)",
+    )
+    burst_noise_files: list[str] = Field(
+        default_factory=list,
+        description="Burst noise files (relative to the burst noise dir)",
+    )
+
+
+class MultilingualPersonaConfig(PersonaConfig):
+    """A language-pack persona: identity, language metadata, and behavior knobs.
+
+    Extends the runtime :class:`PersonaConfig` (verbosity, interrupt tendency)
+    with language-aware fields. The persona's full prompt contribution flows
+    through the existing ``<PERSONA_GUIDELINES>`` slot via
+    :meth:`to_guidelines_text` — no user-simulator changes are required for a
+    persona to take effect.
+
+    A registered persona also becomes a ``VoicePersona`` (for TTS voice-id
+    resolution) automatically; see ``tau2.multilingual.registry``.
+    """
+
+    persona_id: str = Field(
+        description="Globally unique persona id, e.g. 'priya_hindi_v1'. Must not "
+        "collide with existing voice persona names."
+    )
+    display_name: str = Field(description="Human-readable name, e.g. 'Priya'")
+    short_description: str = Field(
+        description="One-line description for logs and visualizations"
+    )
+    language: str = Field(description="ISO 639-1 language code, e.g. 'hi'")
+    locale: Optional[str] = Field(
+        default=None, description="Region/locale tag, e.g. 'IN-MH'"
+    )
+    script: Optional[str] = Field(
+        default=None, description="ISO 15924 script code for the matrix language, "
+        "e.g. 'deva'"
+    )
+    matrix_language: Optional[str] = Field(
+        default=None,
+        description="The grammatical matrix language when code-switching, if "
+        "different from `language`",
+    )
+    cs_density_target: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Target fraction of embedded-language (e.g. English) insertions. "
+        "Prompt-authoring target only; nothing measures it post-hoc.",
+    )
+    tv_form_default: Optional[str] = Field(
+        default=None,
+        description="Default T-V politeness form toward the agent, e.g. 'aap'",
+    )
+    cultural_register: Optional[str] = Field(
+        default=None,
+        description="Free-text cultural/religious register, e.g. 'hindu_neutral', "
+        "'muslim'",
+    )
+    pragmatics_clauses: list[str] = Field(
+        default_factory=list,
+        description="Freeform prompt-injectable clauses describing pragmatics: "
+        "indirect-refusal patterns, code-switch triggers, frustration patterns, "
+        "greeting/closing rituals.",
+    )
+    agent_capability_expectation: Optional[str] = Field(
+        default=None,
+        description="The persona's prior on the agent's fluency in their language, "
+        "and how they react when it is not met.",
+    )
+    backchannel_repertoire_id: Optional[str] = Field(
+        default=None,
+        description="Id of a BackchannelRepertoire in the same pack",
+    )
+    burst_repertoire_id: Optional[str] = Field(
+        default=None,
+        description="Id of a SideTalkRepertoire in the same pack",
+    )
+    voice_id: Optional[str] = Field(
+        default=None,
+        description="ElevenLabs voice id for this persona. Overridable at runtime "
+        "via TAU2_VOICE_ID_<PERSONA_ID_UPPER>.",
+    )
+    tts_voice_prompt: str = Field(
+        default="",
+        description="Speaker-identity prompt (accent, age, tone, pacing). Used as "
+        "the VoicePersona prompt and injected into the user-simulator persona "
+        "guidelines.",
+    )
+    acoustic_preset_id: Optional[str] = Field(
+        default=None,
+        description="Id of an AcousticPreset in the same pack",
+    )
+
+    def to_guidelines_text(self) -> Optional[str]:
+        """Persona guidelines for the ``<PERSONA_GUIDELINES>`` system-prompt slot.
+
+        Extends the base PersonaConfig guidelines (verbosity etc.) with a
+        language/identity block assembled from this persona's fields.
+        """
+        sections: list[str] = []
+        base = super().to_guidelines_text()
+        if base:
+            sections.append(base)
+
+        lines: list[str] = ["## PERSONA AND LANGUAGE"]
+        if self.tts_voice_prompt:
+            lines.append(self.tts_voice_prompt.strip())
+        lang_bits = [f"You speak {self.language}"]
+        if self.matrix_language:
+            lang_bits.append(f"with {self.matrix_language} as your matrix language")
+        if self.script:
+            lang_bits.append(f"written in the '{self.script}' script")
+        lines.append(" ".join(lang_bits) + ".")
+        if self.cs_density_target is not None:
+            lines.append(
+                f"Roughly {round(self.cs_density_target * 100)}% of your words are "
+                "English insertions (code-switching); the rest stay in your "
+                "language. Code-switch the way a real speaker of your profile "
+                "does — never translate whole sentences."
+            )
+        if self.tv_form_default:
+            lines.append(
+                f"You default to the '{self.tv_form_default}' politeness form when "
+                "addressing the agent."
+            )
+        if self.cultural_register:
+            lines.append(
+                f"Your cultural register is '{self.cultural_register}'; greetings, "
+                "exclamations, and religious phrasing follow it naturally."
+            )
+        if self.agent_capability_expectation:
+            lines.append(self.agent_capability_expectation.strip())
+        for clause in self.pragmatics_clauses:
+            lines.append(clause.strip())
+
+        sections.append("\n\n".join(lines))
+        return "\n\n".join(sections)
+
+
+class LanguagePack(BaseModel):
+    """All language-specific content for one language, bundled.
+
+    Shared code consumes packs only through the registry
+    (``tau2.multilingual.registry``); language owners author exactly one pack
+    under ``tau2/multilingual/languages/<lang>/`` and register it.
+    """
+
+    language: str = Field(description="ISO 639-1 language code, e.g. 'hi'")
+    display_name: str = Field(description="Human-readable language name")
+    guidelines_voice_path: Optional[Path] = Field(
+        default=None,
+        description="Path to the localized voice user-simulator guidelines markdown "
+        "(re-authored, not translated). None falls back to the English guidelines.",
+    )
+    personas: dict[str, MultilingualPersonaConfig] = Field(
+        default_factory=dict,
+        description="Personas keyed by persona_id",
+    )
+    backchannel_repertoires: dict[str, BackchannelRepertoire] = Field(
+        default_factory=dict
+    )
+    side_talk_repertoires: dict[str, SideTalkRepertoire] = Field(default_factory=dict)
+    acoustic_presets: dict[str, AcousticPreset] = Field(default_factory=dict)
+    backchannel_decision_prompt: Optional[str] = Field(
+        default=None,
+        description="Pack-level override for the LLM backchannel decision prompt "
+        "(language-appropriate examples and density). Persona repertoires may "
+        "override it further.",
+    )
+    agent_language_clause: Optional[str] = Field(
+        default=None,
+        description="Agent-side system-prompt clause describing how to respond in "
+        "this language (script conventions, mirroring the user's register, keeping "
+        "tool calls in English).",
+    )
+    default_backchannel_poisson_rate: Optional[float] = Field(
+        default=None,
+        description="Language-level default backchannel Poisson rate. None keeps "
+        "the global default.",
+    )
+    default_out_of_turn_events_per_minute: Optional[float] = Field(
+        default=None,
+        description="Language-level default side-talk rate. None keeps the global "
+        "default.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_pack(self) -> "LanguagePack":
+        for persona_id, persona in self.personas.items():
+            if persona.persona_id != persona_id:
+                raise ValueError(
+                    f"Persona key '{persona_id}' does not match its persona_id "
+                    f"'{persona.persona_id}'"
+                )
+            if persona.language != self.language:
+                raise ValueError(
+                    f"Persona '{persona_id}' has language '{persona.language}' but "
+                    f"the pack language is '{self.language}'"
+                )
+            if (
+                persona.backchannel_repertoire_id is not None
+                and persona.backchannel_repertoire_id
+                not in self.backchannel_repertoires
+            ):
+                raise ValueError(
+                    f"Persona '{persona_id}' references unknown backchannel "
+                    f"repertoire '{persona.backchannel_repertoire_id}'"
+                )
+            if (
+                persona.burst_repertoire_id is not None
+                and persona.burst_repertoire_id not in self.side_talk_repertoires
+            ):
+                raise ValueError(
+                    f"Persona '{persona_id}' references unknown side-talk "
+                    f"repertoire '{persona.burst_repertoire_id}'"
+                )
+            if (
+                persona.acoustic_preset_id is not None
+                and persona.acoustic_preset_id not in self.acoustic_presets
+            ):
+                raise ValueError(
+                    f"Persona '{persona_id}' references unknown acoustic preset "
+                    f"'{persona.acoustic_preset_id}'"
+                )
+        if self.guidelines_voice_path is not None and not Path(
+            self.guidelines_voice_path
+        ).exists():
+            raise ValueError(
+                f"Guidelines file does not exist: {self.guidelines_voice_path}"
+            )
+        return self
+
+    def get_persona(self, persona_id: str) -> Optional[MultilingualPersonaConfig]:
+        return self.personas.get(persona_id)
+
+    def get_backchannel_repertoire(
+        self, persona: MultilingualPersonaConfig
+    ) -> Optional[BackchannelRepertoire]:
+        if persona.backchannel_repertoire_id is None:
+            return None
+        return self.backchannel_repertoires.get(persona.backchannel_repertoire_id)
+
+    def get_side_talk_repertoire(
+        self, persona: MultilingualPersonaConfig
+    ) -> Optional[SideTalkRepertoire]:
+        if persona.burst_repertoire_id is None:
+            return None
+        return self.side_talk_repertoires.get(persona.burst_repertoire_id)
+
+    def get_acoustic_preset(
+        self, persona: MultilingualPersonaConfig
+    ) -> Optional[AcousticPreset]:
+        if persona.acoustic_preset_id is None:
+            return None
+        return self.acoustic_presets.get(persona.acoustic_preset_id)

--- a/src/tau2/runner/build.py
+++ b/src/tau2/runner/build.py
@@ -191,6 +191,7 @@ def build_voice_user(
     domain: Optional[str] = None,
     hallucination_feedback: Optional[str] = None,
     audio_taps_dir: Optional[Path] = None,
+    user_persona_id: Optional[str] = None,
 ) -> FullDuplexUser:
     """Build a full-duplex voice user simulator.
 
@@ -215,6 +216,9 @@ def build_voice_user(
         hallucination_feedback: Optional feedback from a previous hallucination
             check. If provided, appended to user instructions to help avoid
             repeating the same errors on retry.
+        user_persona_id: Optional persona override (e.g. a language-pack
+            persona id like 'priya_hindi_v1'). Bypasses pre-sampled persona
+            selection; see tau2.multilingual.
 
     Returns:
         A fully constructed VoiceStreamingUserSimulator.
@@ -244,6 +248,7 @@ def build_voice_user(
         task_seed=task_seed,
         complexity=speech_complexity,
         synthesis_config=task_voice_settings.synthesis_config,
+        persona_name=user_persona_id,
     )
 
     # Update synthesis_config with merged effect configs
@@ -484,6 +489,7 @@ def build_voice_orchestrator(
         domain=domain,
         hallucination_feedback=hallucination_feedback,
         audio_taps_dir=audio_taps_dir,
+        user_persona_id=config.user_persona_id,
     )
 
     orchestrator = FullDuplexOrchestrator(

--- a/src/tau2/user/user_simulator.py
+++ b/src/tau2/user/user_simulator.py
@@ -65,16 +65,37 @@ def get_global_user_sim_guidelines(use_tools: bool = False) -> str:
     return user_sim_guidelines
 
 
-def get_global_user_sim_guidelines_voice(use_tools: bool = False) -> str:
+def get_global_user_sim_guidelines_voice(
+    use_tools: bool = False, language: Optional[str] = None
+) -> str:
     """
     Get the global user simulator guidelines for voice mode.
 
     Args:
         use_tools: Whether to use the tools guidelines.
+        language: ISO 639-1 code of an active language pack. If the pack
+            provides localized guidelines, those are used; otherwise falls
+            back to the English guidelines. None means English.
 
     Returns:
         The global user simulator guidelines for voice mode.
     """
+    if language is not None:
+        from tau2.multilingual.registry import get_language_pack
+
+        pack = get_language_pack(language)
+        if pack is not None and pack.guidelines_voice_path is not None:
+            if use_tools:
+                logger.warning(
+                    f"Language pack '{language}' guidelines have no tools "
+                    "variant; using the localized non-tools guidelines."
+                )
+            with open(pack.guidelines_voice_path, "r") as fp:
+                return fp.read()
+        logger.warning(
+            f"No localized voice guidelines for language '{language}'; "
+            "falling back to English guidelines."
+        )
     if use_tools:
         with open(GLOBAL_USER_SIM_GUIDELINES_PATH_VOICE_TOOLS, "r") as fp:
             user_sim_guidelines = fp.read()

--- a/src/tau2/user/user_simulator_streaming.py
+++ b/src/tau2/user/user_simulator_streaming.py
@@ -620,7 +620,12 @@ class VoiceStreamingUserSimulator(
     def global_simulation_guidelines(self) -> str:
         """The voice-specific simulation guidelines for the user simulator."""
         use_tools = self.tools is not None
-        return get_global_user_sim_guidelines_voice(use_tools=use_tools)
+        # Language-pack personas (MultilingualPersonaConfig) carry a language;
+        # plain PersonaConfig does not, which selects the English guidelines.
+        language = getattr(self.persona_config, "language", None)
+        return get_global_user_sim_guidelines_voice(
+            use_tools=use_tools, language=language
+        )
 
     @property
     def system_prompt(self) -> str:

--- a/src/tau2/user_simulation_voice_presets.py
+++ b/src/tau2/user_simulation_voice_presets.py
@@ -270,13 +270,15 @@ def sample_voice_config(
     seed: int,
     synthesis_config: SynthesisConfig,
     complexity: SpeechComplexity = "regular",
+    persona_name: Optional[str] = None,
 ) -> SampledVoiceConfig:
     """Sample a complete voice configuration from complexity presets.
 
     This function:
     1. Looks up the complexity preset
-    2. Selects persona deterministically from the preset's persona list (unless provided
-       via synthesis_config.provider_config.persona_name)
+    2. Selects persona deterministically from the preset's persona list (unless
+       forced via `persona_name` or provided via
+       synthesis_config.provider_config.voice_id)
     3. For regular mode, selects environment (indoor/outdoor) and associated audio files
     4. Creates configs with complexity settings applied
     5. Creates PersonaConfig from complexity settings
@@ -284,10 +286,17 @@ def sample_voice_config(
     Each complexity level uses a different seed offset to ensure different persona
     selections across complexity levels for the same base seed.
 
+    When `persona_name` names a language-pack persona (see tau2.multilingual),
+    the returned persona_config is that persona's MultilingualPersonaConfig
+    (the persona author controls verbosity/interrupt tendency), and its
+    acoustic preset (if registered) replaces the indoor/outdoor environment
+    selection.
+
     Args:
         seed: Random seed for reproducibility.
         synthesis_config: Base synthesis configuration with effect configs.
         complexity: Speech environment complexity level ("control" or "regular").
+        persona_name: Optional persona override (e.g. from --user-persona-id).
 
     Returns:
         SampledVoiceConfig with all configs instantiated and complexity settings applied.
@@ -305,12 +314,19 @@ def sample_voice_config(
     # -------------------------------------------------------------------------
     # Sample persona (simulation-level, same speaker throughout)
     # -------------------------------------------------------------------------
-    provider_config = synthesis_config.provider_config
-    voice_id = provider_config.voice_id if provider_config else None
-    persona_name = get_persona_name_by_voice_id(voice_id) if voice_id else None
+    if not persona_name:
+        provider_config = synthesis_config.provider_config
+        voice_id = provider_config.voice_id if provider_config else None
+        persona_name = get_persona_name_by_voice_id(voice_id) if voice_id else None
     if not persona_name:
         persona_names = preset.get("persona_names", CONTROL_PERSONA_NAMES)
         persona_name = rng.choice(persona_names)
+
+    # Language-pack persona? Resolves to (pack, MultilingualPersonaConfig);
+    # None for plain English personas (the default path, unchanged).
+    from tau2.multilingual.registry import get_multilingual_persona
+
+    multilingual = get_multilingual_persona(persona_name)
 
     # -------------------------------------------------------------------------
     # Select environment and audio files
@@ -319,7 +335,34 @@ def sample_voice_config(
     background_noise_file: Optional[str] = None
     burst_noise_files: list[str] = []
 
-    if preset.get("enable_background_noise") or preset.get("enable_burst_noise"):
+    noise_enabled = preset.get("enable_background_noise") or preset.get(
+        "enable_burst_noise"
+    )
+    acoustic_preset = (
+        multilingual[0].get_acoustic_preset(multilingual[1]) if multilingual else None
+    )
+
+    if acoustic_preset is not None and noise_enabled:
+        # Language-pack acoustic preset replaces indoor/outdoor selection.
+        environment = acoustic_preset.id
+        if (
+            preset.get("enable_background_noise")
+            and acoustic_preset.background_noise_files
+        ):
+            bg_filename = rng.choice(acoustic_preset.background_noise_files)
+            bg_path = BACKGROUND_NOISE_CONTINUOUS_DIR / bg_filename
+            if bg_path.exists():
+                background_noise_file = bg_filename
+            else:
+                logger.warning(f"Background noise file not found: {bg_path}")
+        if preset.get("enable_burst_noise"):
+            for burst_filename in acoustic_preset.burst_noise_files:
+                burst_path = BURST_NOISE_DIR / burst_filename
+                if burst_path.exists():
+                    burst_noise_files.append(burst_filename)
+                else:
+                    logger.warning(f"Burst noise file not found: {burst_path}")
+    elif preset.get("enable_background_noise") or preset.get("enable_burst_noise"):
         # Select environment deterministically based on seed
         env_setting = preset.get("environment")
         if env_setting == "auto":
@@ -412,10 +455,15 @@ def sample_voice_config(
     # -------------------------------------------------------------------------
     # Create PersonaConfig from complexity settings
     # -------------------------------------------------------------------------
-    persona_config = PersonaConfig(
-        verbosity=Verbosity(preset["verbosity"]),
-        interrupt_tendency=InterruptTendency(preset["interrupt_tendency"]),
-    )
+    if multilingual is not None:
+        # The language-pack persona IS the persona config (verbosity, interrupt
+        # tendency, and language fields are author-controlled).
+        persona_config = multilingual[1]
+    else:
+        persona_config = PersonaConfig(
+            verbosity=Verbosity(preset["verbosity"]),
+            interrupt_tendency=InterruptTendency(preset["interrupt_tendency"]),
+        )
 
     return SampledVoiceConfig(
         persona_name=persona_name,
@@ -623,6 +671,7 @@ def get_or_load_task_voice_config(
     task_seed: int,
     complexity: SpeechComplexity,
     synthesis_config: SynthesisConfig,
+    persona_name: Optional[str] = None,
 ) -> SampledVoiceConfig:
     """Get voice config for a task, loading from file if available.
 
@@ -632,10 +681,25 @@ def get_or_load_task_voice_config(
         task_seed: Seed to use if sampling is needed.
         complexity: Speech complexity level.
         synthesis_config: Base synthesis config for sampling.
+        persona_name: Optional persona override. When set, pre-sampled configs
+            are bypassed (they bake in a different persona) and the config is
+            sampled on the fly with this persona.
 
     Returns:
         SampledVoiceConfig for the task.
     """
+    if persona_name is not None:
+        logger.info(
+            f"Persona override '{persona_name}' for task {task_id}: sampling "
+            f"voice config on the fly (seed={task_seed}, complexity={complexity})"
+        )
+        return sample_voice_config(
+            seed=task_seed,
+            synthesis_config=synthesis_config,
+            complexity=complexity,
+            persona_name=persona_name,
+        )
+
     config_path = get_task_voice_configs_path(domain)
 
     if config_path.exists():

--- a/tests/test_multilingual/test_language_pack.py
+++ b/tests/test_multilingual/test_language_pack.py
@@ -54,10 +54,11 @@ def make_test_pack(**overrides) -> LanguagePack:
         locale="XX-TS",
         script="test",
         cs_density_target=0.3,
-        tv_form_default="formal-you",
         cultural_register="test_register",
-        pragmatics_clauses=["You greet with 'testgreeting'."],
-        agent_capability_expectation="You assume the agent speaks your language.",
+        pragmatics_clauses=[
+            "You greet with 'testgreeting'.",
+            "You assume the agent speaks your language.",
+        ],
         backchannel_repertoire_id="xx_default",
         burst_repertoire_id="xx_household",
         voice_id="fake_voice_id_123",
@@ -166,18 +167,28 @@ class TestRegistry:
 
 
 class TestPersonaGuidelines:
-    def test_guidelines_text_includes_language_fields(self):
+    def test_guidelines_text_is_author_content_verbatim(self):
         persona = make_test_pack().personas["tara_testlang_v1"]
         text = persona.to_guidelines_text()
         assert "PERSONA AND LANGUAGE" in text
         assert "A test speaker in her 30s." in text
-        assert "30%" in text
-        assert "formal-you" in text
-        assert "test_register" in text
         assert "testgreeting" in text
         assert "You assume the agent speaks your language." in text
         # Inherited PersonaConfig behavior still present (minimal verbosity)
         assert "MINIMAL VERBOSITY" in text
+        # Metadata fields are reporting-only: no template prose is generated
+        assert "30%" not in text
+        assert "test_register" not in text
+
+    def test_guidelines_text_empty_persona_content(self):
+        persona = make_test_pack().personas["tara_testlang_v1"].model_copy(
+            update={
+                "tts_voice_prompt": "",
+                "pragmatics_clauses": [],
+                "verbosity": Verbosity.STANDARD,
+            }
+        )
+        assert persona.to_guidelines_text() is None
 
 
 class TestSampling:

--- a/tests/test_multilingual/test_language_pack.py
+++ b/tests/test_multilingual/test_language_pack.py
@@ -1,0 +1,237 @@
+# Copyright Sierra
+"""Tests for the Language Pack registry (tau2.multilingual).
+
+Covers: schema validation, pack/persona registration, VoicePersona
+integration, persona guidelines text, voice-config sampling with a persona
+override, SpeechEnvironment metadata, guidelines fallback, and — critically —
+that English default behavior is unchanged when no pack persona is active.
+"""
+
+import pytest
+
+import tau2.data_model.voice_personas as voice_personas
+import tau2.multilingual.loader as ml_loader
+import tau2.multilingual.registry as ml_registry
+from tau2.data_model.persona import Verbosity
+from tau2.data_model.voice import SynthesisConfig
+from tau2.data_model.voice_personas import get_elevenlabs_voice_id
+from tau2.multilingual.schema import (
+    AcousticPreset,
+    BackchannelRepertoire,
+    LanguagePack,
+    MultilingualPersonaConfig,
+    SideTalkRepertoire,
+)
+from tau2.user.user_simulator import (
+    get_global_user_sim_guidelines_voice,
+)
+from tau2.user_simulation_voice_presets import sample_voice_config
+
+
+@pytest.fixture(autouse=True)
+def clean_registries():
+    """Snapshot/restore the pack registry and voice persona registry."""
+    saved_packs = dict(ml_registry._LANGUAGE_PACKS)
+    saved_personas = dict(voice_personas.ALL_PERSONAS)
+    saved_names = list(voice_personas.ALL_PERSONA_NAMES)
+    saved_loaded = ml_loader._loaded
+    ml_loader._loaded = True  # skip discovery; tests register packs directly
+    yield
+    ml_registry._LANGUAGE_PACKS.clear()
+    ml_registry._LANGUAGE_PACKS.update(saved_packs)
+    voice_personas.ALL_PERSONAS.clear()
+    voice_personas.ALL_PERSONAS.update(saved_personas)
+    voice_personas.ALL_PERSONA_NAMES[:] = saved_names
+    ml_loader._loaded = saved_loaded
+
+
+def make_test_pack(**overrides) -> LanguagePack:
+    persona = MultilingualPersonaConfig(
+        persona_id="tara_testlang_v1",
+        display_name="Tara",
+        short_description="Test-language persona",
+        language="xx",
+        locale="XX-TS",
+        script="test",
+        cs_density_target=0.3,
+        tv_form_default="formal-you",
+        cultural_register="test_register",
+        pragmatics_clauses=["You greet with 'testgreeting'."],
+        agent_capability_expectation="You assume the agent speaks your language.",
+        backchannel_repertoire_id="xx_default",
+        burst_repertoire_id="xx_household",
+        voice_id="fake_voice_id_123",
+        tts_voice_prompt="A test speaker in her 30s.",
+        acoustic_preset_id="xx_market",
+        verbosity=Verbosity.MINIMAL,
+    )
+    fields = dict(
+        language="xx",
+        display_name="Testlang",
+        personas={persona.persona_id: persona},
+        backchannel_repertoires={
+            "xx_default": BackchannelRepertoire(
+                id="xx_default", phrases=["mhm-xx", "ji-xx"]
+            )
+        },
+        side_talk_repertoires={
+            "xx_household": SideTalkRepertoire(
+                id="xx_household", phrases=["one moment (to family)"]
+            )
+        },
+        acoustic_presets={
+            "xx_market": AcousticPreset(
+                id="xx_market",
+                display_name="Test market",
+                background_noise_files=["xx/market.wav"],
+                burst_noise_files=["xx/bell.wav"],
+            )
+        },
+    )
+    fields.update(overrides)
+    return LanguagePack(**fields)
+
+
+class TestSchema:
+    def test_persona_language_must_match_pack(self):
+        pack = make_test_pack()
+        persona = pack.personas["tara_testlang_v1"].model_copy(
+            update={"language": "yy"}
+        )
+        with pytest.raises(ValueError, match="language"):
+            make_test_pack(personas={persona.persona_id: persona})
+
+    def test_unknown_repertoire_id_rejected(self):
+        pack = make_test_pack()
+        persona = pack.personas["tara_testlang_v1"].model_copy(
+            update={"backchannel_repertoire_id": "missing"}
+        )
+        with pytest.raises(ValueError, match="backchannel"):
+            make_test_pack(personas={persona.persona_id: persona})
+
+    def test_persona_key_must_match_persona_id(self):
+        pack = make_test_pack()
+        persona = pack.personas["tara_testlang_v1"]
+        with pytest.raises(ValueError, match="does not match"):
+            make_test_pack(personas={"wrong_key": persona})
+
+    def test_repertoire_lookups(self):
+        pack = make_test_pack()
+        persona = pack.personas["tara_testlang_v1"]
+        assert pack.get_backchannel_repertoire(persona).phrases == ["mhm-xx", "ji-xx"]
+        assert pack.get_side_talk_repertoire(persona).id == "xx_household"
+        assert pack.get_acoustic_preset(persona).id == "xx_market"
+
+
+class TestRegistry:
+    def test_register_and_lookup(self):
+        pack = make_test_pack()
+        ml_registry.register_language_pack(pack)
+        assert ml_registry.get_language_pack("xx") is pack
+        assert "xx" in ml_registry.list_language_packs()
+        found = ml_registry.get_multilingual_persona("tara_testlang_v1")
+        assert found is not None
+        assert found[0] is pack
+        assert found[1].persona_id == "tara_testlang_v1"
+
+    def test_duplicate_language_rejected(self):
+        ml_registry.register_language_pack(make_test_pack())
+        with pytest.raises(ValueError, match="already registered"):
+            ml_registry.register_language_pack(make_test_pack())
+
+    def test_unknown_lookups_return_none(self):
+        assert ml_registry.get_language_pack("zz") is None
+        assert ml_registry.get_multilingual_persona("nobody") is None
+
+    def test_voice_persona_registered_but_not_in_sampling_pools(self):
+        ml_registry.register_language_pack(make_test_pack())
+        assert get_elevenlabs_voice_id("tara_testlang_v1") == "fake_voice_id_123"
+        vp = voice_personas.ALL_PERSONAS["tara_testlang_v1"]
+        assert vp.language == "xx"
+        assert vp.prompt == "A test speaker in her 30s."
+        assert "tara_testlang_v1" not in voice_personas.CONTROL_PERSONA_NAMES
+        assert "tara_testlang_v1" not in voice_personas.REGULAR_PERSONA_NAMES
+
+    def test_duplicate_persona_id_rejected(self):
+        ml_registry.register_language_pack(make_test_pack())
+        persona = make_test_pack().personas["tara_testlang_v1"]
+        other = make_test_pack(
+            language="yy",
+            personas={
+                persona.persona_id: persona.model_copy(update={"language": "yy"})
+            },
+        )
+        with pytest.raises(ValueError, match="already registered"):
+            ml_registry.register_language_pack(other)
+
+
+class TestPersonaGuidelines:
+    def test_guidelines_text_includes_language_fields(self):
+        persona = make_test_pack().personas["tara_testlang_v1"]
+        text = persona.to_guidelines_text()
+        assert "PERSONA AND LANGUAGE" in text
+        assert "A test speaker in her 30s." in text
+        assert "30%" in text
+        assert "formal-you" in text
+        assert "test_register" in text
+        assert "testgreeting" in text
+        assert "You assume the agent speaks your language." in text
+        # Inherited PersonaConfig behavior still present (minimal verbosity)
+        assert "MINIMAL VERBOSITY" in text
+
+
+class TestSampling:
+    def test_persona_override_flows_to_speech_environment(self):
+        ml_registry.register_language_pack(make_test_pack())
+        sampled = sample_voice_config(
+            seed=7,
+            synthesis_config=SynthesisConfig(),
+            complexity="regular",
+            persona_name="tara_testlang_v1",
+        )
+        assert sampled.persona_name == "tara_testlang_v1"
+        assert isinstance(sampled.persona_config, MultilingualPersonaConfig)
+        assert sampled.persona_config.language == "xx"
+        # Acoustic preset replaces indoor/outdoor environment selection
+        assert sampled.environment == "xx_market"
+
+        env = sampled.to_speech_environment(seed=7)
+        assert env.language == "xx"
+        assert env.locale == "XX-TS"
+        assert env.persona_id == "tara_testlang_v1"
+        assert env.voice_id == "fake_voice_id_123"
+
+    def test_english_default_unchanged(self):
+        ml_registry.register_language_pack(make_test_pack())
+        sampled = sample_voice_config(
+            seed=7,
+            synthesis_config=SynthesisConfig(),
+            complexity="regular",
+        )
+        assert sampled.persona_name != "tara_testlang_v1"
+        assert not isinstance(sampled.persona_config, MultilingualPersonaConfig)
+        assert sampled.environment in ("indoor", "outdoor")
+        env = sampled.to_speech_environment(seed=7)
+        assert env.language is None
+        assert env.locale is None
+        assert env.persona_id is None
+
+
+class TestGuidelines:
+    def test_language_without_pack_falls_back_to_english(self):
+        english = get_global_user_sim_guidelines_voice()
+        assert get_global_user_sim_guidelines_voice(language="zz") == english
+
+    def test_pack_guidelines_used_when_present(self, tmp_path):
+        guidelines = tmp_path / "simulation_guidelines_voice_xx.md"
+        guidelines.write_text("LOCALIZED GUIDELINES <PERSONA_GUIDELINES>")
+        ml_registry.register_language_pack(
+            make_test_pack(guidelines_voice_path=guidelines)
+        )
+        text = get_global_user_sim_guidelines_voice(language="xx")
+        assert text.startswith("LOCALIZED GUIDELINES")
+
+    def test_pack_without_guidelines_falls_back(self):
+        ml_registry.register_language_pack(make_test_pack())
+        english = get_global_user_sim_guidelines_voice()
+        assert get_global_user_sim_guidelines_voice(language="xx") == english


### PR DESCRIPTION
## Summary

PR1 of the Hindi extension milestone (Tau-Lost Voices v1) — the language-agnostic **Language Pack** interface that gates all multilingual work. A language owner implements one pack under `tau2/multilingual/languages/<lang>/` and edits zero shared code; English behavior is unchanged everywhere.

### New package `src/tau2/multilingual/`
- **schema.py** — `LanguagePack`, `MultilingualPersonaConfig` (extends `PersonaConfig` with language/locale/script/cs_density_target/tv_form_default/cultural_register/pragmatics_clauses + voice and repertoire refs), `BackchannelRepertoire`, `SideTalkRepertoire`, `AcousticPreset`. Registration-time validators catch broken references.
- **registry.py** — register/lookup by language code or persona_id. Pack personas auto-register as `VoicePersona`s so all existing TTS voice-ID plumbing works untouched, but stay out of the control/regular sampling pools (only active via explicit `--user-persona-id`).
- **loader.py** — lazy discovery of per-language subpackages.

### Surgical hooks in shared code (all no-ops for English)
- `VoicePersona.language` + `register_voice_persona()` (voice_personas.py)
- `SpeechEnvironment.language/locale/persona_id` metadata, populated in `to_speech_environment()` (voice.py)
- `get_global_user_sim_guidelines_voice(language=...)` resolves pack-localized guidelines, English fallback; streaming sim passes the active persona's language
- `sample_voice_config(persona_name=...)` override; multilingual personas carry their own `PersonaConfig` and acoustic preset; `get_or_load_task_voice_config` bypasses pre-sampled configs on override
- CLI `--user-persona-id` (audio-native only) → `VoiceRunConfig.user_persona_id` → `build_voice_user`

### Design notes
- Persona prompt injection flows through the existing `<PERSONA_GUIDELINES>` slot via `MultilingualPersonaConfig.to_guidelines_text()` — the previously unused `VoicePersona.prompt` field is wired for pack personas only, keeping English system prompts byte-identical.
- The English sampling path makes the identical RNG call sequence as before, so pre-sampled `tasks_voice.json` configs reproduce exactly.

## Test plan
- [x] `tests/test_multilingual/` — 15 new tests: schema validation, registration, persona guidelines, sampling override → `SpeechEnvironment` metadata, guidelines fallback, and an explicit English-default regression test
- [x] `tests/test_voice/ tests/test_streaming/ tests/test_user.py` — 216 passed; 3 failures are missing-API-key live tests; `test_discrete_time_audio_native_agent.py` is pre-broken on main (imports `tick_runner` deleted in acf281e)
- [x] `ruff check` clean on all touched files; `tau2 run --help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)