### PR TITLE
feat: add Azure OpenAI support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ DEEPGRAM_API_KEY=<your_key_here>
 # Required for banking_knowledge qwen_embeddings* retrieval configs (via OpenRouter)
 OPENROUTER_API_KEY=<your_key_here>
 
+# Required for Azure OpenAI models (use model name format: azure/<deployment-name>)
+# AZURE_API_KEY=<your_key_here>
+# AZURE_API_BASE=<your_endpoint_here, e.g. https://your-resource.openai.azure.com>
+# AZURE_API_VERSION=<your_api_version_here, e.g. 2025-04-01-preview>
+
 # ── Voice Persona Overrides ────────────────────────────────────────────
 # The default voice IDs are Sierra-internal and won't work for external users.
 # Create your own voices in ElevenLabs and set the IDs here.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -24,7 +24,7 @@ tau2 run \
 | Option | Description |
 |--------|-------------|
 | `--domain`, `-d` | Domain to evaluate: `airline`, `retail`, `telecom`, `mock`, `banking_knowledge` |
-| `--agent-llm` | LLM model for the agent |
+| `--agent-llm` | LLM model for the agent (any [LiteLLM](https://docs.litellm.ai/docs/providers) model name, e.g. `gpt-4.1`, `claude-sonnet-4-5`, `azure/<deployment-name>`) |
 | `--user-llm` | LLM model for the user simulator |
 | `--agent-llm-args` | JSON dict of extra args for agent LLM (e.g. `'{"temperature": 0.5}'`) |
 | `--user-llm-args` | JSON dict of extra args for user LLM |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -69,6 +69,23 @@ Copy `.env.example` as `.env` and edit it to include your API keys:
 cp .env.example .env
 ```
 
+### Azure OpenAI
+
+To use models deployed on Azure OpenAI, add the following to your `.env` file:
+
+```bash
+AZURE_API_KEY=<your_azure_api_key>
+AZURE_API_BASE=https://<your-resource-name>.openai.azure.com
+AZURE_API_VERSION=2025-04-01-preview
+```
+
+Then prefix your deployment name with `azure/` wherever a model name is expected:
+
+```bash
+tau2 run --domain airline --agent-llm azure/<your-deployment-name> \
+  --user-llm azure/<your-deployment-name> --num-trials 1 --num-tasks 5
+```
+
 ### Voice API Keys (for voice-enabled features)
 
 If you're using voice features, add the following to your `.env` file:

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from tau2.data_model.message import (
@@ -10,10 +12,27 @@ from tau2.data_model.message import (
 from tau2.environment.tool import Tool, as_tool
 from tau2.utils.llm_utils import generate
 
+AZURE_TEST_DEPLOYMENT = os.environ.get("TAU2_TEST_AZURE_DEPLOYMENT")
 
-@pytest.fixture
-def model() -> str:
-    return "gpt-4o-mini"
+requires_azure = pytest.mark.skipif(
+    AZURE_TEST_DEPLOYMENT is None,
+    reason=(
+        "Azure OpenAI tests require TAU2_TEST_AZURE_DEPLOYMENT, "
+        "AZURE_API_KEY, AZURE_API_BASE, and AZURE_API_VERSION"
+    ),
+)
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("gpt-4o-mini", id="openai"),
+        pytest.param(
+            f"azure/{AZURE_TEST_DEPLOYMENT}", marks=requires_azure, id="azure"
+        ),
+    ]
+)
+def model(request: pytest.FixtureRequest) -> str:
+    return request.param
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Adds Azure OpenAI as a supported, documented provider. tau2-bench routes all LLM calls through LiteLLM, which can already talk to Azure OpenAI via `azure/<deployment-name>` model names — but this was undocumented, missing from `.env.example`, and untested. This PR wires it up end to end: setup docs, env var template, and test coverage.

## Changes Made
- `.env.example`: added `AZURE_API_KEY`, `AZURE_API_BASE`, `AZURE_API_VERSION` entries (commented, optional)
- `docs/getting-started.md`: new "Azure OpenAI" section covering the env vars and the `azure/<deployment-name>` model name format, with a `tau2 run` example
- `docs/cli-reference.md`: clarified that `--agent-llm` accepts any LiteLLM model name (e.g. `gpt-4.1`, `claude-sonnet-4-5`, `azure/<deployment-name>`)
- `tests/test_llm_utils.py`: parametrized the `model` fixture so `test_generate_no_tool_call` and `test_generate_tool_call` also run against an Azure OpenAI deployment. The Azure variants are gated behind a `TAU2_TEST_AZURE_DEPLOYMENT` env var and skip cleanly when it is not set, so CI is unaffected.

No new dependencies, no breaking changes, no changes to the core LLM path.

## Testing
- Verified against a live Azure OpenAI deployment (gpt-4o behind an Azure API Management gateway): text generation, tool-calling round trip, and cost/usage tracking all work through `tau2.utils.llm_utils.generate()`
- Full end-to-end benchmark run with both agent and user simulator on Azure: `tau2 run --domain mock --agent-llm azure/<deployment> --user-llm azure/<deployment>` completed with reward 1.0 and per-message costs tracked
- `pytest tests/test_llm_utils.py`: `[azure]` variants pass with credentials configured and skip without them
- `make test`: passes except for pre-existing failures caused by an out-of-quota OpenAI key in the local environment (`insufficient_quota` 429s) — unrelated to this change
- `make check-all` and the pre-commit hook pass

## Documentation
- `docs/getting-started.md` — Azure OpenAI setup section
- `docs/cli-reference.md` — model name format for `--agent-llm`

## Checklist
- [x] Tests pass (`make test`; failures limited to pre-existing local OpenAI quota issues)
- [x] Code follows style guidelines (`make check-all`)
- [x] Documentation updated
- [x] Breaking changes noted (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
