### PR TITLE
feat: provider language config + agent-side language clause (PR3)

### DIFF
--- a/src/tau2/agent/base/voice.py
+++ b/src/tau2/agent/base/voice.py
@@ -61,9 +61,21 @@ class VoiceMixin(
             format=message.audio_format,
             audio_path=message.audio_path,
         )
+        transcription_config = self.voice_settings.transcription_config
+        speech_environment = self.voice_settings.speech_environment
+        if (
+            transcription_config.language is None
+            and speech_environment is not None
+            and speech_environment.language is not None
+        ):
+            # Default the transcription language from the active language-pack
+            # persona. No-op for English runs (language is None).
+            transcription_config = transcription_config.model_copy(
+                update={"language": speech_environment.language}
+            )
         transcription_result = transcribe_audio(
             audio_data=audio_data,
-            config=self.voice_settings.transcription_config,
+            config=transcription_config,
         )
         if transcription_result.error:
             raise ValueError(f"Transcription failed: {transcription_result.error}")

--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -211,6 +211,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         use_xml_prompt: bool = False,
         cascaded_config: Optional["CascadedConfig"] = None,
         audio_taps_dir: Optional[Path] = None,
+        language: Optional[str] = None,
     ):
         """Initialize the discrete-time audio native agent.
 
@@ -242,6 +243,11 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
                 Only used when provider="livekit". Ignored for other providers.
                 Can be a CascadedConfig instance or None to use defaults.
             audio_taps_dir: Directory to save audio taps. Only used when audio_taps_dir is not None.
+            language: ISO 639-1 language code of the run's active language-pack
+                persona (see tau2.multilingual). When set, the pack's
+                agent_language_clause (if any) is appended to the system prompt
+                and the code is forwarded to provider STT/transcription configs.
+                None means English (behavior unchanged).
         """
         self.tools = tools
         self.domain_policy = domain_policy
@@ -254,6 +260,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         self.reasoning_effort = reasoning_effort
         self.max_inactive_seconds = max_inactive_seconds
         self.cascaded_config = cascaded_config
+        self.language = language
 
         # Audio format (defaults to telephony)
         self.audio_format = audio_format or TELEPHONY_AUDIO_FORMAT
@@ -350,10 +357,34 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         else:
             agent_instruction = AUDIO_NATIVE_VOICE_INSTRUCTION
 
-        return template.format(
+        prompt = template.format(
             agent_instruction=agent_instruction,
             domain_policy=self.domain_policy,
         )
+
+        # Append the language pack's agent-side clause for non-English runs.
+        # No-op when language is None (English), no pack exists for the
+        # language, or the pack defines no clause.
+        language_clause = self._get_agent_language_clause()
+        if language_clause:
+            prompt = f"{prompt}\n\n{language_clause}"
+
+        return prompt
+
+    def _get_agent_language_clause(self) -> Optional[str]:
+        """Resolve the agent-side language clause for the run's language.
+
+        Returns None when the run is English (language is None), the language
+        has no registered pack, or the pack defines no agent_language_clause.
+        """
+        if self.language is None:
+            return None
+        from tau2.multilingual import get_language_pack
+
+        pack = get_language_pack(self.language)
+        if pack is None:
+            return None
+        return pack.agent_language_clause
 
     @property
     def adapter(self) -> DiscreteTimeAdapter:
@@ -367,6 +398,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
                 reasoning_effort=self.reasoning_effort,
                 audio_format=self.audio_format,
                 cascaded_config=self.cascaded_config,
+                language=self.language,
             )
         return self._adapter
 
@@ -800,10 +832,13 @@ def create_discrete_time_audio_native_agent(tools, domain_policy, **kwargs):
             - audio_native_config: AudioNativeConfig with provider settings.
               If provided, the following fields are extracted from it:
               tick_duration_ms, send_audio_instant, provider, model, use_xml_prompt.
+            - language: ISO 639-1 code of the run's active language-pack
+              persona. None means English.
             - Individual overrides for any of the above fields.
     """
     audio_native_config = kwargs.get("audio_native_config")
     audio_taps_dir = kwargs.get("audio_taps_dir")
+    language = kwargs.get("language")
     if audio_native_config is not None:
         return DiscreteTimeAudioNativeAgent(
             tools=tools,
@@ -817,6 +852,7 @@ def create_discrete_time_audio_native_agent(tools, domain_policy, **kwargs):
             use_xml_prompt=audio_native_config.use_xml_prompt,
             cascaded_config=getattr(audio_native_config, "cascaded_config", None),
             audio_taps_dir=audio_taps_dir,
+            language=language,
         )
     else:
         # Fallback: use individual kwargs or defaults
@@ -828,4 +864,5 @@ def create_discrete_time_audio_native_agent(tools, domain_policy, **kwargs):
             provider=kwargs.get("provider", DEFAULT_AUDIO_NATIVE_PROVIDER),
             model=kwargs.get("model"),
             audio_taps_dir=audio_taps_dir,
+            language=language,
         )

--- a/src/tau2/runner/build.py
+++ b/src/tau2/runner/build.py
@@ -75,6 +75,7 @@ def build_agent(
     audio_native_config: Optional[AudioNativeConfig] = None,
     solo_mode: bool = False,
     audio_taps_dir: Optional[Path] = None,
+    language: Optional[str] = None,
 ) -> Union[HalfDuplexAgent, FullDuplexAgent]:
     """Build an agent from a registered name and an environment.
 
@@ -90,6 +91,8 @@ def build_agent(
         task: The task (required for some agents like llm_agent_gt, llm_agent_solo).
         audio_native_config: Audio config (full-duplex agents).
         solo_mode: If True, agent tools include both agent and user tools.
+        language: ISO 639-1 code of the run's active language-pack persona
+            (see tau2.multilingual). None means English.
 
     Returns:
         A fully constructed agent instance.
@@ -122,6 +125,7 @@ def build_agent(
         task=task,
         audio_native_config=audio_native_config,
         audio_taps_dir=audio_taps_dir,
+        language=language,
     )
 
 
@@ -265,6 +269,16 @@ def build_voice_user(
     # Set speech environment
     speech_environment = sampled_voice_config.to_speech_environment(task_seed)
     task_voice_settings.speech_environment = speech_environment
+
+    # Default the transcription language from the active language-pack persona.
+    # No-op for English runs (speech_environment.language is None) and when the
+    # caller set a language explicitly.
+    if (
+        task_voice_settings.transcription_config is not None
+        and task_voice_settings.transcription_config.language is None
+        and speech_environment.language is not None
+    ):
+        task_voice_settings.transcription_config.language = speech_environment.language
 
     # Use provided persona config or fall back to sampled config
     if persona_config is None:
@@ -469,11 +483,25 @@ def build_voice_orchestrator(
 
     environment = build_environment(domain, env_kwargs=env_kwargs)
 
+    # Resolve the run's language from the persona override. The agent is built
+    # before the voice user (whose sampled SpeechEnvironment carries the
+    # language), so resolve from config.user_persona_id via the same
+    # language-pack lookup used by SampledVoiceConfig.to_speech_environment.
+    # None (no override, or a plain English persona) means English.
+    user_language = None
+    if config.user_persona_id is not None:
+        from tau2.multilingual import get_multilingual_persona
+
+        multilingual = get_multilingual_persona(config.user_persona_id)
+        if multilingual is not None:
+            user_language = multilingual[0].language
+
     agent = build_agent(
         config.effective_agent,
         environment,
         audio_native_config=config.audio_native_config,
         audio_taps_dir=audio_taps_dir,
+        language=user_language,
     )
 
     user = build_voice_user(

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -337,6 +337,7 @@ def create_adapter(
     reasoning_effort: Optional[str] = None,
     audio_format: Optional[AudioFormat] = None,
     cascaded_config: Any = None,
+    language: Optional[str] = None,
 ) -> Tuple[DiscreteTimeAdapter, str]:
     """Create a discrete-time adapter for the given provider.
 
@@ -353,6 +354,10 @@ def create_adapter(
         audio_format: Audio format for external communication. Defaults to
             telephony (8kHz μ-law).
         cascaded_config: Configuration for cascaded providers (livekit).
+        language: ISO 639-1 code of the run's active language-pack persona
+            (see tau2.multilingual). Forwarded to provider transcription/STT
+            configs where supported (openai, livekit). None means English
+            (provider defaults unchanged).
 
     Returns:
         Tuple of (adapter, resolved_model).
@@ -395,6 +400,7 @@ def create_adapter(
             model=model,
             reasoning_effort=reasoning_effort,
             audio_format=audio_format,
+            language=language,
         )
     elif provider == "gemini":
         from tau2.voice.audio_native.gemini.discrete_time_adapter import (
@@ -446,6 +452,10 @@ def create_adapter(
         )
 
         config = cascaded_config or CascadedConfig()
+        if language is not None:
+            # Deep copy so shared presets (CASCADED_CONFIGS) are not mutated.
+            config = config.model_copy(deep=True)
+            config.stt.language = language
         adapter = LiveKitCascadedAdapter(
             tick_duration_ms=tick_duration_ms,
             cascaded_config=config,

--- a/src/tau2/voice/audio_native/livekit/config.py
+++ b/src/tau2/voice/audio_native/livekit/config.py
@@ -26,7 +26,10 @@ class DeepgramSTTConfig(BaseModel):
     Attributes:
         provider: Provider identifier (always "deepgram").
         model: Deepgram model to use. "nova-3" is the latest and most accurate.
-        language: Language code (e.g., "en-US", "es", "fr").
+        language: Language code (e.g., "en-US", "es", "fr"). Defaults to
+            "en-US"; overridden with the run's language-pack code when a
+            multilingual persona is active (see create_adapter in
+            tau2.voice.audio_native.adapter).
         interim_results: Whether to return interim (partial) transcripts.
         vad_events: Whether to emit VAD events (speech start/end).
         endpointing_ms: Silence duration (ms) before considering speech ended.

--- a/src/tau2/voice/audio_native/openai/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/openai/discrete_time_adapter.py
@@ -71,6 +71,7 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
         reasoning_effort: Optional[str] = None,
         provider: Optional[OpenAIRealtimeProvider] = None,
         audio_format: Optional[AudioFormat] = None,
+        language: Optional[str] = None,
     ):
         super().__init__(
             tick_duration_ms,
@@ -87,6 +88,7 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
 
         self.model = model
         self.reasoning_effort = reasoning_effort
+        self.language = language
         self._provider = provider
         self._owns_provider = provider is None
 
@@ -99,6 +101,7 @@ class DiscreteTimeOpenAIAdapter(DiscreteTimeAdapter):
             self._provider = OpenAIRealtimeProvider(
                 model=self.model,
                 reasoning_effort=self.reasoning_effort,
+                language=self.language,
             )
         return self._provider
 

--- a/src/tau2/voice/audio_native/openai/provider.py
+++ b/src/tau2/voice/audio_native/openai/provider.py
@@ -118,6 +118,7 @@ class OpenAIRealtimeProvider:
         api_key: Optional[str] = None,
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
+        language: Optional[str] = None,
     ):
         """Initialize the OpenAI Realtime provider.
 
@@ -127,6 +128,8 @@ class OpenAIRealtimeProvider:
             model: Model identifier to use. Defaults to DEFAULT_MODEL.
             reasoning_effort: Reasoning effort for thinking models ("minimal",
                 "low", "medium", "high"). If None, not sent to the API.
+            language: ISO 639-1 language code for input audio transcription.
+                Defaults to "en" when None.
 
         Raises:
             ValueError: If no API key is provided or found in environment.
@@ -137,6 +140,7 @@ class OpenAIRealtimeProvider:
 
         self.model = model or self.DEFAULT_MODEL
         self.reasoning_effort = reasoning_effort
+        self.language = language or "en"
         self.ws: Optional[websockets.WebSocketClientProtocol] = None
         self._current_vad_config: Optional[OpenAIVADConfig] = None
         self._audio_format: AudioFormat = TELEPHONY_AUDIO_FORMAT
@@ -334,7 +338,7 @@ class OpenAIRealtimeProvider:
                     "format": audio_fmt,
                     "transcription": {
                         "model": DEFAULT_OPENAI_TRANSCRIPTION_MODEL,
-                        "language": "en",
+                        "language": self.language,
                     },
                     "noise_reduction": {"type": DEFAULT_OPENAI_NOISE_REDUCTION},
                     "turn_detection": self._build_turn_detection_config(vad_config),

--- a/tests/test_multilingual/test_agent_language.py
+++ b/tests/test_multilingual/test_agent_language.py
@@ -1,0 +1,249 @@
+# Copyright Sierra
+"""Tests for run-language plumbing (PR3).
+
+Covers: the agent-side language clause in the audio-native agent's system
+prompt (on iff a pack persona is active AND the pack defines a clause),
+TranscriptionConfig language defaulting from the active SpeechEnvironment,
+provider STT language plumbing (OpenAI realtime, LiveKit cascaded), and —
+critically — that English behavior (language=None) is unchanged.
+"""
+
+import base64
+
+import pytest
+
+import tau2.data_model.voice_personas as voice_personas
+import tau2.multilingual.loader as ml_loader
+import tau2.multilingual.registry as ml_registry
+from tau2.agent.base.voice import VoiceMixin
+from tau2.agent.discrete_time_audio_native_agent import (
+    DiscreteTimeAudioNativeAgent,
+    create_discrete_time_audio_native_agent,
+)
+from tau2.data_model.audio import TELEPHONY_AUDIO_FORMAT
+from tau2.data_model.message import UserMessage
+from tau2.data_model.persona import Verbosity
+from tau2.data_model.voice import (
+    SpeechEnvironment,
+    TranscriptionConfig,
+    TranscriptionResult,
+    VoiceSettings,
+)
+from tau2.multilingual.schema import LanguagePack, MultilingualPersonaConfig
+from tau2.voice.audio_native.adapter import create_adapter
+from tau2.voice.audio_native.livekit.config import (
+    CASCADED_CONFIGS,
+    CascadedConfig,
+)
+
+AGENT_CLAUSE = (
+    "Respond in Testlang using its native script; mirror the user's "
+    "code-switching register; keep tool calls and structured outputs unchanged."
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_registries():
+    """Snapshot/restore the pack registry and voice persona registry."""
+    saved_packs = dict(ml_registry._LANGUAGE_PACKS)
+    saved_personas = dict(voice_personas.ALL_PERSONAS)
+    saved_names = list(voice_personas.ALL_PERSONA_NAMES)
+    saved_loaded = ml_loader._loaded
+    ml_loader._loaded = True  # skip discovery; tests register packs directly
+    yield
+    ml_registry._LANGUAGE_PACKS.clear()
+    ml_registry._LANGUAGE_PACKS.update(saved_packs)
+    voice_personas.ALL_PERSONAS.clear()
+    voice_personas.ALL_PERSONAS.update(saved_personas)
+    voice_personas.ALL_PERSONA_NAMES[:] = saved_names
+    ml_loader._loaded = saved_loaded
+
+
+def make_test_pack(**overrides) -> LanguagePack:
+    persona = MultilingualPersonaConfig(
+        persona_id="tara_testlang_v1",
+        display_name="Tara",
+        short_description="Test-language persona",
+        language="xx",
+        locale="XX-TS",
+        script="test",
+        voice_id="fake_voice_id_123",
+        tts_voice_prompt="A test speaker in her 30s.",
+        verbosity=Verbosity.MINIMAL,
+    )
+    fields = dict(
+        language="xx",
+        display_name="Testlang",
+        personas={persona.persona_id: persona},
+        agent_language_clause=AGENT_CLAUSE,
+    )
+    fields.update(overrides)
+    return LanguagePack(**fields)
+
+
+def make_agent(language=None, **kwargs) -> DiscreteTimeAudioNativeAgent:
+    return DiscreteTimeAudioNativeAgent(
+        tools=[],
+        domain_policy="TEST DOMAIN POLICY",
+        language=language,
+        **kwargs,
+    )
+
+
+class TestAgentLanguageClause:
+    def test_clause_appended_when_pack_persona_active(self):
+        ml_registry.register_language_pack(make_test_pack())
+        agent = make_agent(language="xx")
+        assert agent.system_prompt.endswith(AGENT_CLAUSE)
+        assert "TEST DOMAIN POLICY" in agent.system_prompt
+
+    def test_clause_off_when_language_is_none(self):
+        ml_registry.register_language_pack(make_test_pack())
+        agent = make_agent(language=None)
+        assert AGENT_CLAUSE not in agent.system_prompt
+
+    def test_clause_off_when_no_pack_exists(self):
+        ml_registry.register_language_pack(make_test_pack())
+        agent = make_agent(language="zz")
+        assert AGENT_CLAUSE not in agent.system_prompt
+
+    def test_clause_off_when_pack_has_no_clause(self):
+        ml_registry.register_language_pack(make_test_pack(agent_language_clause=None))
+        agent = make_agent(language="xx")
+        assert AGENT_CLAUSE not in agent.system_prompt
+
+    def test_english_prompt_unchanged(self):
+        """language=None must produce a byte-identical system prompt."""
+        ml_registry.register_language_pack(make_test_pack())
+        baseline = DiscreteTimeAudioNativeAgent(
+            tools=[], domain_policy="TEST DOMAIN POLICY"
+        )
+        agent = make_agent(language=None)
+        assert agent.system_prompt == baseline.system_prompt
+        # The prompt ends exactly at the policy (no appended text)
+        assert agent.system_prompt.endswith("TEST DOMAIN POLICY")
+
+    def test_factory_threads_language(self):
+        ml_registry.register_language_pack(make_test_pack())
+        agent = create_discrete_time_audio_native_agent(
+            tools=[],
+            domain_policy="TEST DOMAIN POLICY",
+            language="xx",
+        )
+        assert agent.language == "xx"
+        assert agent.system_prompt.endswith(AGENT_CLAUSE)
+
+    def test_factory_defaults_to_english(self):
+        ml_registry.register_language_pack(make_test_pack())
+        agent = create_discrete_time_audio_native_agent(
+            tools=[],
+            domain_policy="TEST DOMAIN POLICY",
+        )
+        assert agent.language is None
+        assert AGENT_CLAUSE not in agent.system_prompt
+
+
+class _VoiceHolder(VoiceMixin):
+    """Minimal VoiceMixin host for exercising transcribe_voice."""
+
+
+def make_audio_message() -> UserMessage:
+    silence = b"\x7f" * 160  # 20ms of mu-law silence
+    return UserMessage(
+        role="user",
+        is_audio=True,
+        audio_content=base64.b64encode(silence).decode("utf-8"),
+        audio_format=TELEPHONY_AUDIO_FORMAT,
+    )
+
+
+class TestTranscriptionLanguageDefaulting:
+    def _capture_transcribe(self, monkeypatch):
+        captured = {}
+
+        def fake_transcribe_audio(audio_data, config):
+            captured["config"] = config
+            return TranscriptionResult(transcript="hello")
+
+        monkeypatch.setattr(
+            "tau2.agent.base.voice.transcribe_audio", fake_transcribe_audio
+        )
+        return captured
+
+    def test_language_defaults_from_speech_environment(self, monkeypatch):
+        captured = self._capture_transcribe(monkeypatch)
+        transcription_config = TranscriptionConfig()
+        holder = _VoiceHolder(
+            voice_settings=VoiceSettings(
+                transcription_config=transcription_config,
+                speech_environment=SpeechEnvironment(language="xx"),
+            )
+        )
+        holder.transcribe_voice(make_audio_message())
+        assert captured["config"].language == "xx"
+        # The run-level config is not mutated
+        assert transcription_config.language is None
+
+    def test_explicit_language_not_overridden(self, monkeypatch):
+        captured = self._capture_transcribe(monkeypatch)
+        holder = _VoiceHolder(
+            voice_settings=VoiceSettings(
+                transcription_config=TranscriptionConfig(language="fr"),
+                speech_environment=SpeechEnvironment(language="xx"),
+            )
+        )
+        holder.transcribe_voice(make_audio_message())
+        assert captured["config"].language == "fr"
+
+    def test_english_path_unchanged(self, monkeypatch):
+        captured = self._capture_transcribe(monkeypatch)
+        transcription_config = TranscriptionConfig()
+        holder = _VoiceHolder(
+            voice_settings=VoiceSettings(
+                transcription_config=transcription_config,
+                speech_environment=SpeechEnvironment(),  # language=None
+            )
+        )
+        holder.transcribe_voice(make_audio_message())
+        assert captured["config"].language is None
+        assert captured["config"] is transcription_config
+
+
+class TestProviderLanguagePlumbing:
+    def test_openai_provider_language_defaults_to_en(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        from tau2.voice.audio_native.openai.discrete_time_adapter import (
+            DiscreteTimeOpenAIAdapter,
+        )
+
+        adapter = DiscreteTimeOpenAIAdapter(tick_duration_ms=1000)
+        assert adapter.provider.language == "en"
+
+    def test_openai_provider_receives_run_language(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        adapter, _ = create_adapter(
+            provider="openai", tick_duration_ms=1000, language="xx"
+        )
+        assert adapter.language == "xx"
+        assert adapter.provider.language == "xx"
+
+    def test_livekit_stt_language_overridden_without_mutating_presets(self):
+        preset = CASCADED_CONFIGS["default"]
+        adapter, _ = create_adapter(
+            provider="livekit",
+            tick_duration_ms=1000,
+            cascaded_config=preset,
+            language="xx",
+        )
+        assert adapter.cascaded_config.stt.language == "xx"
+        # Shared preset untouched
+        assert preset.stt.language == "en-US"
+
+    def test_livekit_stt_language_default_unchanged_for_english(self):
+        adapter, _ = create_adapter(
+            provider="livekit",
+            tick_duration_ms=1000,
+            cascaded_config=CascadedConfig(),
+            language=None,
+        )
+        assert adapter.cascaded_config.stt.language == "en-US"


### PR DESCRIPTION
## Summary

PR3 of the multilingual extension: when the active language-pack persona is non-English, speech-to-text/transcription components use that language and the agent's system prompt gains the pack's `agent_language_clause`. English runs (`language=None`) are byte-identical to before.

### Changes

- **TranscriptionConfig language defaulting**
  - `runner/build.py build_voice_user`: after the per-task `SpeechEnvironment` is set, `transcription_config.language` defaults from `speech_environment.language` when not explicitly set (no-op for English, where language is None).
  - `agent/base/voice.py VoiceMixin.transcribe_voice`: same defaulting at the actual transcription call (covers VoiceSettings not built via `build_voice_user`), using a `model_copy` so the run-level config is never mutated. Note: user-side transcription is currently rejected by the user simulators' `validate_voice_settings`, so this wiring is forward-looking; it activates as soon as a transcribing consumer exists.

- **OpenAI realtime provider (v1 smoke provider)**: `voice/audio_native/openai/provider.py` had hardcoded `"language": "en"` in the input-audio transcription config. Now configurable: agent → `create_adapter(language=...)` → `DiscreteTimeOpenAIAdapter` → `OpenAIRealtimeProvider(language=...)`, defaulting to `"en"`.

- **LiveKit cascaded STT**: `create_adapter` overrides `cascaded_config.stt.language` with the run language when set (deep copy, so shared `CASCADED_CONFIGS` presets are never mutated). `DeepgramSTTConfig.language` keeps its `"en-US"` default.

- **Agent-side language clause**: `DiscreteTimeAudioNativeAgent` takes `language: Optional[str]`. `_build_system_prompt` appends `get_language_pack(language).agent_language_clause` when present. The clause is OFF when language is None, no pack exists, or the pack has no clause. This covers both the audio-native and the LiveKit cascaded paths — the cascaded provider receives this same agent system prompt via `adapter.connect`; there is no separate cascaded prompt assembly.

### Language threading to the agent

`build_agent` is called in `build_voice_orchestrator` *before* `build_voice_user`, so the sampled `SpeechEnvironment` does not exist yet. The language is therefore resolved from `config.user_persona_id` via `get_multilingual_persona` — the exact same lookup `SampledVoiceConfig.to_speech_environment` performs later for the user side, so agent and user always agree. `build_agent` gained an optional `language` kwarg forwarded to agent factories (all factories accept `**kwargs`; text path passes None and is unchanged).

### Deliberately left as-is

- **`src/tau2/voice/audio_native/deepgram/provider.py` does not exist** in this repo (stale plan reference). The actual hardcoded `"language": "en"` was in the OpenAI realtime provider, which is now configurable (see above). No Deepgram voice-agent provider exists to wire.
- Gemini/xAI/Nova/Qwen audio-native adapters: no transcription-language parameter plumbed (audio-native models don't take an STT language the way OpenAI realtime's input transcription does); `create_adapter(language=...)` is in place if/when they grow one.

## Test plan

- New `tests/test_multilingual/test_agent_language.py` (reuses the registry snapshot/restore fixture from `test_language_pack.py`):
  - agent clause appended iff a pack with a clause is active; OFF for language=None / unknown language / clause=None; English system prompt byte-identical
  - factory threads `language` through `create_discrete_time_audio_native_agent`
  - transcription language defaults from `SpeechEnvironment.language`; explicit language not overridden; English path passes the identical config object
  - OpenAI provider defaults to `"en"`, receives run language via `create_adapter`
  - LiveKit STT language overridden without mutating shared presets; `"en-US"` default unchanged for English
- `PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/test_multilingual/ tests/test_streaming/ tests/test_voice/ -q --ignore=tests/test_streaming/test_discrete_time_audio_native_agent.py`: **244 passed, 80 skipped, 2 xfailed**; 2 failures (`test_run_task(s)_base_audio_native`) are pre-existing missing-`OPENAI_API_KEY` live tests, verified failing identically on the base branch.
- `ruff check` / `ruff format` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)