### PR TITLE
feat: Hindi-localized airline task subset + airline_hi task set (PR6)

### DIFF
--- a/data/tau2/multilingual/hi/airline_tasks_hi.json
+++ b/data/tau2/multilingual/hi/airline_tasks_hi.json
@@ -1,0 +1,869 @@
+[
+  {
+    "id": "3_hi",
+    "description": {
+      "purpose": "यह जाँचना कि agent membership status verify करता है। User को लगता है कि वह Gold member है, जबकि असल में वह Silver है।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "अगर agent ने पहले से ऐसा न किया हो, तो ज़ोर देकर कहिए कि total संख्या आपको अंकों में (numeric form में) चाहिए, क्योंकि शब्दों के मुकाबले numbers आपको ज़्यादा साफ़ समझ आते हैं। अगर agent बार-बार कहे कि आप Silver member हैं, तो supervisor को transfer करने के लिए कहिए।",
+        "domain": "airline",
+        "reason_for_call": "आप जानना चाहती हैं कि आपकी upcoming flight पर reservation के हिसाब से total कितने suitcases ले जाने की allowance है।\n\nइस trip पर आपको काफ़ी सामान साथ ले जाना है। आप stressed हैं और आपके लिए बहुत ज़रूरी है कि जानकारी बिल्कुल सही हो।\n\nआपको पूरा यकीन है कि आप Gold member हैं।",
+        "known_info": "आप Anya Garcia हैं।\n\nआपका user id है: anya_garcia_5901.\n\nआपका confirmation number JMO1MG है।",
+        "unknown_info": "आपको नहीं पता कि upcoming flight का cabin कौन-सा है।"
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "3_0",
+          "name": "get_reservation_details",
+          "arguments": {
+            "reservation_id": "JMO1MG"
+          },
+          "info": null
+        },
+        {
+          "action_id": "3_1",
+          "name": "get_user_details",
+          "arguments": {
+            "user_id": "anya_garcia_5901"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [
+        "4"
+      ],
+      "nl_assertions": [
+        "Agent detects that user is actually a Silver member.",
+        "Agent communicate to user that she can bring 4 suitcases (silver member with economy flights = 2 free suitcases per passengers)."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "7_hi",
+    "description": {
+      "purpose": "बातचीत के बीच में user का नया intent introduce करने की testing।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "अगर agent कहे कि दोनों में से कोई भी reservation basic economy है, तो पहले उसे business में upgrade करवाइए और फिर reservation cancel करवाइए (payment के लिए 2135 पर ख़त्म होने वाला CC इस्तेमाल कीजिए)।\n\nआप बहुत persistent हैं, कम शब्दों में लेकिन साफ़ बात करते हैं।\n\nआपकी तबियत ख़राब है।\n\nबातचीत के बीच में, agent के तीसरे message के बाद, आप यह भी check करना चाहते हैं कि आपकी कोई और upcoming flights हैं या नहीं, और पूछिए कि उन flights की total cost कितनी है।",
+        "domain": "airline",
+        "reason_for_call": "आपको reservation IDs XEHM4B और 59XX6W के अंदर की अपनी upcoming flights cancel करनी हैं।",
+        "known_info": "आपका user id 'daiki_muller_1116' है।",
+        "unknown_info": null
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "7_0",
+          "name": "get_reservation_details",
+          "arguments": {
+            "reservation_id": "XEHM4B"
+          },
+          "info": null
+        },
+        {
+          "action_id": "7_1",
+          "name": "get_reservation_details",
+          "arguments": {
+            "reservation_id": "59XX6W"
+          },
+          "info": null
+        },
+        {
+          "action_id": "7_2",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "XEHM4B",
+            "cabin": "business",
+            "flights": [
+              {
+                "flight_number": "HAT005",
+                "date": "2024-05-20"
+              },
+              {
+                "flight_number": "HAT178",
+                "date": "2024-05-30"
+              }
+            ],
+            "payment_id": "credit_card_2408938"
+          },
+          "info": null
+        },
+        {
+          "action_id": "7_3",
+          "name": "cancel_reservation",
+          "arguments": {
+            "reservation_id": "XEHM4B"
+          },
+          "info": null
+        },
+        {
+          "action_id": "7_4",
+          "name": "cancel_reservation",
+          "arguments": {
+            "reservation_id": "59XX6W"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [
+        "1628"
+      ],
+      "nl_assertions": [
+        "Agent upgrades XEHM4B to business.",
+        "Agent cancels XEHM4B (as it is business flight).",
+        "Agent cancels 59XX6W (as it has insurance and the user is sick).",
+        "Agent communicates that total cost of upcoming flights is $1,628."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "8_hi",
+    "description": {
+      "purpose": "Extra passenger के साथ booking।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "आपको बिल्कुल वही flight book करनी है जो आपने हाल ही में May 10 को ORD से PHL ली थी।\n\nकोई दूसरी flight आपको नहीं चाहिए।\n\nआपके पास कोई baggage नहीं है, लेकिन आप एक extra passenger Kevin Smith को add करना चाहती हैं, जिनका DOB 2001-04-12 है।\n\nEconomy आपके लिए ठीक है और आपको aisle और middle seat साथ-साथ चाहिए। इस purchase के लिए आप ज़्यादा से ज़्यादा $500 तक देने को तैयार हैं।\n\nअगर और सिर्फ़ अगर price $500 से ऊपर हो, तो दूसरे passenger को drop कर दीजिए और सिर्फ़ अपने लिए book कीजिए।\n\nअगर agent पूछे, तो आपको सिर्फ़ one-way ticket चाहिए, roundtrip नहीं।\n\nआपको कोई travel insurance नहीं चाहिए।\n\nPayment आप सिर्फ़ अपने certificates में से किसी एक से करना चाहती हैं।\n\nकोई और mode of payment आपको मंज़ूर नहीं है।\n\nआपका birthday आपके user profile में है, इसलिए आप उसे खुद बताना नहीं चाहतीं।",
+        "domain": "airline",
+        "reason_for_call": "आपको May 26 को ORD से PHL की one-way flight book करनी है।",
+        "known_info": "आपका नाम Sophia Silva है।\n\nआपका user id sophia_silva_7557 है।",
+        "unknown_info": "आपको अपनी May 10 वाली ORD से PHL flight का flight number नहीं पता।"
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "8_0",
+          "name": "get_user_details",
+          "arguments": {
+            "user_id": "sophia_silva_7557"
+          },
+          "info": null
+        },
+        {
+          "action_id": "8_1",
+          "name": "get_reservation_details",
+          "arguments": {
+            "reservation_id": "WUNA5K"
+          },
+          "info": null
+        },
+        {
+          "action_id": "8_2",
+          "name": "search_direct_flight",
+          "arguments": {
+            "origin": "ORD",
+            "destination": "PHL",
+            "date": "2024-05-26"
+          },
+          "info": null
+        },
+        {
+          "action_id": "8_3",
+          "name": "book_reservation",
+          "arguments": {
+            "user_id": "sophia_silva_7557",
+            "origin": "ORD",
+            "destination": "PHL",
+            "flight_type": "one_way",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT271",
+                "date": "2024-05-26"
+              }
+            ],
+            "passengers": [
+              {
+                "first_name": "Sophia",
+                "last_name": "Silva",
+                "dob": "1957-10-05"
+              },
+              {
+                "first_name": "Kevin",
+                "last_name": "Smith",
+                "dob": "2001-04-12"
+              }
+            ],
+            "payment_methods": [
+              {
+                "payment_id": "certificate_8045380",
+                "amount": 348
+              }
+            ],
+            "total_baggages": 0,
+            "nonfree_baggages": 0,
+            "insurance": "no"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [],
+      "nl_assertions": [
+        "Agent get sophia_silva_7557 user details.",
+        "Agent identifies reservation id as WUNA5K.",
+        "Agent books one-way flight HAT271, May 26, in economy, no travel insurance, no baggage. Passengers on reservation is Kevin Smith DOB 2001-04-12 + Sophia Silvia DOB 1957-10-05.",
+        "Agent uses single certificate for payment."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "11_hi",
+    "description": {
+      "purpose": "यह test करना कि agent flight के passengers की संख्या change नहीं करता।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "बातचीत के पहले 2 rounds में आपको अपना reservation ID याद नहीं रहता, लेकिन फिर अचानक वह आपको अपने email में मिल जाता है: वह है GV1N64.\n\nआप impatient हैं और चाहते हैं कि change जल्दी से हो जाए।\n\nआप चाहते हैं कि पूरा amount original payment method में refund हो।\n\nअगर और सिर्फ़ अगर agent कहे कि सिर्फ़ एक passenger को remove नहीं किया जा सकता, तो आप सभी passengers को basic economy में downgrade करवाना चाहते हैं।\n\nपूछिए कि refund कितना बनेगा।\n\nयह ज़रूर कहिए कि refund original payment method में ही process किया जाए।",
+        "domain": "airline",
+        "reason_for_call": "आपको LAS से DEN की अपनी upcoming round trip flights से passenger Sophia को हटवाना है — departure May 19 की है, return May 20 की।",
+        "known_info": "आपका नाम James Patel है।\n\nआपका user id james_patel_9828 है।",
+        "unknown_info": null
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "11_0",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "GV1N64",
+            "cabin": "basic_economy",
+            "flights": [
+              {
+                "flight_number": "HAT003",
+                "date": "2024-05-19"
+              },
+              {
+                "flight_number": "HAT290",
+                "date": "2024-05-20"
+              }
+            ],
+            "payment_id": "gift_card_1642017"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [
+        "5244"
+      ],
+      "nl_assertions": [
+        "Check that agent does not remove passenger since changing the number of passengers is not allowed.",
+        "Check that agent downgrades all passengers to basic economy.",
+        "Check that agent refunds $5244 to original payment method."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "14_hi",
+    "description": {
+      "purpose": "Agent की यह capacity test करना कि वह dates, cities और cabin की constraints के साथ सबसे सस्ती flights ढूँढ सके।\n\nयह test करना कि agent इस rule को follow करता है कि payment में max 1 certificate use हो सकता है।\n\nपैसों के amounts पर reason करने की agents की capacity test करना।\n\nUser के पास multiple certificates, gift cards और 2 credit cards file पर हैं। Payment के लिए हम expect करते हैं कि agent समझे कि gift card + 1 certificate का use maximize करके credit card पर डाला जाने वाला amount कैसे minimize किया जाए।\n\nनई flight की total cost $2613 होगी। सही split यह है: पहले दोनों gift cards के $327, फिर $500 का certificate, और बाकी $1786 master card पर।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "आप अपने gift card balances का sum और certificate balances का sum जानना चाहते हैं।\n\nअगर agent आपको अलग-अलग balances बताए, तो आपको उनके sums चाहिए।\n\nफिर आप अपना recent reservation change करना चाहते हैं। Dates वही रखनी हैं, लेकिन आप उसे सबसे सस्ती business round trip में change करना चाहते हैं — direct flights हों या न हों, दोनों चलेगा।\n\nअगर agent कहे कि basic economy change नहीं हो सकती (अगर agent इसका ज़िक्र न करे तो आप भी मत कीजिए), तो आप चाहते हैं कि agent current reservation cancel करके नया book कर दे।\n\nPayment के लिए आप पहले certificates को जितना हो सके use करना चाहते हैं, फिर gift cards को जितना हो सके, और बाकी अपने master card से cover करना चाहते हैं।\n\nलेकिन आप जानना चाहते हैं कि आपके master card पर कितना charge होगा।\n\nआपको baggage या insurance नहीं चाहिए।\n\nआप master card का payment कम से कम रखना चाहते हैं, इसलिए नई flight तभी book करेंगे जब master card के charges $2000 से कम हों।\n\nआप शांत स्वभाव के हैं।",
+        "domain": "airline",
+        "reason_for_call": "आप जानना चाहते हैं कि आपके gift cards और certificates पर कितना balance है। फिर आप अपना upcoming reservation change करना चाहते हैं।",
+        "known_info": "आपका नाम Mohamed Silva है।\n\nआपका user id mohamed_silva_9265 है।",
+        "unknown_info": null
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "14_0",
+          "name": "cancel_reservation",
+          "arguments": {
+            "reservation_id": "K1NW8N"
+          },
+          "info": null
+        },
+        {
+          "action_id": "14_1",
+          "name": "book_reservation",
+          "arguments": {
+            "user_id": "mohamed_silva_9265",
+            "origin": "JFK",
+            "destination": "SFO",
+            "flight_type": "round_trip",
+            "cabin": "business",
+            "flights": [
+              {
+                "flight_number": "HAT023",
+                "date": "2024-05-26"
+              },
+              {
+                "flight_number": "HAT204",
+                "date": "2024-05-28"
+              },
+              {
+                "flight_number": "HAT100",
+                "date": "2024-05-28"
+              }
+            ],
+            "passengers": [
+              {
+                "first_name": "Mohamed",
+                "last_name": "Silva",
+                "dob": "1960-11-26"
+              },
+              {
+                "first_name": "Raj",
+                "last_name": "Sanchez",
+                "dob": "1986-09-12"
+              },
+              {
+                "first_name": "Liam",
+                "last_name": "Wilson",
+                "dob": "1980-03-27"
+              }
+            ],
+            "payment_methods": [
+              {
+                "payment_id": "certificate_3765853",
+                "amount": 500
+              },
+              {
+                "payment_id": "gift_card_8020792",
+                "amount": 198
+              },
+              {
+                "payment_id": "gift_card_6136092",
+                "amount": 129
+              },
+              {
+                "payment_id": "credit_card_2198526",
+                "amount": 1786
+              }
+            ],
+            "total_baggages": 0,
+            "nonfree_baggages": 0,
+            "insurance": "no"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [
+        "327",
+        "1000",
+        "1786"
+      ],
+      "nl_assertions": [
+        "Agent communicates that total gift card balance is $327.",
+        "Agent communicates that total certificate balance if $1000.",
+        "Agent should cancel reservation K1NW8N.",
+        "Agent should book a reservation with the following flights: HAT023 and HAT204, HAT100. No insurance. No baggage. Departure on 2024-05-26, return on 2024-05-28.",
+        "Agent communicated that the $1786 will be charged to the mastercard."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "18_hi",
+    "description": {
+      "purpose": "यह जाँचना कि agent सही flights को ठीक से downgrade कर पाता है और total savings calculate कर पाता है।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "हर reservation के लिए refund original payment में लेना आपके लिए ठीक है।\n\nआप जानना चाहते हैं कि total मिलाकर आपके कितने पैसे बचे, लेकिन यह जानकारी refunds process होने के बाद मिले तो भी चलेगा।\n\nआप emotional हैं और थोड़े गुस्से में भी, लेकिन agent के साथ cooperate करने को तैयार हैं।",
+        "domain": "airline",
+        "reason_for_call": "आपको अभी-अभी पैसों की कुछ दिक्कत आई है और आप अपनी सभी business flights को economy में downgrade करवाना चाहते हैं — flights या passengers में कोई बदलाव किए बिना।",
+        "known_info": "आपका नाम Omar Davis है।\n\nआपका user id omar_davis_3817 है।",
+        "unknown_info": "आपको याद नहीं कि आपने कौन-सा payment method use किया था।"
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "18_0",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "JG7FMM",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT028",
+                "date": "2024-05-21"
+              },
+              {
+                "flight_number": "HAT277",
+                "date": "2024-05-21"
+              }
+            ],
+            "payment_id": "credit_card_2929732"
+          },
+          "info": null
+        },
+        {
+          "action_id": "18_1",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "2FBBAH",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT080",
+                "date": "2024-05-28"
+              },
+              {
+                "flight_number": "HAT076",
+                "date": "2024-05-28"
+              },
+              {
+                "flight_number": "HAT255",
+                "date": "2024-05-30"
+              },
+              {
+                "flight_number": "HAT148",
+                "date": "2024-05-30"
+              }
+            ],
+            "payment_id": "gift_card_3481935"
+          },
+          "info": null
+        },
+        {
+          "action_id": "18_2",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "X7BYG1",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT232",
+                "date": "2024-05-24"
+              },
+              {
+                "flight_number": "HAT228",
+                "date": "2024-05-24"
+              }
+            ],
+            "payment_id": "credit_card_2929732"
+          },
+          "info": null
+        },
+        {
+          "action_id": "18_3",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "EQ1G6C",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT084",
+                "date": "2024-05-23"
+              },
+              {
+                "flight_number": "HAT175",
+                "date": "2024-05-23"
+              }
+            ],
+            "payment_id": "gift_card_6847880"
+          },
+          "info": null
+        },
+        {
+          "action_id": "18_4",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "BOH180",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT276",
+                "date": "2024-05-21"
+              },
+              {
+                "flight_number": "HAT279",
+                "date": "2024-05-22"
+              }
+            ],
+            "payment_id": "credit_card_9525117"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [
+        "23553"
+      ],
+      "nl_assertions": [
+        "Reservation JG7FMM is updated to economy.",
+        "Reservation 2FBBAH is updated to economy.",
+        "Reservation X7BYG1 is updated to economy. ",
+        "Reservation BOH180 is updated to economy. ",
+        "Reservation EQ1G6C is updated to economy.",
+        "Agent communicates that user will save $23553 in total."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "29_hi",
+    "description": {
+      "purpose": "Complex reservation change की testing।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "आपको सिर्फ़ ऐसी early flights चाहिए जो destination पर सुबह 7am से पहले पहुँच जाएँ।\n\nइन constraints के अंदर आपको सबसे सस्ते Economy (Basic Economy नहीं) options ही चाहिए — यह पक्का कर लीजिए।\n\nअगर agent पूछे, तो आपकी return flight 19 तारीख को निकलनी चाहिए।\n\nआप चाहते हैं कि agent ही आपके लिए figure out करे कि कौन-सी flights इन requirements में fit होती हैं।\n\nचूँकि इस trip के लिए आपने insurance ली थी, आप चाहते हैं कि change fees waive हो जाएँ (बातचीत की शुरुआत में ही अपनी health problem का ज़िक्र कीजिए)।\n\nअगर और सिर्फ़ अगर आपको prices बता दी गई हों और choose करने को कहा जाए, तो flights HAT169 और HAT033 चुनिए (अगर ये agent के दिए options में available हों)।\n\nआप 1 checked bag भी add करवाना चाहते हैं।",
+        "domain": "airline",
+        "reason_for_call": "आप अपनी upcoming roundtrip flights change करना चाहते हैं, जो अभी DTW से LGA और वापसी की हैं।\n\nआप उन्हें उन्हीं dates पर DTW से JFK और वापसी की nonstop flights में change करना चाहते हैं।",
+        "known_info": "आप Raj Brown हैं।\n\nआपका user id raj_brown_5782 है।\n\nआपकी DTW से LGA वाली trip का reservation ID VA5SGQ है।",
+        "unknown_info": null
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "29_0",
+          "name": "get_reservation_details",
+          "arguments": {
+            "reservation_id": "VA5SGQ"
+          },
+          "info": null
+        },
+        {
+          "action_id": "29_1",
+          "name": "cancel_reservation",
+          "arguments": {
+            "reservation_id": "VA5SGQ"
+          },
+          "info": null
+        },
+        {
+          "action_id": "29_2",
+          "name": "book_reservation",
+          "arguments": {
+            "user_id": "raj_brown_5782",
+            "origin": "DTW",
+            "destination": "JFK",
+            "flight_type": "round_trip",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT169",
+                "date": "2024-05-17"
+              },
+              {
+                "flight_number": "HAT033",
+                "date": "2024-05-19"
+              }
+            ],
+            "passengers": [
+              {
+                "first_name": "Raj",
+                "last_name": "Brown",
+                "dob": "1967-03-12"
+              }
+            ],
+            "payment_methods": [
+              {
+                "payment_id": "credit_card_8003957",
+                "amount": 282
+              }
+            ],
+            "total_baggages": 1,
+            "nonfree_baggages": 0,
+            "insurance": "no"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [],
+      "nl_assertions": [
+        "Agent informs the user that the reservation can't be changed and it can be cancelled instead.",
+        "Agent cancelled reservation VA5SGQ.",
+        "Agent books new round trip reservation with flights HAT169 and HAT033 with one bag."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "30_hi",
+    "description": {
+      "purpose": "यह जाँचना कि agent reservation से bags remove नहीं करता।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "आप LAS से IAH की अपनी upcoming one-stop flight को nonstop flight में change करवाना चाहते हैं।\n\nआप अपना checked bag भी remove करवाना चाहते हैं और उसके पैसे refund में चाहते हैं। अगर agent कहे कि bags remove नहीं हो सकते, तो मान लीजिए और आगे बढ़िए।\n\nPayment के लिए आप gift card use करना चाहते हैं (जब तक agent न पूछे, इसका ज़िक्र मत कीजिए)।",
+        "domain": "airline",
+        "reason_for_call": "आप LAS से IAH की अपनी upcoming one-stop flight (HAT266 — flight number सिर्फ़ तभी बताइए अगर agent पहले उसे आपके सामने रखे) में modifications करवाना चाहते हैं।",
+        "known_info": "आप James Taylor हैं।\n\nआपका user id james_taylor_7043 है।\n\nआपका reservation ID 1N99U6 है।",
+        "unknown_info": null
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "30_0",
+          "name": "get_reservation_details",
+          "arguments": {
+            "reservation_id": "1N99U6"
+          },
+          "info": null
+        },
+        {
+          "action_id": "30_1",
+          "name": "search_direct_flight",
+          "arguments": {
+            "origin": "LAS",
+            "destination": "IAH",
+            "date": "2024-05-19"
+          },
+          "info": null
+        },
+        {
+          "action_id": "30_2",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "1N99U6",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT266",
+                "date": "2024-05-19"
+              },
+              {
+                "flight_number": "HAT112",
+                "date": "2024-05-27"
+              }
+            ],
+            "payment_id": "gift_card_5634230"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [],
+      "nl_assertions": [
+        "Agent updates reservation to flights HAT266 and HAT112.",
+        "Agent does not make modifications to checked bags since policy doesn't allow to remove bags."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "33_hi",
+    "description": {
+      "purpose": "User flight की dates change करना चाहता है। फिर user business class में upgrade और luggage add करना चाहता है, लेकिन यह budget से ऊपर चला जाएगा। User सिर्फ़ एक leg को business में change करने की कोशिश करेगा, पर इसकी अनुमति नहीं है। आखिर में user बस और bags add कर लेगा।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "आपको सिर्फ़ ऐसी flights चाहिए जो सुबह 8am के बाद और रात 9pm से पहले depart करें।\n\nअगर agent changes के लिए कोई fee माँगे, तो बताइए कि आपके पास insurance है, इसलिए fees waive होनी चाहिए।\n\nआपने यह website पर पढ़ा है और चाहती हैं कि agent इस policy को honor करे।\n\nPersistent रहिए।\n\nFlights में modifications हो जाने के बाद ही, आप अचानक decide करती हैं कि आप अपना ticket business class में upgrade भी करवाना चाहती हैं और 2 checked bags भी add करवाना चाहती हैं।\n\nइसके लिए आप ज़्यादा से ज़्यादा $200 तक देने को तैयार हैं। अगर agent कहे कि इससे ज़्यादा लगेगा, तो कहिए कि return flight के लिए economy रखना आपको ठीक है।\n\nअगर और सिर्फ़ अगर वह भी possible न हो, तो दोनों legs economy में रखना आपको मंज़ूर है। लेकिन 2 bags आपको ज़रूर add करवाने हैं।\n\nइसका payment original form of payment से करना आपके लिए ठीक है।",
+        "domain": "airline",
+        "reason_for_call": "आप reservation HXDUBJ की अपनी upcoming outgoing flight को अगले दिन की nonstop flight में change करवाना चाहती हैं (यानी एक दिन delay करना है)।\n\nआप SFO से अपनी return flight भी एक दिन आगे खिसकाना चाहती हैं।",
+        "known_info": "आप Yara Garcia हैं।\nआपका user id yara_garcia_1905 है।",
+        "unknown_info": null
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "33_0",
+          "name": "get_reservation_details",
+          "arguments": {
+            "reservation_id": "HXDUBJ"
+          },
+          "info": null
+        },
+        {
+          "action_id": "33_1",
+          "name": "search_direct_flight",
+          "arguments": {
+            "origin": "IAH",
+            "destination": "SFO",
+            "date": "2024-05-19"
+          },
+          "info": null
+        },
+        {
+          "action_id": "33_2",
+          "name": "search_direct_flight",
+          "arguments": {
+            "origin": "SFO",
+            "destination": "IAH",
+            "date": "2024-05-21"
+          },
+          "info": null
+        },
+        {
+          "action_id": "33_3",
+          "name": "update_reservation_flights",
+          "arguments": {
+            "reservation_id": "HXDUBJ",
+            "cabin": "economy",
+            "flights": [
+              {
+                "flight_number": "HAT072",
+                "date": "2024-05-19"
+              },
+              {
+                "flight_number": "HAT278",
+                "date": "2024-05-23"
+              }
+            ],
+            "payment_id": "gift_card_6941833"
+          },
+          "info": null
+        },
+        {
+          "action_id": "33_4",
+          "name": "update_reservation_baggages",
+          "arguments": {
+            "reservation_id": "HXDUBJ",
+            "total_baggages": 2,
+            "nonfree_baggages": 0,
+            "payment_id": "gift_card_6941833"
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [],
+      "nl_assertions": [
+        "Agent updates reservation HXDUBJ to flights HAT072 on 2024-05-19 and HAT278 on 2024-05-23.",
+        "Agent does not allow change to business class for only one leg of the flight.",
+        "Agent add 2 free baggages to reservation HXDUBJ."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  },
+  {
+    "id": "40_hi",
+    "description": {
+      "purpose": "Flight change handle करने की agent की capacity की testing।",
+      "relevant_policies": null,
+      "notes": null
+    },
+    "user_scenario": {
+      "persona": null,
+      "instructions": {
+        "task_instructions": "आप passenger का नाम Mei Lee से बदलकर Mei Garcia करवाना चाहती हैं।\n\nInsistent रहिए और ज़रूरत से ज़्यादा जानकारी मत दीजिए।",
+        "domain": "airline",
+        "reason_for_call": "आपने यह flight book की थी और अब आप reservation पर passenger का नाम change करवाना चाहती हैं।",
+        "known_info": "आप Anya Garcia हैं।\n\nआपका user id anya_garcia_5901 है।\n\nआपका reservation id 3RK2T9 है।",
+        "unknown_info": null
+      }
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "40_0",
+          "name": "get_reservation_details",
+          "arguments": {
+            "reservation_id": "3RK2T9"
+          },
+          "info": null
+        },
+        {
+          "action_id": "40_1",
+          "name": "update_reservation_passengers",
+          "arguments": {
+            "reservation_id": "3RK2T9",
+            "passengers": [
+              {
+                "first_name": "Anya",
+                "last_name": "Garcia",
+                "dob": "1992-11-12"
+              },
+              {
+                "first_name": "Mei",
+                "last_name": "Garcia",
+                "dob": "1989-12-13"
+              }
+            ]
+          },
+          "info": null
+        }
+      ],
+      "communicate_info": [],
+      "nl_assertions": [
+        "Agent updates reservation 3RK2T9 to passenger Mei Garcia."
+      ],
+      "reward_basis": [
+        "DB",
+        "COMMUNICATE"
+      ]
+    },
+    "annotations": null
+  }
+]

--- a/src/tau2/domains/airline/environment.py
+++ b/src/tau2/domains/airline/environment.py
@@ -8,6 +8,7 @@ from tau2.domains.airline.tools import AirlineTools
 from tau2.domains.airline.utils import (
     AIRLINE_DB_PATH,
     AIRLINE_POLICY_PATH,
+    AIRLINE_TASK_SET_HI_PATH,
     AIRLINE_TASK_SET_PATH,
 )
 from tau2.environment.environment import Environment
@@ -43,6 +44,18 @@ def get_tasks(task_split_name: Optional[str] = "base") -> list[Task]:
             f"Invalid task split name: {task_split_name}. Valid splits are: {task_splits.keys()}"
         )
     return [task for task in tasks if task.id in task_splits[task_split_name]]
+
+
+def get_tasks_hi(task_split_name: Optional[str] = "base") -> list[Task]:
+    """Hindi-localized airline task subset (reuses the airline environment)."""
+    tasks = load_file(AIRLINE_TASK_SET_HI_PATH)
+    tasks = [Task.model_validate(task) for task in tasks]
+    if task_split_name in (None, "base"):
+        return tasks
+    raise ValueError(
+        f"Invalid task split name: {task_split_name}. "
+        "Task set 'airline_hi' only supports the 'base' split."
+    )
 
 
 def get_tasks_split() -> dict[str, list[str]]:

--- a/src/tau2/domains/airline/utils.py
+++ b/src/tau2/domains/airline/utils.py
@@ -4,3 +4,6 @@ AIRLINE_DATA_DIR = DATA_DIR / "tau2" / "domains" / "airline"
 AIRLINE_DB_PATH = AIRLINE_DATA_DIR / "db.json"
 AIRLINE_POLICY_PATH = AIRLINE_DATA_DIR / "policy.md"
 AIRLINE_TASK_SET_PATH = AIRLINE_DATA_DIR / "tasks.json"
+AIRLINE_TASK_SET_HI_PATH = (
+    DATA_DIR / "tau2" / "multilingual" / "hi" / "airline_tasks_hi.json"
+)

--- a/src/tau2/registry.py
+++ b/src/tau2/registry.py
@@ -20,6 +20,9 @@ from tau2.domains.airline.environment import (
 )
 from tau2.domains.airline.environment import get_tasks as airline_domain_get_tasks
 from tau2.domains.airline.environment import (
+    get_tasks_hi as airline_domain_get_tasks_hi,
+)
+from tau2.domains.airline.environment import (
     get_tasks_split as airline_domain_get_tasks_split,
 )
 from tau2.domains.banking_knowledge.environment import (
@@ -319,6 +322,7 @@ try:
         "airline",
         get_task_splits=airline_domain_get_tasks_split,
     )
+    registry.register_tasks(airline_domain_get_tasks_hi, "airline_hi")
 
     registry.register_domain(retail_domain_get_environment, "retail")
     registry.register_tasks(

--- a/tests/test_multilingual/test_hindi_tasks.py
+++ b/tests/test_multilingual/test_hindi_tasks.py
@@ -1,0 +1,134 @@
+# Copyright Sierra
+"""Tests for the Hindi-localized airline task subset (``airline_hi``).
+
+Localization invariants:
+- Exactly 10 tasks; each id is ``<source_id>_hi`` for an existing airline task.
+- ``evaluation_criteria`` is byte-for-byte identical to the English source.
+- Every concrete value (emails, user ids, reservation/flight codes, numbers)
+  appearing in the English instructions appears verbatim in the Hindi
+  instructions (values must stay in Latin script for tool lookups/ASR tests).
+- Prose is actually localized (contains Devanagari).
+"""
+
+import json
+import re
+
+import pytest
+
+from tau2.data_model.tasks import Task
+from tau2.domains.airline.utils import AIRLINE_TASK_SET_HI_PATH, AIRLINE_TASK_SET_PATH
+from tau2.registry import registry
+
+DEVANAGARI_RE = re.compile(r"[ऀ-ॿ]")
+
+# Concrete-value extractors for the English source instructions.
+VALUE_PATTERNS = [
+    # Emails (none in current selection, but guard against future edits).
+    re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+"),
+    # User ids, e.g. anya_garcia_5901 (also matches quoted daiki_muller_1116).
+    re.compile(r"\b[a-z]+_[a-z]+_\d+\b"),
+    # Uppercase alphanumeric codes containing a digit: reservation ids
+    # (JMO1MG, 1N99U6), flight numbers (HAT169), etc.
+    re.compile(r"\b(?=[A-Z0-9]*\d)[A-Z][A-Z0-9]{2,}\b|\b\d[A-Z0-9]{2,}\b"),
+    # Numbers: amounts, dates, last-4 digits, DOBs (each numeric run must
+    # survive verbatim, e.g. 2001-04-12 -> 2001, 04, 12).
+    re.compile(r"\d+"),
+]
+
+
+def _load_raw(path):
+    with open(path) as fp:
+        return json.load(fp)
+
+
+@pytest.fixture(scope="module")
+def hi_tasks_raw() -> list[dict]:
+    return _load_raw(AIRLINE_TASK_SET_HI_PATH)
+
+
+@pytest.fixture(scope="module")
+def source_tasks_raw() -> dict[str, dict]:
+    return {task["id"]: task for task in _load_raw(AIRLINE_TASK_SET_PATH)}
+
+
+def _instruction_text(task: dict) -> str:
+    instructions = task["user_scenario"]["instructions"]
+    fields = ["task_instructions", "reason_for_call", "known_info", "unknown_info"]
+    return "\n".join(instructions[field] or "" for field in fields)
+
+
+def test_airline_hi_task_set_loads_via_registry():
+    loader = registry.get_tasks_loader("airline_hi")
+    tasks = loader(task_split_name="base")
+    assert len(tasks) == 10
+    assert all(isinstance(task, Task) for task in tasks)
+    # Default split (None) behaves the same; unknown splits are rejected.
+    assert len(loader(task_split_name=None)) == 10
+    with pytest.raises(ValueError):
+        loader(task_split_name="full")
+
+
+def test_airline_hi_registered_in_task_sets():
+    assert "airline_hi" in registry.get_task_sets()
+
+
+def test_exactly_ten_tasks_with_hi_suffix_mapping_to_source(
+    hi_tasks_raw, source_tasks_raw
+):
+    assert len(hi_tasks_raw) == 10
+    ids = [task["id"] for task in hi_tasks_raw]
+    assert len(set(ids)) == 10
+    for task_id in ids:
+        assert task_id.endswith("_hi")
+        assert task_id.removesuffix("_hi") in source_tasks_raw
+
+
+def test_evaluation_criteria_identical_to_source(hi_tasks_raw, source_tasks_raw):
+    for task in hi_tasks_raw:
+        source = source_tasks_raw[task["id"].removesuffix("_hi")]
+        assert task["evaluation_criteria"] == source["evaluation_criteria"], (
+            f"evaluation_criteria modified for task {task['id']}"
+        )
+
+
+def test_concrete_values_preserved_verbatim(hi_tasks_raw, source_tasks_raw):
+    for task in hi_tasks_raw:
+        source = source_tasks_raw[task["id"].removesuffix("_hi")]
+        source_text = _instruction_text(source)
+        hi_text = _instruction_text(task)
+        values = set()
+        for pattern in VALUE_PATTERNS:
+            values.update(pattern.findall(source_text))
+        # Drop pure-English words accidentally caught by the code pattern
+        # (e.g. "DOB", "NOT"): keep only tokens containing a digit or '@'.
+        values = {v for v in values if any(ch.isdigit() for ch in v) or "@" in v}
+        for value in sorted(values):
+            assert value in hi_text, (
+                f"Value '{value}' from source task "
+                f"{source['id']} missing in Hindi instructions of {task['id']}"
+            )
+
+
+def test_tasks_validate_against_task_model(hi_tasks_raw):
+    for task in hi_tasks_raw:
+        Task.model_validate(task)
+
+
+def test_prose_contains_devanagari(hi_tasks_raw):
+    for task in hi_tasks_raw:
+        purpose = task["description"]["purpose"] or ""
+        assert DEVANAGARI_RE.search(purpose), (
+            f"description.purpose of {task['id']} not localized"
+        )
+        instructions = task["user_scenario"]["instructions"]
+        for field in ["task_instructions", "reason_for_call", "known_info"]:
+            text = instructions[field] or ""
+            assert DEVANAGARI_RE.search(text), f"{field} of {task['id']} not localized"
+
+
+def test_values_stay_latin_script(hi_tasks_raw):
+    """IDs/codes must not be transliterated into Devanagari digits/letters."""
+    for task in hi_tasks_raw:
+        text = _instruction_text(task)
+        # No Devanagari digits anywhere (०-९).
+        assert not re.search(r"[०-९]", text), f"Devanagari digits found in {task['id']}"


### PR DESCRIPTION
## Summary

PR6 of the multilingual extension: 10 airline tasks localized to Hindi/Hinglish in `data/tau2/multilingual/hi/airline_tasks_hi.json`, plus a registered `airline_hi` task set that reuses the airline environment (same db, tools, policy), so `tau2 run --domain airline --task-set-name airline_hi` works.

## Task selection (10 of 50)

Ranked all airline tasks by (a) `communicate_info` entries (numbers the agent must say back — where ASR/language genuinely bites), (b) spell-sensitive entities in the scenario (booking refs, user ids, names, DOBs, amounts, flight numbers), (c) task-type variety. No airline task contains emails, so refs/ids/numbers carry the spelling load.

| Task | Why |
|---|---|
| `3_hi` | communicate_info `4`; ref JMO1MG; membership dispute; user demands numbers in numeric form (info query) |
| `7_hi` | communicate_info `$1628`; two refs XEHM4B/59XX6W + CC last-4 2135; mid-call intent switch (upgrade→cancel) |
| `8_hi` | New booking with extra passenger Kevin Smith, DOB 2001-04-12 (spell-out-heavy); $500 budget gate; certificate-only payment |
| `11_hi` | communicate_info `$5244`; ref GV1N64 surfaces mid-conversation (realistic "found it in my email" moment); passenger-removal refusal → downgrade |
| `14_hi` | 3 communicate_info amounts ($327/$1000/$1786); gift-card/certificate/mastercard payment optimization |
| `18_hi` | communicate_info `$23553` (large number verbalization in Hindi is ASR-hard); bulk downgrade across 5 reservations |
| `29_hi` | Ref VA5SGQ + user must pick flight numbers HAT169/HAT033 by voice; time constraints (before 7am); insurance fee waiver; +1 bag |
| `30_hi` | Ref 1N99U6 + flight HAT266; baggage-removal refusal; gift-card payment held back until asked |
| `33_hi` | Ref HXDUBJ; date-shift change; insurance-waiver insistence; $200 budget; business-one-leg refusal; +2 bags |
| `40_hi` | Name change Mei Lee → Mei Garcia + ref 3RK2T9 — near-pure spelling/confirmation task |

Coverage: info queries, cancellations, flight changes, new booking, baggage add/remove, downgrades/upgrades, payment-split reasoning, name change. Tasks that were pure tool-call sequencing with no spoken-value pressure were deprioritized.

## Localization conventions

- **Mixed script**: Devanagari for Hindi prose; Latin script for ALL values (names, user ids, refs, flight numbers, dates, amounts) and for English aviation/tech vocabulary (flight, booking, reservation, economy, business, refund, checked bag, gift card, certificate, insurance, upgrade…). Natural spoken Hinglish, not shuddh Hindi.
- **Verbatim values**: every concrete value is character-for-character identical to the English source (NRI framing — US identities kept deliberately; changing them would break db.json tool lookups). `evaluation_criteria` is byte-identical to the source (deep-equality enforced by test).
- **Addressing convention (stated per spec)**: polite **-इए imperatives** for directives to the simulated user (कहिए, पूछिए, चुनिए, "...करवाइए") and **आप-form declaratives** for facts ("आपका user id X है", "आपको Y cancel करनी हैं"); never तुम. Gender-neutral constructions ("आपको …करना है") preferred; where the verb forces gender, it follows the named character (Anya/Sophia/Yara → feminine, James/Raj/Omar/Mohamed/Daiki → masculine).
- **Register-neutral**: no Hindu/Muslim lexical coding; heavy nuqta spellings avoided (गुस्सा, खराब, यकीन, दिक्कत) except the fully standard ज़/फ़ (ज़्यादा, सिर्फ़); code-switch density is a runtime persona knob, not baked in.
- `description.purpose` translated too (amounts kept verbatim); `domain`, `initial_state`, `annotations`, `evaluation_criteria` untouched.

## Passages flagged for native review

- **`7_hi`**: "2135 पर ख़त्म होने वाला CC" for "CC ending in 2135" — unsure if "…पर ख़त्म होने वाला" is the most natural rendering vs. "जिसके last four digits 2135 हैं"; also kept तबियत ख़राब with nuqta here, inconsistent with the no-nuqta convention elsewhere.
- **`11_hi`**: "refund कितना बनेगा" for "how much the refund would be" — colloquial "बनेगा" felt right but please confirm.
- **`14_hi` / `18_hi`**: "आप शांत स्वभाव के हैं" for "You are calm" and "थोड़े गुस्से में" for "a bit angry" — personality descriptions risk reading translationese.
- **`29_hi`**: "अगर और सिर्फ़ अगर" for "if and only if" (used in 8/11/29/33) — intentionally literal to preserve the conditional semantics for the simulator, but it is not idiomatic Hindi; happy to switch to "सिर्फ़ उसी हालत में जब…" if you prefer naturalness over literalness.
- **`33_hi`**: "एक दिन आगे खिसकाना" for "move back the return by one day" — direction of "आगे" (later vs earlier) is ambiguous in Hindi date talk; source means delay by one day, please sanity-check.
- **`3_hi`**: "supervisor को transfer करने के लिए कहिए" — arguably "supervisor से baat करवाने के लिए कहिए" is more ecological.

## Code changes (minimal, airline-owned files only)

- `src/tau2/domains/airline/utils.py`: `AIRLINE_TASK_SET_HI_PATH` constant.
- `src/tau2/domains/airline/environment.py`: `get_tasks_hi()` loader (accepts the default `"base"` split, rejects others).
- `src/tau2/registry.py`: one import block + `registry.register_tasks(airline_domain_get_tasks_hi, "airline_hi")`.

## Test plan

- New `tests/test_multilingual/test_hindi_tasks.py`: registry loads `airline_hi`; exactly 10 tasks; every id ends `_hi` and maps to an existing airline id; `evaluation_criteria` deep-equals the source; every concrete value (emails/user ids/codes/numbers extracted by regex from the English instructions) appears verbatim in the Hindi instructions; tasks validate against the `Task` pydantic model; prose contains Devanagari; no Devanagari digits.
- `PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/test_multilingual/ tests/test_tasks.py tests/test_domains/ -q`: all pass except pre-existing `tests/test_domains/test_banking_knowledge` failures caused by `rank_bm25` missing from the shared venv (fails identically with this change stashed; unrelated). Excluding that directory: **107 passed, 0 failed**.
- `ruff check` + `ruff format --check` clean on all changed files.
- Smoke: `registry.get_tasks_loader("airline_hi")(task_split_name="base")` returns the 10 validated tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)