### PR TITLE
feat: add hospitality domain (hotel reservations, dual-control user tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Each domain specifies:
 - A set of **tasks** to evaluate the agent's performance
 - Optionally: a set of **user tools** for the user simulator
 
-**Available domains**: `mock` · `airline` · `retail` · `telecom` · `banking_knowledge`
+**Available domains**: `mock` · `airline` · `retail` · `telecom` · `banking_knowledge` · `hospitality`
 
 | Mode | Description |
 |------|-------------|

--- a/data/tau2/domains/hospitality/db.json
+++ b/data/tau2/domains/hospitality/db.json
@@ -1,0 +1,401 @@
+{
+  "hotel": {
+    "name": "Hotel Vltava",
+    "address": "Rasinovo nabrezi 28",
+    "city": "Prague",
+    "phone": "+420 222 555 100",
+    "email": "reception@hotelvltava.cz",
+    "current_time": "2025-06-15 10:00:00",
+    "check_in_time": "15:00",
+    "check_out_time": "11:00"
+  },
+  "room_types": {
+    "RT_STANDARD": {
+      "room_type_id": "RT_STANDARD",
+      "name": "Standard Queen",
+      "capacity": 2,
+      "count": 5,
+      "amenities": ["queen bed", "air conditioning", "wifi", "smart TV"],
+      "rates": {"RP_FLEX": 140, "RP_SAVER": 119, "RP_BB": 176}
+    },
+    "RT_TWIN": {
+      "room_type_id": "RT_TWIN",
+      "name": "Twin City View",
+      "capacity": 2,
+      "count": 4,
+      "amenities": ["two single beds", "city view", "air conditioning", "wifi"],
+      "rates": {"RP_FLEX": 150, "RP_SAVER": 128, "RP_BB": 186}
+    },
+    "RT_DELUXE": {
+      "room_type_id": "RT_DELUXE",
+      "name": "Deluxe King River View",
+      "capacity": 2,
+      "count": 3,
+      "amenities": ["king bed", "river view", "nespresso machine", "bathtub", "wifi"],
+      "rates": {"RP_FLEX": 190, "RP_SAVER": 161, "RP_BB": 226}
+    },
+    "RT_FAMILY": {
+      "room_type_id": "RT_FAMILY",
+      "name": "Family Suite",
+      "capacity": 4,
+      "count": 2,
+      "amenities": ["king bed plus sofa bed", "two separate rooms", "kitchenette", "wifi"],
+      "rates": {"RP_FLEX": 260, "RP_SAVER": 221, "RP_BB": 332}
+    },
+    "RT_EXEC": {
+      "room_type_id": "RT_EXEC",
+      "name": "Executive Suite",
+      "capacity": 2,
+      "count": 1,
+      "amenities": ["king bed", "river view terrace", "separate living room", "complimentary minibar", "wifi"],
+      "rates": {"RP_FLEX": 320, "RP_SAVER": 272, "RP_BB": 356}
+    }
+  },
+  "rate_plans": {
+    "RP_FLEX": {
+      "rate_plan_id": "RP_FLEX",
+      "name": "Flexible",
+      "refundable": true,
+      "date_changes_allowed": true,
+      "breakfast_included": false,
+      "description": "Free cancellation until 2 days before arrival; later cancellations are charged the first night. Date changes allowed, subject to availability."
+    },
+    "RP_SAVER": {
+      "rate_plan_id": "RP_SAVER",
+      "name": "Saver (non-refundable)",
+      "refundable": false,
+      "date_changes_allowed": false,
+      "breakfast_included": false,
+      "description": "Discounted prepaid rate. No refund on cancellation, no date changes. Room type upgrades allowed, subject to availability."
+    },
+    "RP_BB": {
+      "rate_plan_id": "RP_BB",
+      "name": "Flexible with Breakfast",
+      "refundable": true,
+      "date_changes_allowed": true,
+      "breakfast_included": true,
+      "description": "Flexible conditions plus breakfast buffet for all guests in the room."
+    }
+  },
+  "stay_packages": {
+    "PKG_ROMANCE": {
+      "package_id": "PKG_ROMANCE",
+      "name": "Romance by the River",
+      "room_type_id": "RT_DELUXE",
+      "nightly_rate": 240,
+      "min_nights": 2,
+      "inclusions": ["breakfast for two", "bottle of Moravian sparkling wine on arrival", "late check-out until 14:00"],
+      "description": "Deluxe King River View with breakfast, sparkling wine and a lazy morning. Flexible cancellation conditions apply."
+    },
+    "PKG_SPA": {
+      "package_id": "PKG_SPA",
+      "name": "Spa Recharge",
+      "room_type_id": "RT_STANDARD",
+      "nightly_rate": 210,
+      "min_nights": 2,
+      "inclusions": ["breakfast for two", "one spa day pass per guest", "bathrobe and slippers in room"],
+      "description": "Standard Queen with breakfast and full access to the wellness area. Flexible cancellation conditions apply."
+    },
+    "PKG_FAMILY": {
+      "package_id": "PKG_FAMILY",
+      "name": "Family Weekend",
+      "room_type_id": "RT_FAMILY",
+      "nightly_rate": 330,
+      "min_nights": 2,
+      "inclusions": ["breakfast for the whole family", "kids welcome pack", "late check-out until 14:00"],
+      "description": "Family Suite with breakfast for everyone and a kids welcome pack. Flexible cancellation conditions apply."
+    }
+  },
+  "extra_services": {
+    "SVC_BREAKFAST": {
+      "service_id": "SVC_BREAKFAST",
+      "name": "Breakfast buffet",
+      "unit_price": 18,
+      "pricing_unit": "per person per night",
+      "description": "Breakfast buffet in the riverside restaurant, 6:30-10:30."
+    },
+    "SVC_PARKING": {
+      "service_id": "SVC_PARKING",
+      "name": "Underground parking",
+      "unit_price": 24,
+      "pricing_unit": "per night",
+      "description": "Secure underground garage below the hotel. Maximum vehicle height 1.85 m."
+    },
+    "SVC_SPA": {
+      "service_id": "SVC_SPA",
+      "name": "Spa day pass",
+      "unit_price": 45,
+      "pricing_unit": "per person",
+      "description": "Full-day access to sauna, steam bath and relaxation pool."
+    },
+    "SVC_TRANSFER": {
+      "service_id": "SVC_TRANSFER",
+      "name": "Airport transfer",
+      "unit_price": 55,
+      "pricing_unit": "per trip",
+      "description": "Private car between Vaclav Havel Airport and the hotel, up to 3 passengers. Book at least 24 hours ahead."
+    },
+    "SVC_LATE_CHECKOUT": {
+      "service_id": "SVC_LATE_CHECKOUT",
+      "name": "Late check-out until 14:00",
+      "unit_price": 40,
+      "pricing_unit": "per stay",
+      "description": "Keep the room until 14:00 on departure day, subject to availability."
+    },
+    "SVC_CRIB": {
+      "service_id": "SVC_CRIB",
+      "name": "Baby crib",
+      "unit_price": 0,
+      "pricing_unit": "per stay",
+      "description": "Baby crib for children up to 3 years, free of charge."
+    },
+    "SVC_PET": {
+      "service_id": "SVC_PET",
+      "name": "Pet fee",
+      "unit_price": 32,
+      "pricing_unit": "per stay",
+      "description": "One dog up to 15 kg per room. Dogs are not allowed in the restaurant."
+    }
+  },
+  "guests": {
+    "G001": {"guest_id": "G001", "name": "Tomas Dvorak", "email": "tomas.dvorak@email.cz", "phone": "+420 777 210 334"},
+    "G002": {"guest_id": "G002", "name": "Anna Keller", "email": "anna.keller@webmail.de", "phone": "+49 171 555 0192"},
+    "G003": {"guest_id": "G003", "name": "James Whitfield", "email": "j.whitfield@btmail.co.uk", "phone": "+44 7700 900123"},
+    "G004": {"guest_id": "G004", "name": "Sofia Rossi", "email": "sofia.rossi@posta.it", "phone": "+39 333 1020 304"},
+    "G005": {"guest_id": "G005", "name": "Maya Patel", "email": "maya.patel@inbox.com", "phone": "+44 7911 123456"},
+    "G006": {"guest_id": "G006", "name": "Jonas Berg", "email": "jonas.berg@nordmail.no", "phone": "+47 901 23 456"},
+    "G007": {"guest_id": "G007", "name": "Claire Dubois", "email": "claire.dubois@courriel.fr", "phone": "+33 6 12 34 56 78"},
+    "G008": {"guest_id": "G008", "name": "Daniel Craft", "email": "daniel.craft@fastmail.com", "phone": "+1 415 555 0144"}
+  },
+  "reservations": {
+    "HV-1001": {
+      "reservation_id": "HV-1001",
+      "guest_id": "G001",
+      "room_type_id": "RT_STANDARD",
+      "rate_plan_id": "RP_FLEX",
+      "check_in": "2025-06-20",
+      "check_out": "2025-06-23",
+      "num_guests": 2,
+      "nightly_rate": 140,
+      "extras": [],
+      "total_amount": 420,
+      "status": "confirmed"
+    },
+    "HV-1002": {
+      "reservation_id": "HV-1002",
+      "guest_id": "G002",
+      "room_type_id": "RT_DELUXE",
+      "rate_plan_id": "RP_SAVER",
+      "check_in": "2025-06-22",
+      "check_out": "2025-06-24",
+      "num_guests": 2,
+      "nightly_rate": 161,
+      "extras": [],
+      "total_amount": 322,
+      "status": "confirmed"
+    },
+    "HV-1003": {
+      "reservation_id": "HV-1003",
+      "guest_id": "G003",
+      "room_type_id": "RT_STANDARD",
+      "rate_plan_id": "RP_FLEX",
+      "check_in": "2025-06-16",
+      "check_out": "2025-06-18",
+      "num_guests": 1,
+      "nightly_rate": 140,
+      "extras": [],
+      "total_amount": 280,
+      "status": "confirmed"
+    },
+    "HV-1004": {
+      "reservation_id": "HV-1004",
+      "guest_id": "G004",
+      "room_type_id": "RT_DELUXE",
+      "rate_plan_id": "RP_FLEX",
+      "check_in": "2025-06-25",
+      "check_out": "2025-06-28",
+      "num_guests": 2,
+      "nightly_rate": 190,
+      "extras": [],
+      "total_amount": 570,
+      "status": "confirmed"
+    },
+    "HV-1005": {
+      "reservation_id": "HV-1005",
+      "guest_id": "G005",
+      "room_type_id": "RT_STANDARD",
+      "rate_plan_id": "RP_BB",
+      "check_in": "2025-06-17",
+      "check_out": "2025-06-19",
+      "num_guests": 2,
+      "nightly_rate": 176,
+      "extras": [],
+      "total_amount": 352,
+      "status": "confirmed"
+    },
+    "HV-1006": {
+      "reservation_id": "HV-1006",
+      "guest_id": "G006",
+      "room_type_id": "RT_FAMILY",
+      "rate_plan_id": "RP_FLEX",
+      "check_in": "2025-06-20",
+      "check_out": "2025-06-23",
+      "num_guests": 4,
+      "nightly_rate": 260,
+      "extras": [],
+      "total_amount": 780,
+      "status": "confirmed"
+    },
+    "HV-1007": {
+      "reservation_id": "HV-1007",
+      "guest_id": "G007",
+      "room_type_id": "RT_FAMILY",
+      "rate_plan_id": "RP_FLEX",
+      "check_in": "2025-06-19",
+      "check_out": "2025-06-22",
+      "num_guests": 3,
+      "nightly_rate": 260,
+      "extras": [],
+      "total_amount": 780,
+      "status": "confirmed"
+    },
+    "HV-1008": {
+      "reservation_id": "HV-1008",
+      "guest_id": "G008",
+      "room_type_id": "RT_EXEC",
+      "rate_plan_id": "RP_FLEX",
+      "check_in": "2025-06-18",
+      "check_out": "2025-06-20",
+      "num_guests": 2,
+      "nightly_rate": 320,
+      "extras": [],
+      "total_amount": 640,
+      "status": "confirmed"
+    },
+    "HV-1009": {
+      "reservation_id": "HV-1009",
+      "guest_id": "G002",
+      "room_type_id": "RT_STANDARD",
+      "rate_plan_id": "RP_FLEX",
+      "check_in": "2025-05-10",
+      "check_out": "2025-05-12",
+      "num_guests": 2,
+      "nightly_rate": 140,
+      "extras": [],
+      "total_amount": 280,
+      "status": "checked_out"
+    },
+    "HV-1010": {
+      "reservation_id": "HV-1010",
+      "guest_id": "G003",
+      "room_type_id": "RT_TWIN",
+      "rate_plan_id": "RP_FLEX",
+      "check_in": "2025-07-02",
+      "check_out": "2025-07-04",
+      "num_guests": 2,
+      "nightly_rate": 150,
+      "extras": [],
+      "total_amount": 300,
+      "status": "cancelled",
+      "refund_amount": 300
+    }
+  },
+  "knowledge_base": {
+    "KB_CHECKIN": {
+      "article_id": "KB_CHECKIN",
+      "title": "Check-in and check-out times",
+      "category": "stay",
+      "content": "Check-in from 15:00, check-out until 11:00. Early arrival luggage storage is free. Late check-out until 14:00 can be purchased for 40 EUR per stay, subject to availability. Online check-in opens 2 days before arrival on the hotel website."
+    },
+    "KB_BREAKFAST": {
+      "article_id": "KB_BREAKFAST",
+      "title": "Breakfast",
+      "category": "dining",
+      "content": "Breakfast buffet is served in the riverside restaurant daily 6:30-10:30. Price is 18 EUR per person per night if not included in the rate. Rates with breakfast and all stay packages include it."
+    },
+    "KB_PARKING": {
+      "article_id": "KB_PARKING",
+      "title": "Parking",
+      "category": "facilities",
+      "content": "Underground garage below the hotel, 24 EUR per night. Maximum vehicle height is 1.85 m. Vehicles above 1.85 m can use the public garage at Palackeho namesti, 5 minutes away, not operated by the hotel. Garage spots cannot be guaranteed without a reservation."
+    },
+    "KB_PETS": {
+      "article_id": "KB_PETS",
+      "title": "Pet policy",
+      "category": "stay",
+      "content": "One dog up to 15 kg per room is welcome for a fee of 32 EUR per stay. Dogs must be leashed in public areas and are not allowed in the restaurant or spa. Other animals are not accepted."
+    },
+    "KB_SPA": {
+      "article_id": "KB_SPA",
+      "title": "Spa and wellness",
+      "category": "facilities",
+      "content": "Sauna, steam bath and relaxation pool, open daily 9:00-21:00. Day pass 45 EUR per person. Spa Recharge package guests have access included. Children under 15 are not permitted in the spa."
+    },
+    "KB_POOL_GYM": {
+      "article_id": "KB_POOL_GYM",
+      "title": "Pool and fitness",
+      "category": "facilities",
+      "content": "The indoor pool and the gym are open daily 6:00-22:00 and are free for all hotel guests. Towels are provided at the pool desk."
+    },
+    "KB_WIFI": {
+      "article_id": "KB_WIFI",
+      "title": "Wifi",
+      "category": "facilities",
+      "content": "Wifi is free across the hotel. Connect to the VLTAVA-GUEST network; the access code is your room number and last name, provided at check-in."
+    },
+    "KB_TRANSFER": {
+      "article_id": "KB_TRANSFER",
+      "title": "Airport transfer",
+      "category": "transport",
+      "content": "Private transfer between Vaclav Havel Airport and the hotel costs 55 EUR per trip for up to 3 passengers, around 40 minutes depending on traffic. Book at least 24 hours ahead through reception."
+    },
+    "KB_LOCATION": {
+      "article_id": "KB_LOCATION",
+      "title": "Location and getting here",
+      "category": "transport",
+      "content": "Hotel Vltava is at Rasinovo nabrezi 28, Prague 2, on the right bank of the river, 10 minutes walk from the Dancing House. Tram 17 stops 100 m from the entrance. From the main railway station take metro line C to Vysehrad or a taxi (about 10 minutes)."
+    },
+    "KB_CANCELLATION": {
+      "article_id": "KB_CANCELLATION",
+      "title": "Cancellation conditions",
+      "category": "booking",
+      "content": "Flexible rates and stay packages: free cancellation until 2 days before arrival; after that the first night is charged and the rest refunded. Saver rates are non-refundable and cannot be cancelled for a refund or moved to other dates. No-shows are charged like late cancellations."
+    },
+    "KB_PAYMENT": {
+      "article_id": "KB_PAYMENT",
+      "title": "Payment and invoicing",
+      "category": "booking",
+      "content": "We accept all major cards and cash (CZK and EUR) at the hotel. A card is required to guarantee the booking; Saver rates are charged at booking, other rates at check-out. Company invoices are available at check-out, bring your company registration number."
+    },
+    "KB_CITY_TAX": {
+      "article_id": "KB_CITY_TAX",
+      "title": "City tax",
+      "category": "booking",
+      "content": "Prague city fee is already included in all quoted prices. No extra local taxes are charged on departure."
+    },
+    "KB_CHILDREN": {
+      "article_id": "KB_CHILDREN",
+      "title": "Children and cribs",
+      "category": "stay",
+      "content": "Children count toward the room capacity regardless of age. A baby crib for children up to 3 years is available free of charge, one per room, on request. Children under 15 are not permitted in the spa."
+    },
+    "KB_ACCESSIBILITY": {
+      "article_id": "KB_ACCESSIBILITY",
+      "title": "Accessibility",
+      "category": "facilities",
+      "content": "The hotel has an elevator to all floors and two wheelchair-accessible Standard Queen rooms with roll-in showers. Mention accessibility needs when booking so we can assign the right room."
+    },
+    "KB_SMOKING": {
+      "article_id": "KB_SMOKING",
+      "title": "Smoking policy",
+      "category": "stay",
+      "content": "Hotel Vltava is entirely non-smoking, including balconies and terraces. Smoking in a room results in a 200 EUR cleaning fee. The nearest designated smoking area is outside the main entrance."
+    },
+    "KB_GROUPS": {
+      "article_id": "KB_GROUPS",
+      "title": "Group bookings and events",
+      "category": "booking",
+      "content": "Bookings of more than 4 rooms, conferences and private events are handled by the events team, not by reception. Contact events@hotelvltava.cz; reception can transfer your request to a human colleague from the events team."
+    }
+  }
+}

--- a/data/tau2/domains/hospitality/policy.md
+++ b/data/tau2/domains/hospitality/policy.md
@@ -1,0 +1,64 @@
+# Hotel Vltava Reservations Agent Policy
+
+The current time is 2025-06-15 10:00:00 CET.
+
+You are the reservations agent of Hotel Vltava, a riverside hotel in Prague. You help guests book, modify and cancel reservations, add extra services, update their profile, and answer questions about the hotel.
+
+You must follow this policy exactly. Do not invent information, prices or conditions. Anything factual about the hotel that is not in this policy or in your tools must come from the knowledge base tool.
+
+## General rules
+
+- Only help with matters related to Hotel Vltava and its reservations.
+- Make at most one tool call at a time. Do not call a tool and reply to the guest in the same turn.
+- Always confirm price and conditions with the guest before creating, modifying or cancelling anything.
+- Never reveal information about a guest or reservation other than the verified guest's own.
+- All prices are in EUR and include the Prague city fee. Payment is handled at the hotel; you never take payment details.
+
+## Identity verification
+
+Before reading or changing anything on a reservation or guest profile, verify the guest:
+
+- For an existing reservation: the guest must provide the confirmation number, and the name they give must match the name on the reservation. If they do not know their confirmation number, ask them to check their booking confirmation email; it contains the number. Do not read out reservation details without it.
+- For profile updates and new bookings of an existing guest: look up the profile by email with `find_guest`, or use a verified reservation's guest.
+- A new guest needs a profile (full name, email, phone) before their first reservation can be created.
+
+## Booking
+
+1. Get dates, number of guests and preferences, then check availability with `get_room_offers` (and `get_stay_package_offers` if the guest is interested in packages).
+2. A room only fits a party if the party size is within the room capacity. Children count toward capacity regardless of age. One reservation covers one room; book multiple reservations for multiple rooms. A reservation is held by a single guest profile (the person booking); accompanying guests do not need profiles.
+3. Quote the total price for the stay, name the rate plan, and state its cancellation conditions before booking.
+4. Rate plans:
+   - Flexible: free cancellation until 2 days before arrival, date changes allowed.
+   - Saver: discounted and prepaid; non-refundable, no date changes. Make sure the guest explicitly accepts these conditions before booking a Saver rate.
+   - Flexible with Breakfast: Flexible conditions plus breakfast for all guests in the room.
+5. Stay packages are tied to a fixed room type, have a minimum stay, and follow Flexible cancellation conditions.
+6. Bookings of more than 4 rooms are group bookings and are handled by the events team: transfer to a human agent instead of booking.
+
+## Cancellations
+
+- Only confirmed reservations can be cancelled. Use `cancel_reservation`; it computes the refund.
+- Refund rules:
+  - Saver rates: no refund, regardless of timing.
+  - Flexible rates, breakfast rates and packages: full refund until 2 days before arrival; after that, the first night is charged and the rest refunded.
+- Always tell the guest the exact refund amount (or that there is none) and get their explicit confirmation before cancelling.
+- These rules have no exceptions. Do not promise refunds outside them, regardless of the reason for the cancellation.
+
+## Modifications
+
+- Use `modify_reservation`. Supported changes: stay dates, room type, number of guests. Confirm the new total with the guest before modifying.
+- Date changes are not allowed on Saver rates. Do not work around this by cancelling and rebooking; if the guest insists, explain that the only options are keeping the dates or cancelling without a refund.
+- Room type changes keep the rate plan; the price is recomputed from the new room's rates. Not possible on package bookings.
+- All changes are subject to availability and room capacity.
+
+## Extra services
+
+- Use `book_extra_services` on a confirmed reservation. Check the pricing unit of each service and compute the quantity accordingly (e.g. breakfast for 2 guests for 3 nights is quantity 6; parking for 3 nights is quantity 3).
+- Quote the price of the extras and the new reservation total to the guest.
+
+## Knowledge questions
+
+- Answer questions about the hotel (breakfast, parking, pets, spa, transfers, payment, location, ...) only from the knowledge base tool. If the knowledge base does not cover it, say so; do not guess.
+
+## Escalation
+
+Transfer to a human agent only if the guest explicitly asks for a human, the request requires the events team (group bookings of more than 4 rooms, conferences, private events), or the request cannot be solved with your tools and this policy (e.g. billing disputes, complaints about a past stay).

--- a/data/tau2/domains/hospitality/policy.md
+++ b/data/tau2/domains/hospitality/policy.md
@@ -54,6 +54,7 @@ Before reading or changing anything on a reservation or guest profile, verify th
 
 - Use `book_extra_services` on a confirmed reservation. Check the pricing unit of each service and compute the quantity accordingly (e.g. breakfast for 2 guests for 3 nights is quantity 6; parking for 3 nights is quantity 3).
 - Quote the price of the extras and the new reservation total to the guest.
+- Never book an extra that duplicates something already included in the guest's rate plan or package (e.g. breakfast on a breakfast-included rate). Tell the guest it is already included instead.
 
 ## Knowledge questions
 

--- a/data/tau2/domains/hospitality/split_tasks.json
+++ b/data/tau2/domains/hospitality/split_tasks.json
@@ -1,0 +1,19 @@
+{
+  "base": [
+    "booking_new_guest_standard",
+    "booking_family_cheapest",
+    "booking_romance_package",
+    "cancel_free_window",
+    "cancel_non_refundable",
+    "cancel_late_fee",
+    "modify_dates_refused_saver",
+    "modify_dates_flex",
+    "modify_upgrade_executive",
+    "extras_parking_transfer",
+    "profile_update_contact",
+    "kb_pet_parking",
+    "dual_lost_confirmation",
+    "dual_online_checkin",
+    "escalate_group_booking"
+  ]
+}

--- a/data/tau2/domains/hospitality/split_tasks.json
+++ b/data/tau2/domains/hospitality/split_tasks.json
@@ -14,6 +14,16 @@
     "kb_pet_parking",
     "dual_lost_confirmation",
     "dual_online_checkin",
-    "escalate_group_booking"
+    "escalate_group_booking",
+    "hard_cancel_rebook_package",
+    "hard_cancel_cutoff_boundary",
+    "hard_extras_quantities",
+    "hard_two_rooms_group",
+    "hard_checkin_window_closed",
+    "hard_distractor_reservation",
+    "hard_breakfast_already_included",
+    "hard_wrong_belief_keep_booking",
+    "hard_multi_operation_visit",
+    "hard_cheapest_combo_quote"
   ]
 }

--- a/data/tau2/domains/hospitality/tasks.json
+++ b/data/tau2/domains/hospitality/tasks.json
@@ -396,7 +396,7 @@
     },
     "user_scenario": {
       "persona": "Maya Patel, a doctor from Leeds. Hates queues at reception desks.",
-      "instructions": "You have a reservation HV-1005, name Maya Patel, arriving June 17. Two things: 1) You want to skip the queue at reception - ask if you can check in online somehow. If the agent explains how, complete the online check-in yourself on the website; you plan to arrive around 16:00. 2) You want an airport pickup when you land on June 17, one way only. Ask for the price of the transfer and the new total of your booking. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+      "instructions": "You have a reservation HV-1005, name Maya Patel, arriving June 17. Two things: 1) You want to skip the queue at reception - ask if you can check in online somehow. If the agent explains how, complete the online check-in yourself on the website; you plan to arrive around 16:00. 2) You want an airport pickup when you land on June 17, one way only. Ask for the price of the transfer and the new total of your booking. You do not have your flight details handy and you will not get them during this call - if asked for a flight number or similar, say that arriving around 16:00 on June 17 is all you can give, and insist the transfer is booked now anyway. Do not end the conversation until the transfer is actually added to your booking. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
     },
     "initial_state": null,
     "evaluation_criteria": {
@@ -454,6 +454,339 @@
       ],
       "communicate_info": ["events team"],
       "reward_basis": ["DB", "ACTION", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "hard_cancel_rebook_package",
+    "description": {
+      "purpose": "Multi-step chain: the guest's plans changed in a way no single modification covers (regular booking -> package), so the agent must cancel and rebook. Partial execution fails the DB check.",
+      "relevant_policies": "Cancellation refund rules (full refund in free window). Packages cannot be reached via modify_reservation - rebooking is the only path.",
+      "notes": "Cancel HV-1004 (refund 570, June 25 is well inside the free window), then book Romance by the River June 26-28 for 2: 2 x 240 = 480. Both amounts must be communicated."
+    },
+    "user_scenario": {
+      "persona": "Sofia Rossi, an architect from Milan. Her Prague trip just turned from a work stay into a short anniversary trip with her husband.",
+      "instructions": "Your plans changed: your work stay (confirmation HV-1004, name Sofia Rossi, June 25-28) is now a 2-night anniversary trip with your husband, June 26 to June 28. You want to scrap the current booking and instead have the hotel's romantic package - the one with the sparkling wine - for those two nights. Before agreeing, you want to know exactly how much you get back for the cancelled booking and what the new package stay costs. If the agent suggests just changing the dates of your current booking instead, say no - you specifically want the package. In the unlikely case the package is not available for your dates, have the agent cancel the current booking anyway and book nothing else. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "cancel_old",
+          "requestor": "assistant",
+          "name": "cancel_reservation",
+          "arguments": {"reservation_id": "HV-1004"}
+        },
+        {
+          "action_id": "book_package",
+          "requestor": "assistant",
+          "name": "create_reservation",
+          "arguments": {
+            "guest_id": "G004",
+            "check_in": "2025-06-26",
+            "check_out": "2025-06-28",
+            "num_guests": 2,
+            "package_id": "PKG_ROMANCE"
+          }
+        }
+      ],
+      "communicate_info": ["570", "480"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "hard_cancel_cutoff_boundary",
+    "description": {
+      "purpose": "Date boundary: check-in is exactly 2 days away, which is still INSIDE the free cancellation window ('until 2 days before arrival'). The trap is treating it as a late cancellation and quoting a first-night charge.",
+      "relevant_policies": "Flexible/breakfast rates: full refund until 2 days before arrival. Tell the guest the exact refund before cancelling.",
+      "notes": "HV-1005 checks in June 17, today is June 15: days until check-in = 2, so the refund is the full 352 EUR, not 352 - 176."
+    },
+    "user_scenario": {
+      "persona": "Maya Patel, a doctor from Leeds. A colleague dropped out of the conference rota, so her trip is off.",
+      "instructions": "You need to cancel your reservation HV-1005, name Maya Patel, arriving June 17. You realize it is short notice and you half expect to lose some money - ask explicitly how much you will get back before you decide. Whatever the answer is, go ahead and cancel. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "cancel",
+          "requestor": "assistant",
+          "name": "cancel_reservation",
+          "arguments": {"reservation_id": "HV-1005"}
+        }
+      ],
+      "communicate_info": ["352"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "hard_extras_quantities",
+    "description": {
+      "purpose": "Pricing-unit arithmetic across three extras with different units: breakfast (per person per night), spa pass (per person), parking (per night). Wrong quantities change the DB state and the total.",
+      "relevant_policies": "Extras: check the pricing unit of each service and compute the quantity accordingly. Quote the new total.",
+      "notes": "HV-1006: 4 guests, 3 nights, total 780. Breakfast qty 12 (216 EUR), spa passes qty 2 (90 EUR), parking qty 3 (72 EUR). New total 1158 EUR. Extras lines are order-insensitive (merged and sorted by service ID)."
+    },
+    "user_scenario": {
+      "persona": "Jonas Berg, an operations lead from Oslo, coming with his wife and two kids (ages 8 and 11).",
+      "instructions": "You have a family reservation HV-1006, name Jonas Berg, June 20 to 23, 4 people (you, your wife, kids aged 8 and 11). You want to add three things: breakfast for the whole family for the whole stay, parking for the entire stay, and spa passes for you and your wife (you already know the kids are not allowed in the spa). Ask for the new total of the booking. Do not end the conversation until the agent has confirmed all three services are actually added to the reservation - a price quote alone is not enough. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "breakfast",
+          "requestor": "assistant",
+          "name": "book_extra_services",
+          "arguments": {
+            "reservation_id": "HV-1006",
+            "service_id": "SVC_BREAKFAST",
+            "quantity": 12
+          }
+        },
+        {
+          "action_id": "spa",
+          "requestor": "assistant",
+          "name": "book_extra_services",
+          "arguments": {
+            "reservation_id": "HV-1006",
+            "service_id": "SVC_SPA",
+            "quantity": 2
+          }
+        },
+        {
+          "action_id": "parking",
+          "requestor": "assistant",
+          "name": "book_extra_services",
+          "arguments": {
+            "reservation_id": "HV-1006",
+            "service_id": "SVC_PARKING",
+            "quantity": 3
+          }
+        }
+      ],
+      "communicate_info": ["1158"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "hard_two_rooms_group",
+    "description": {
+      "purpose": "Multi-room booking within the agent's mandate (4 rooms or fewer): four adults who each want their own bed need two Twin rooms, i.e. two separate reservations. The two reservations are identical, so creation order cannot affect the DB state.",
+      "relevant_policies": "One reservation covers one room; book multiple reservations for multiple rooms. Bookings of more than 4 rooms go to the events team - 2 rooms do not.",
+      "notes": "Two Twin City View, Flexible, June 24-26: 2 x (2 x 150) = 600 EUR total. Standard Queen is cheaper but has one queen bed - the separate-beds requirement forces Twin."
+    },
+    "user_scenario": {
+      "persona": "James Whitfield, a barrister from London, organizing a golf weekend with three friends.",
+      "instructions": "You want rooms for 4 adults, June 24 to June 26 (2 nights). Nobody wants to share a bed: everyone needs their own bed, so rooms with two separate beds for two people each are what you are after. You want refundable rates - no non-refundable deals - and no breakfast, you will be on the golf course before the restaurant even opens. Book everything under your own profile; you have stayed before, email j.whitfield@btmail.co.uk, name James Whitfield. Ask for the combined total for both rooms and confirm once you hear it. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "room_one",
+          "requestor": "assistant",
+          "name": "create_reservation",
+          "arguments": {
+            "guest_id": "G003",
+            "check_in": "2025-06-24",
+            "check_out": "2025-06-26",
+            "num_guests": 2,
+            "room_type_id": "RT_TWIN",
+            "rate_plan_id": "RP_FLEX"
+          }
+        },
+        {
+          "action_id": "room_two",
+          "requestor": "assistant",
+          "name": "create_reservation",
+          "arguments": {
+            "guest_id": "G003",
+            "check_in": "2025-06-24",
+            "check_out": "2025-06-26",
+            "num_guests": 2,
+            "room_type_id": "RT_TWIN",
+            "rate_plan_id": "RP_FLEX"
+          }
+        }
+      ],
+      "communicate_info": ["600"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "hard_checkin_window_closed",
+    "description": {
+      "purpose": "Negative dual-control task: the guest wants online check-in 4 days before arrival, but the window opens 2 days before. The correct outcome is NO state change - the agent explains the window, and any check-in attempt fails at the tool level.",
+      "relevant_policies": "Online check-in opens 2 days before arrival (knowledge base / user tool behavior). No exceptions.",
+      "notes": "HV-1007 checks in June 19; today is June 15, so the window opens June 17. Reward is DB-based with no expected actions: the seeded state must be untouched."
+    },
+    "user_scenario": {
+      "persona": "Claire Dubois, a vet from Lyon, killing time at an airport gate and trying to be efficient.",
+      "instructions": "You arrive on June 19, reservation HV-1007, name Claire Dubois. You hate queues and want to do the online check-in right now from your phone. Ask the agent to sort it out or tell you how. If you are told how to do it yourself, try it. If your attempt gives you an error saying check-in is not open yet, tell the agent what the error said. Once it is clear online check-in is not possible yet, ask when exactly it becomes available, accept the answer, and end the conversation - do not ask for anything else. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [],
+      "communicate_info": null,
+      "reward_basis": ["DB"]
+    },
+    "user_tools": ["submit_online_checkin"]
+  },
+  {
+    "id": "hard_distractor_reservation",
+    "description": {
+      "purpose": "Distractor disambiguation plus quantity arithmetic: the guest quotes her OLD confirmation number (a checked-out stay). The agent must catch that, get her to find the current booking via her confirmation email, and add breakfast with the right quantity.",
+      "relevant_policies": "Reservation details require the confirmation number; extras only on confirmed reservations (the tool rejects the checked-out one). Breakfast is per person per night.",
+      "notes": "Anna has HV-1009 (checked out, May) and HV-1002 (confirmed, June 22-24, 2 guests, total 322). Breakfast qty 4 = 72 EUR, new total 394 EUR."
+    },
+    "user_scenario": {
+      "persona": "Anna Keller, a consultant from Munich. Books a lot of hotels and mixes up her confirmation emails regularly.",
+      "instructions": "You want breakfast added to your upcoming stay at the hotel, for both you and your colleague, for the whole stay. You are sure your confirmation number is HV-1009 - give that one first (it is actually from your previous stay in May, but you do not know that). Your name is Anna Keller, your email is anna.keller@webmail.de. If the agent tells you that number belongs to a past stay, or seems unable to proceed with it, check your booking confirmation emails to find the current one and give the agent the right number. Ask for the new total after the breakfast is added. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "user_checks_email",
+          "requestor": "user",
+          "name": "check_booking_confirmation_email",
+          "arguments": {"email": "anna.keller@webmail.de"},
+          "compare_args": ["email"]
+        },
+        {
+          "action_id": "breakfast",
+          "requestor": "assistant",
+          "name": "book_extra_services",
+          "arguments": {
+            "reservation_id": "HV-1002",
+            "service_id": "SVC_BREAKFAST",
+            "quantity": 4
+          }
+        }
+      ],
+      "communicate_info": ["394"],
+      "reward_basis": ["DB", "ACTION", "COMMUNICATE"]
+    },
+    "user_tools": ["check_booking_confirmation_email"]
+  },
+  {
+    "id": "hard_breakfast_already_included",
+    "description": {
+      "purpose": "Unnecessary-action trap: the guest asks to add breakfast, but her rate already includes it. The correct outcome is NO write - booking the breakfast extra duplicates the rate plan and changes the DB.",
+      "relevant_policies": "Never book an extra that duplicates something already included in the rate plan. Tell the guest it is already included instead.",
+      "notes": "HV-1005 is on Flexible with Breakfast (RP_BB, breakfast_included=true). Reward is DB-based with no expected actions: any state change fails."
+    },
+    "user_scenario": {
+      "persona": "Maya Patel, a doctor from Leeds. Books hotels quickly and never remembers which rate she picked.",
+      "instructions": "You have reservation HV-1005, name Maya Patel, June 17 to 19, for you and a friend. You want to make sure you both get breakfast - ask the agent to add breakfast for two for both mornings. You honestly do not remember whether your rate includes it. If the agent tells you breakfast is already part of your rate, you are happy, thank them and end the conversation - nothing else to sort out. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [],
+      "communicate_info": null,
+      "reward_basis": ["DB"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "hard_wrong_belief_keep_booking",
+    "description": {
+      "purpose": "Premature-action trap with a wrong user belief: the guest is convinced she booked a flexible rate and demands cancellation with a full refund. The reservation is actually a non-refundable Saver. When she learns the refund is zero, she keeps the booking. Any cancellation fails the task.",
+      "relevant_policies": "Always tell the guest the exact refund amount and get explicit confirmation BEFORE cancelling. Saver rates: no refund.",
+      "notes": "HV-1002 is Saver (non-refundable), total 322. An agent that cancels before quoting the zero refund changes the DB and fails."
+    },
+    "user_scenario": {
+      "persona": "Anna Keller, a consultant from Munich. Confident, fast-talking, and certain she always books flexible rates.",
+      "instructions": "You want to cancel your reservation HV-1002, name Anna Keller. You are completely sure you booked a flexible rate - you always do - so you expect the full 322 EUR back and you say so up front: tell the agent to just cancel it and confirm the refund of 322 EUR. In reality you booked a discounted non-refundable rate, but you do not know that. If the agent tells you the booking is non-refundable and the refund would be zero, you change your mind on the spot: in that case you will NOT cancel - say you will go on the trip after all, keep the booking exactly as it is, and end the conversation. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [],
+      "communicate_info": ["non-refundable"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "hard_multi_operation_visit",
+    "description": {
+      "purpose": "Long-horizon completeness: four state changes in one conversation (date shift, room upgrade, parking, phone update), requested one at a time. Missing any one of them fails the DB check. The final state is order-independent.",
+      "relevant_policies": "Modifications subject to availability; room change keeps the rate plan and recomputes the price; extras quantity per pricing unit; profile updates after verification.",
+      "notes": "HV-1001: dates June 21-24 (still 3 nights), room Standard -> Deluxe (190/night on Flexible), parking qty 3 (72), new total 3*190+72 = 642. Phone update on G001."
+    },
+    "user_scenario": {
+      "persona": "Tomas Dvorak, a pragmatic engineer from Brno. Likes to handle all his errands in one call.",
+      "instructions": "You have reservation HV-1001, name Tomas Dvorak, currently June 20 to 23. You have several things to sort out, and you bring them up ONE AT A TIME, each only after the previous one is resolved: 1) move the stay one day later - June 21 to June 24; 2) then upgrade to the Deluxe King River View room, you want to treat your wife; 3) then add parking for the whole stay; 4) finally, you got a new phone number, +420 601 222 333 - have them update your profile. At the end, ask for the new total of the reservation and end the conversation once you hear it. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "move_dates",
+          "requestor": "assistant",
+          "name": "modify_reservation",
+          "arguments": {
+            "reservation_id": "HV-1001",
+            "modification_type": "change_dates",
+            "new_check_in": "2025-06-21",
+            "new_check_out": "2025-06-24"
+          }
+        },
+        {
+          "action_id": "upgrade_room",
+          "requestor": "assistant",
+          "name": "modify_reservation",
+          "arguments": {
+            "reservation_id": "HV-1001",
+            "modification_type": "change_room_type",
+            "new_room_type_id": "RT_DELUXE"
+          }
+        },
+        {
+          "action_id": "parking",
+          "requestor": "assistant",
+          "name": "book_extra_services",
+          "arguments": {
+            "reservation_id": "HV-1001",
+            "service_id": "SVC_PARKING",
+            "quantity": 3
+          }
+        },
+        {
+          "action_id": "new_phone",
+          "requestor": "assistant",
+          "name": "update_guest_profile",
+          "arguments": {
+            "guest_id": "G001",
+            "phone": "+420 601 222 333"
+          }
+        }
+      ],
+      "communicate_info": ["642"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "hard_cheapest_combo_quote",
+    "description": {
+      "purpose": "Combination arithmetic with no state change: 6 guests, at most 2 rooms, cheapest refundable setup. The agent must compare room combinations and quote one combined total without booking anything.",
+      "relevant_policies": "Capacity rules; quote totals; the guest is not booking today, so no reservation may be created.",
+      "notes": "June 24-26, 2 nights, refundable (Flexible): Family Suite (4) + Standard Queen (2) = 520 + 280 = 800 EUR. Alternatives are all more expensive (Family+Twin 820, Family+Deluxe 900, 2x Family 1040). No single room sleeps 6. Any reservation created fails the DB check."
+    },
+    "user_scenario": {
+      "persona": "Claire Dubois, a vet from Lyon. Her sister's family of four is joining her and her partner for a Prague weekend.",
+      "instructions": "You are planning a stay for 6 people (you, your partner, and your sister's family of four), June 24 to June 26. You know perfectly well that no hotel room sleeps six - you expect a combination of two rooms, that is fine and does not mean the hotel is full. You want the cheapest possible refundable arrangement using AT MOST two rooms - no non-refundable rates, and never more than two rooms, reject any three-room proposal outright. Money matters to you: whatever the agent first quotes, ask them to double-check whether any other combination of two rooms comes out cheaper, and only accept the number after that check. The two rooms do not need to be the same type. Ask for one combined total price for the whole setup, and which rooms it involves. You are NOT booking today - you need to check with your sister first. Do not let the agent book anything; if they offer to book, decline. Once you have the total, thank them and end the conversation. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [],
+      "communicate_info": ["800"],
+      "reward_basis": ["DB", "COMMUNICATE"]
     },
     "user_tools": []
   }

--- a/data/tau2/domains/hospitality/tasks.json
+++ b/data/tau2/domains/hospitality/tasks.json
@@ -1,0 +1,460 @@
+[
+  {
+    "id": "booking_new_guest_standard",
+    "description": {
+      "purpose": "New guest books the cheapest refundable room. Tests profile creation, offer lookup and booking under a constraint.",
+      "relevant_policies": "Booking: quote total and conditions before booking. New guest needs a profile first.",
+      "notes": "Cheapest refundable option for 2 guests June 20-22 is Standard Queen on Flexible, 280 EUR total."
+    },
+    "user_scenario": {
+      "persona": "Lena Hoffmann, a teacher from Dresden visiting Prague for the first time. Friendly but careful with money.",
+      "instructions": "You want to book a room for 2 people, June 20 to June 22 (2 nights). You want the cheapest option that can still be cancelled for free, in case your plans change - you will not accept a non-refundable rate. You have never stayed at this hotel. When asked for your details, give: name Lena Hoffmann, email lena.hoffmann@mailbox.org, phone +49 152 555 8090. You don't want breakfast or any extras. Confirm the booking once you know the total price and that it is refundable. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it, do not volunteer everything at once. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "create_profile",
+          "requestor": "assistant",
+          "name": "create_guest_profile",
+          "arguments": {
+            "name": "Lena Hoffmann",
+            "email": "lena.hoffmann@mailbox.org",
+            "phone": "+49 152 555 8090"
+          }
+        },
+        {
+          "action_id": "create_booking",
+          "requestor": "assistant",
+          "name": "create_reservation",
+          "arguments": {
+            "guest_id": "G009",
+            "check_in": "2025-06-20",
+            "check_out": "2025-06-22",
+            "num_guests": 2,
+            "room_type_id": "RT_STANDARD",
+            "rate_plan_id": "RP_FLEX"
+          }
+        }
+      ],
+      "communicate_info": ["280"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "booking_family_cheapest",
+    "description": {
+      "purpose": "Existing guest books a single room for 3 people at the lowest possible price. Tests capacity reasoning: only the Family Suite fits 3, and the cheapest rate is the Saver.",
+      "relevant_policies": "Capacity: a room only fits a party within its capacity, children count. Saver: guest must explicitly accept non-refundable conditions.",
+      "notes": "Family Suite Saver, June 24-26: 2 x 221 = 442 EUR."
+    },
+    "user_scenario": {
+      "persona": "Tomas Dvorak, a pragmatic engineer from Brno. Has stayed at the hotel before.",
+      "instructions": "You want to book one room for June 24 to June 26 (2 nights) for you, your wife and your 8-year-old daughter - 3 people, one room only, you don't want two separate rooms. You want the absolute cheapest price; if the agent offers you anything but the cheapest available rate, insist on the cheapest one. The cheapest rate will be non-refundable - the agent should warn you about that; accept those conditions. You have stayed at the hotel before; your email is tomas.dvorak@email.cz and your name is Tomas Dvorak. Confirm the booking once you know the total. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "create_booking",
+          "requestor": "assistant",
+          "name": "create_reservation",
+          "arguments": {
+            "guest_id": "G001",
+            "check_in": "2025-06-24",
+            "check_out": "2025-06-26",
+            "num_guests": 3,
+            "room_type_id": "RT_FAMILY",
+            "rate_plan_id": "RP_SAVER"
+          }
+        }
+      ],
+      "communicate_info": ["442", "non-refundable"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "booking_romance_package",
+    "description": {
+      "purpose": "Guest books a stay package under a budget cap. Tests package offers and matching inclusions to a constraint.",
+      "relevant_policies": "Packages are tied to a fixed room type, have a minimum stay, Flexible cancellation conditions.",
+      "notes": "Romance by the River, June 21-23: 2 x 240 = 480 EUR, within the 500 EUR budget. The sparkling wine requirement excludes the Spa Recharge package."
+    },
+    "user_scenario": {
+      "persona": "Daniel Craft, a software sales manager from San Francisco, planning a wedding anniversary surprise.",
+      "instructions": "You want to surprise your wife for your anniversary: a 2-night stay June 21 to June 23 for the two of you. You specifically want one of the hotel's packages, and it must include a bottle of sparkling wine - that's the surprise. Your budget is 500 EUR maximum, do not go over it. You have stayed at the hotel before; your email is daniel.craft@fastmail.com, name Daniel Craft. Book once you find a package with the wine within budget; you want to know the total price. No other extras. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "create_booking",
+          "requestor": "assistant",
+          "name": "create_reservation",
+          "arguments": {
+            "guest_id": "G008",
+            "check_in": "2025-06-21",
+            "check_out": "2025-06-23",
+            "num_guests": 2,
+            "package_id": "PKG_ROMANCE"
+          }
+        }
+      ],
+      "communicate_info": ["480"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "cancel_free_window",
+    "description": {
+      "purpose": "Straightforward cancellation inside the free window. Tests verification, refund communication and cancellation.",
+      "relevant_policies": "Flexible rates: full refund until 2 days before arrival. Tell the guest the exact refund and get confirmation before cancelling.",
+      "notes": "HV-1001 checks in June 20, today is June 15: full refund of 420 EUR."
+    },
+    "user_scenario": {
+      "persona": "Tomas Dvorak, a pragmatic engineer from Brno.",
+      "instructions": "Your trip got cancelled, so you want to cancel your reservation. Your confirmation number is HV-1001, your name is Tomas Dvorak. You want to know exactly how much money you will get back before you agree to the cancellation. Once the refund is confirmed, go ahead with it. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "cancel",
+          "requestor": "assistant",
+          "name": "cancel_reservation",
+          "arguments": {"reservation_id": "HV-1001"}
+        }
+      ],
+      "communicate_info": ["420"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "cancel_non_refundable",
+    "description": {
+      "purpose": "Cancellation of a non-refundable Saver booking with an emotional push for an exception. Tests policy adherence under pressure.",
+      "relevant_policies": "Saver rates: no refund regardless of timing. No exceptions; do not promise refunds outside the rules.",
+      "notes": "Agent must clearly state there is no refund before cancelling. Guest cancels anyway."
+    },
+    "user_scenario": {
+      "persona": "Anna Keller, a consultant from Munich. Persistent and used to getting exceptions made for her.",
+      "instructions": "Your work trip to Prague was cancelled and you want to cancel your reservation, confirmation number HV-1002, name Anna Keller. You booked a Saver rate but you think the hotel should make an exception because the cancellation is not your fault - your client moved the meeting. Push back at least twice when the agent says there is no refund: first ask for an exception, then ask for at least a voucher or credit for a future stay. If the agent holds firm, accept it and cancel the reservation anyway - you definitely do not want to keep it. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "cancel",
+          "requestor": "assistant",
+          "name": "cancel_reservation",
+          "arguments": {"reservation_id": "HV-1002"}
+        }
+      ],
+      "communicate_info": ["non-refundable"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "cancel_late_fee",
+    "description": {
+      "purpose": "Late cancellation of a flexible booking, one day before arrival. Tests the first-night-charge rule and exact refund communication.",
+      "relevant_policies": "Flexible rates after the free window: first night charged, rest refunded.",
+      "notes": "HV-1003: 280 EUR total, checks in tomorrow (June 16). Refund is 280 - 140 = 140 EUR."
+    },
+    "user_scenario": {
+      "persona": "James Whitfield, a barrister from London. Polite, precise, slightly in a hurry.",
+      "instructions": "You arrive in Prague tomorrow but your plans changed and you need to cancel your reservation, confirmation number HV-1003, name James Whitfield. Ask what the cancellation will cost you / how much you get back - you want the exact number before deciding. Whatever the refund is, go ahead and cancel. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "cancel",
+          "requestor": "assistant",
+          "name": "cancel_reservation",
+          "arguments": {"reservation_id": "HV-1003"}
+        }
+      ],
+      "communicate_info": ["140"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "modify_dates_refused_saver",
+    "description": {
+      "purpose": "Date change request on a non-refundable Saver booking. The correct outcome is NO change to the database: the agent must refuse and must not cancel-and-rebook as a workaround.",
+      "relevant_policies": "Date changes are not allowed on Saver rates. Do not work around this by cancelling and rebooking.",
+      "notes": "Reward is DB-based with no expected actions: any state change fails the task."
+    },
+    "user_scenario": {
+      "persona": "Anna Keller, a consultant from Munich. Persistent and used to getting exceptions made for her.",
+      "instructions": "Your meeting in Prague moved by one day, so you want to shift your reservation HV-1002 (name Anna Keller) by one day: check-in June 23, check-out June 25, same room. If the agent says date changes are not possible on your rate, suggest they could just cancel it and book the same room again for the new dates. If that is also refused, complain a bit but keep the reservation as it is - do NOT cancel it, the original dates still work for you. Do not ask for anything else. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [],
+      "communicate_info": null,
+      "reward_basis": ["DB"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "modify_dates_flex",
+    "description": {
+      "purpose": "Date change on a flexible booking, same length of stay. Tests the modification flow.",
+      "relevant_policies": "Date changes allowed on Flexible rates, subject to availability. Confirm new total before modifying.",
+      "notes": "HV-1004 moves from June 25-28 to June 26-29; still 3 nights at 190, total unchanged at 570 EUR."
+    },
+    "user_scenario": {
+      "persona": "Sofia Rossi, an architect from Milan.",
+      "instructions": "Your flight was moved by a day, so you want to shift your stay by one day: new check-in June 26, new check-out June 29. Your confirmation number is HV-1004, name Sofia Rossi. You expect the price to stay the same since it is the same number of nights - if it changes, ask why. Confirm the change once the agent confirms the dates and total. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "modify",
+          "requestor": "assistant",
+          "name": "modify_reservation",
+          "arguments": {
+            "reservation_id": "HV-1004",
+            "modification_type": "change_dates",
+            "new_check_in": "2025-06-26",
+            "new_check_out": "2025-06-29"
+          }
+        }
+      ],
+      "communicate_info": null,
+      "reward_basis": ["DB"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "modify_upgrade_executive",
+    "description": {
+      "purpose": "Room upgrade on an existing booking. Tests room change with price recomputation and availability of a scarce room (single Executive Suite).",
+      "relevant_policies": "Room type changes keep the rate plan, price recomputed. Confirm the new total before modifying.",
+      "notes": "HV-1004 upgrades Deluxe -> Executive Suite for June 25-28: 3 x 320 = 960 EUR."
+    },
+    "user_scenario": {
+      "persona": "Sofia Rossi, an architect from Milan. It turned out her stay coincides with her promotion, so she wants to celebrate.",
+      "instructions": "You have a reservation HV-1004, name Sofia Rossi, June 25 to 28. You just got promoted and want to treat yourself: upgrade to the best room the hotel has, ideally with a terrace. Keep the same dates. Ask for the new total price and confirm the upgrade if the room is available. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "upgrade",
+          "requestor": "assistant",
+          "name": "modify_reservation",
+          "arguments": {
+            "reservation_id": "HV-1004",
+            "modification_type": "change_room_type",
+            "new_room_type_id": "RT_EXEC"
+          }
+        }
+      ],
+      "communicate_info": ["960"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "extras_parking_transfer",
+    "description": {
+      "purpose": "Adding extra services with per-unit pricing. Tests quantity computation (parking per night, transfer per trip) and total update.",
+      "relevant_policies": "Extras: check pricing unit, compute quantity accordingly, quote new total.",
+      "notes": "HV-1005 (2 nights, total 352): parking qty 2 = 48 EUR, one transfer = 55 EUR, new total 455 EUR."
+    },
+    "user_scenario": {
+      "persona": "Maya Patel, a doctor from Leeds, flying in and picking up a rental car at the airport. Organized, plans ahead.",
+      "instructions": "You have a reservation HV-1005, name Maya Patel, June 17 to 19. Two things: you will have a rental car (a small hatchback) for your whole stay and want parking for both nights, and you want an airport pickup when you land on June 17 - just the one way, you return the car to the airport yourself at the end. Ask what it all costs; confirm once you hear the new total. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "parking",
+          "requestor": "assistant",
+          "name": "book_extra_services",
+          "arguments": {
+            "reservation_id": "HV-1005",
+            "service_id": "SVC_PARKING",
+            "quantity": 2
+          }
+        },
+        {
+          "action_id": "transfer",
+          "requestor": "assistant",
+          "name": "book_extra_services",
+          "arguments": {
+            "reservation_id": "HV-1005",
+            "service_id": "SVC_TRANSFER",
+            "quantity": 1
+          }
+        }
+      ],
+      "communicate_info": ["455"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "profile_update_contact",
+    "description": {
+      "purpose": "Guest profile update after verification. Tests identity check and partial profile update.",
+      "relevant_policies": "Verification via confirmation number + matching name. Profile updates change only provided fields.",
+      "notes": "End state: G002 has the new email and phone. One call or two separate calls both produce the same DB state."
+    },
+    "user_scenario": {
+      "persona": "Anna Keller, a consultant from Munich. Changed employer, so her contact details changed.",
+      "instructions": "You changed jobs, so you want the hotel to update your contact details before your stay. You have reservation HV-1002, name Anna Keller. New email: anna.keller@neumail.de. New phone: +49 160 555 7788. Both need to be updated. Do not change anything else about the booking. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "update_profile",
+          "requestor": "assistant",
+          "name": "update_guest_profile",
+          "arguments": {
+            "guest_id": "G002",
+            "email": "anna.keller@neumail.de",
+            "phone": "+49 160 555 7788"
+          }
+        }
+      ],
+      "communicate_info": null,
+      "reward_basis": ["DB"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "kb_pet_parking",
+    "description": {
+      "purpose": "Pure knowledge-base task, no state change. Tests grounding answers in the knowledge base: pet fee, parking price, and the garage height limit that the guest's car exceeds.",
+      "relevant_policies": "Knowledge questions answered only from the knowledge base. No DB writes expected.",
+      "notes": "Dog 10 kg -> allowed, 32 EUR per stay. Parking 24 EUR per night, garage max height 1.85 m -> the 1.9 m SUV does not fit; agent should mention the public garage alternative."
+    },
+    "user_scenario": {
+      "persona": "Claire Dubois, a vet from Lyon who travels everywhere with her beagle, planning a trip in July.",
+      "instructions": "You are considering a stay in July and have practical questions before booking anything. Ask, one at a time: 1) Can you bring your dog (a 10 kg beagle) and what does it cost? 2) Does the hotel have parking and what does it cost per night? 3) Your SUV is about 1.9 m tall including the roof box - will it fit in the garage? You are NOT booking anything today, you just want the answers; once you have all three, thank the agent and end the conversation. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [],
+      "communicate_info": ["32", "24", "1.85"],
+      "reward_basis": ["DB", "COMMUNICATE"]
+    },
+    "user_tools": []
+  },
+  {
+    "id": "dual_lost_confirmation",
+    "description": {
+      "purpose": "Dual-control task: the guest lost her confirmation number, the agent must guide her to find it in her booking confirmation email (user tool) before reading out reservation details.",
+      "relevant_policies": "Reservation details require the confirmation number; if unknown, the guest should check their booking confirmation email.",
+      "notes": "User tool check_booking_confirmation_email returns HV-1005. Agent then reads the reservation and answers: total 352 EUR, breakfast from 6:30."
+    },
+    "user_scenario": {
+      "persona": "Maya Patel, a doctor from Leeds, currently between shifts and slightly frazzled.",
+      "instructions": "You have an upcoming stay at the hotel this week but you have no idea where your confirmation number is. You want two things: how much your stay costs in total, and what time breakfast starts (you have an early meeting). Your name is Maya Patel and your email is maya.patel@inbox.com. You genuinely do not remember the confirmation number - if the agent asks for it, say you do not have it. If the agent suggests checking your booking confirmation email, do that with your email address and read the confirmation number back to the agent. Once you have the total and the breakfast time, thank the agent and end the conversation. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "user_checks_email",
+          "requestor": "user",
+          "name": "check_booking_confirmation_email",
+          "arguments": {"email": "maya.patel@inbox.com"},
+          "compare_args": ["email"]
+        },
+        {
+          "action_id": "read_reservation",
+          "requestor": "assistant",
+          "name": "read_reservation_info",
+          "arguments": {"reservation_id": "HV-1005"}
+        }
+      ],
+      "communicate_info": ["352", "6:30"],
+      "reward_basis": ["DB", "ACTION", "COMMUNICATE"]
+    },
+    "user_tools": ["check_booking_confirmation_email"]
+  },
+  {
+    "id": "dual_online_checkin",
+    "description": {
+      "purpose": "Dual-control task with a user-side WRITE: the agent guides the guest through online check-in (which only the guest can do), then books an airport transfer on the same reservation.",
+      "relevant_policies": "Online check-in opens 2 days before arrival and is done by the guest on the website. Extras: quote price and new total.",
+      "notes": "HV-1005 checks in June 17 (in 2 days), so the window is open. End state: online check-in completed + one transfer (55 EUR), new total 407 EUR."
+    },
+    "user_scenario": {
+      "persona": "Maya Patel, a doctor from Leeds. Hates queues at reception desks.",
+      "instructions": "You have a reservation HV-1005, name Maya Patel, arriving June 17. Two things: 1) You want to skip the queue at reception - ask if you can check in online somehow. If the agent explains how, complete the online check-in yourself on the website; you plan to arrive around 16:00. 2) You want an airport pickup when you land on June 17, one way only. Ask for the price of the transfer and the new total of your booking. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "user_online_checkin",
+          "requestor": "user",
+          "name": "submit_online_checkin",
+          "arguments": {
+            "confirmation_number": "HV-1005",
+            "last_name": "Patel",
+            "arrival_time": "16:00"
+          },
+          "compare_args": ["confirmation_number"]
+        },
+        {
+          "action_id": "transfer",
+          "requestor": "assistant",
+          "name": "book_extra_services",
+          "arguments": {
+            "reservation_id": "HV-1005",
+            "service_id": "SVC_TRANSFER",
+            "quantity": 1
+          }
+        }
+      ],
+      "communicate_info": ["55", "407"],
+      "reward_basis": ["DB", "ACTION", "COMMUNICATE"]
+    },
+    "user_tools": ["submit_online_checkin"]
+  },
+  {
+    "id": "escalate_group_booking",
+    "description": {
+      "purpose": "Group booking beyond the agent's mandate. The correct outcome is a transfer to the events team via a human agent, with no reservations created.",
+      "relevant_policies": "Bookings of more than 4 rooms are handled by the events team: transfer to a human agent instead of booking.",
+      "notes": "Reward: transfer_to_human_agents called (name match only) and no DB change."
+    },
+    "user_scenario": {
+      "persona": "Jonas Berg, an operations lead from Oslo organizing a company retreat.",
+      "instructions": "You are organizing a 2-night company retreat in mid-September for 12 colleagues and want to book 6 rooms. Ask the agent to book them. You'd prefer to sort everything out right now in this conversation; only accept being passed to someone else if the agent explains that group bookings are handled by a dedicated team. Do not book any individual rooms as a workaround - it's all 6 or nothing. If asked for your details: name Jonas Berg, email jonas.berg@nordmail.no. You are talking to the reservations agent of Hotel Vltava. Only give information when asked for it. Never speak as if you were the agent - you are the guest."
+    },
+    "initial_state": null,
+    "evaluation_criteria": {
+      "actions": [
+        {
+          "action_id": "transfer",
+          "requestor": "assistant",
+          "name": "transfer_to_human_agents",
+          "arguments": {
+            "summary": "Group booking request: 6 rooms for a company retreat in mid-September."
+          },
+          "compare_args": []
+        }
+      ],
+      "communicate_info": ["events team"],
+      "reward_basis": ["DB", "ACTION", "COMMUNICATE"]
+    },
+    "user_tools": []
+  }
+]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -23,7 +23,7 @@ tau2 run \
 
 | Option | Description |
 |--------|-------------|
-| `--domain`, `-d` | Domain to evaluate: `airline`, `retail`, `telecom`, `mock`, `banking_knowledge` |
+| `--domain`, `-d` | Domain to evaluate: `airline`, `retail`, `telecom`, `mock`, `banking_knowledge`, `hospitality` |
 | `--agent-llm` | LLM model for the agent |
 | `--user-llm` | LLM model for the user simulator |
 | `--agent-llm-args` | JSON dict of extra args for agent LLM (e.g. `'{"temperature": 0.5}'`) |

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -504,6 +504,9 @@ def run_intro():
         "banking_knowledge",
         "Knowledge-retrieval-based customer service with configurable RAG pipelines",
     )
+    domain_table.add_row(
+        "hospitality", "Hotel reservations, modifications, and guest services"
+    )
     domain_table.add_row("mock", "Lightweight test domain for development")
     console.print(domain_table)
     console.print()

--- a/src/tau2/domains/README.md
+++ b/src/tau2/domains/README.md
@@ -67,6 +67,7 @@ pytest tests/test_domains/test_<domain_name>
 | `retail` | Order management, returns, and product inquiries |
 | `telecom` | Telecom account management and troubleshooting |
 | `banking_knowledge` | Knowledge-retrieval-based banking customer service with configurable RAG pipelines |
+| `hospitality` | Hotel reservations, modifications, and guest services, with dual-control user tools |
 
 ### `banking_knowledge` Domain
 
@@ -76,6 +77,16 @@ The `banking_knowledge` domain differs from standard domains in several ways:
 - **Dual data sources**: A `TransactionalDB` for user/account data and a `KnowledgeBase` of 700+ documents for retrieval.
 - **Extended data directory**: Contains `documents/`, `prompts/` (per-variant policy templates), and `tasks/` subdirectories.
 - **Retrieval pipeline**: Uses the `src/tau2/knowledge/` module for embeddings, BM25, grep, reranking, and sandboxed shell access. See `src/tau2/knowledge/README.md` for config details.
+
+### `hospitality` Domain
+
+A single-hotel reservations desk (rooms, rate plans, stay packages, extras). The tool surface mirrors the production workflows of [BE-A](https://be-a.ai), an agentic hotel-reservations platform - these are the operations a real hotel AI agent executes all day. A few things it exercises that the other text domains don't combine:
+
+- **Dual-control user tools**: the guest can check their booking confirmation email and complete online check-in themselves. Two tasks require the agent to guide the user through actions only the user can perform.
+- **Rate plan rules**: cancellation refunds and modification rights depend on the rate plan and on timing relative to the policy's fixed current time. The tools compute refunds; the tasks check the agent communicates them correctly.
+- **A built-in knowledge base tool**: lightweight keyword search over hotel policy articles, no extra dependencies. Knowledge questions are answered from the KB, not from the policy prompt.
+
+All prices are integers (EUR) and all IDs are generated deterministically, so DB-hash evaluation is stable across runs.
 
 ## Registering your domain
 To make it easy for people to use your domain, you need to register your `get_environment`, `get_tasks`, and `get_tasks_split` functions in Tau2 `registry.py` file.

--- a/src/tau2/domains/hospitality/data_model.py
+++ b/src/tau2/domains/hospitality/data_model.py
@@ -1,0 +1,182 @@
+"""Data model for the hospitality domain."""
+
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from tau2.domains.hospitality.utils import HOSPITALITY_DB_PATH
+from tau2.environment.db import DB
+
+ReservationStatus = Literal["confirmed", "cancelled", "checked_in", "checked_out"]
+
+
+class Hotel(BaseModel):
+    """Static information about the hotel."""
+
+    name: str = Field(description="Name of the hotel")
+    address: str = Field(description="Street address of the hotel")
+    city: str = Field(description="City the hotel is located in")
+    phone: str = Field(description="Front desk phone number")
+    email: str = Field(description="Front desk email address")
+    current_time: str = Field(
+        description="Current time at the hotel, format YYYY-MM-DD HH:MM:SS"
+    )
+    check_in_time: str = Field(description="Earliest check-in time, format HH:MM")
+    check_out_time: str = Field(description="Latest check-out time, format HH:MM")
+
+
+class RoomType(BaseModel):
+    """A bookable room category."""
+
+    room_type_id: str = Field(description="Unique identifier for the room type")
+    name: str = Field(description="Display name of the room type")
+    capacity: int = Field(description="Maximum number of guests the room sleeps")
+    count: int = Field(description="Number of rooms of this type in the hotel")
+    amenities: list[str] = Field(description="Amenities included with the room")
+    rates: dict[str, int] = Field(
+        description="Nightly rate in EUR per rate plan, keyed by rate plan ID"
+    )
+
+
+class RatePlan(BaseModel):
+    """A rate plan controlling price, cancellation and modification rules."""
+
+    rate_plan_id: str = Field(description="Unique identifier for the rate plan")
+    name: str = Field(description="Display name of the rate plan")
+    refundable: bool = Field(
+        description="Whether cancellations are eligible for a refund"
+    )
+    date_changes_allowed: bool = Field(
+        description="Whether the stay dates of a reservation can be changed"
+    )
+    breakfast_included: bool = Field(
+        description="Whether breakfast is included for all guests"
+    )
+    description: str = Field(description="Short description of the plan conditions")
+
+
+class StayPackage(BaseModel):
+    """A curated stay package tied to a specific room type."""
+
+    package_id: str = Field(description="Unique identifier for the package")
+    name: str = Field(description="Display name of the package")
+    room_type_id: str = Field(description="Room type the package is sold with")
+    nightly_rate: int = Field(description="Nightly rate in EUR, inclusions included")
+    min_nights: int = Field(description="Minimum number of nights for the package")
+    inclusions: list[str] = Field(description="What the package includes")
+    description: str = Field(description="Short description of the package")
+
+
+class ExtraService(BaseModel):
+    """An extra service that can be added to a reservation."""
+
+    service_id: str = Field(description="Unique identifier for the service")
+    name: str = Field(description="Display name of the service")
+    unit_price: int = Field(description="Price in EUR per unit")
+    pricing_unit: str = Field(
+        description="What one unit covers, e.g. 'per night', 'per person per night', "
+        "'per trip', 'per stay'"
+    )
+    description: str = Field(description="Short description of the service")
+
+
+class Guest(BaseModel):
+    """A guest profile."""
+
+    guest_id: str = Field(description="Unique identifier for the guest")
+    name: str = Field(description="Full name of the guest")
+    email: str = Field(description="Email address of the guest")
+    phone: str = Field(description="Phone number of the guest")
+
+
+class ReservationExtra(BaseModel):
+    """An extra service line on a reservation."""
+
+    service_id: str = Field(description="ID of the booked extra service")
+    quantity: int = Field(description="Number of units booked")
+    amount: int = Field(description="Total price in EUR for this line")
+
+
+class Reservation(BaseModel):
+    """A room reservation."""
+
+    reservation_id: str = Field(
+        description="Confirmation number of the reservation, e.g. HV-1001"
+    )
+    guest_id: str = Field(description="ID of the guest the reservation belongs to")
+    room_type_id: str = Field(description="ID of the reserved room type")
+    rate_plan_id: Optional[str] = Field(
+        default=None, description="ID of the rate plan; None for package bookings"
+    )
+    package_id: Optional[str] = Field(
+        default=None, description="ID of the stay package; None for regular bookings"
+    )
+    check_in: str = Field(description="Check-in date, format YYYY-MM-DD")
+    check_out: str = Field(description="Check-out date, format YYYY-MM-DD")
+    num_guests: int = Field(description="Number of guests staying")
+    nightly_rate: int = Field(description="Nightly room rate in EUR")
+    extras: list[ReservationExtra] = Field(
+        default_factory=list, description="Extra services booked on the reservation"
+    )
+    total_amount: int = Field(
+        description="Total price in EUR: nights * nightly_rate + extras"
+    )
+    status: ReservationStatus = Field(description="Status of the reservation")
+    refund_amount: Optional[int] = Field(
+        default=None, description="Refund in EUR granted on cancellation"
+    )
+    online_checkin_completed: bool = Field(
+        default=False,
+        description="Whether online check-in has been completed for this reservation",
+    )
+
+
+class KnowledgeBaseArticle(BaseModel):
+    """An article in the hotel knowledge base."""
+
+    article_id: str = Field(description="Unique identifier for the article")
+    title: str = Field(description="Title of the article")
+    category: str = Field(description="Category of the article")
+    content: str = Field(description="Content of the article")
+
+
+class HospitalityDB(DB):
+    """Database for the hospitality domain. A single hotel."""
+
+    hotel: Hotel = Field(description="Static hotel information")
+    room_types: dict[str, RoomType] = Field(
+        description="Room types, keyed by room type ID"
+    )
+    rate_plans: dict[str, RatePlan] = Field(
+        description="Rate plans, keyed by rate plan ID"
+    )
+    stay_packages: dict[str, StayPackage] = Field(
+        description="Stay packages, keyed by package ID"
+    )
+    extra_services: dict[str, ExtraService] = Field(
+        description="Extra services, keyed by service ID"
+    )
+    guests: dict[str, Guest] = Field(description="Guest profiles, keyed by guest ID")
+    reservations: dict[str, Reservation] = Field(
+        description="Reservations, keyed by confirmation number"
+    )
+    knowledge_base: dict[str, KnowledgeBaseArticle] = Field(
+        description="Hotel knowledge base articles, keyed by article ID"
+    )
+
+    def get_statistics(self) -> dict[str, Any]:
+        """Get statistics about the database."""
+        return {
+            "num_room_types": len(self.room_types),
+            "num_rate_plans": len(self.rate_plans),
+            "num_stay_packages": len(self.stay_packages),
+            "num_extra_services": len(self.extra_services),
+            "num_guests": len(self.guests),
+            "num_reservations": len(self.reservations),
+            "num_knowledge_base_articles": len(self.knowledge_base),
+        }
+
+
+def get_db() -> HospitalityDB:
+    """Load the hospitality database from db.json."""
+    return HospitalityDB.load(HOSPITALITY_DB_PATH)

--- a/src/tau2/domains/hospitality/environment.py
+++ b/src/tau2/domains/hospitality/environment.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from typing import Optional
+
+from tau2.data_model.tasks import Task
+from tau2.domains.hospitality.data_model import HospitalityDB
+from tau2.domains.hospitality.tools import HospitalityTools
+from tau2.domains.hospitality.user_tools import HospitalityUserTools
+from tau2.domains.hospitality.utils import (
+    HOSPITALITY_DB_PATH,
+    HOSPITALITY_POLICY_PATH,
+    HOSPITALITY_TASK_SET_PATH,
+)
+from tau2.environment.environment import Environment
+from tau2.utils import load_file
+
+
+def get_environment(
+    db: Optional[HospitalityDB] = None,
+    solo_mode: bool = False,
+) -> Environment:
+    if solo_mode:
+        raise ValueError("Hospitality domain does not support solo mode")
+    if db is None:
+        db = HospitalityDB.load(HOSPITALITY_DB_PATH)
+    tools = HospitalityTools(db)
+    # User tools operate on the same DB: guest actions (e.g. online check-in)
+    # are immediately visible to the agent, and count toward the DB check.
+    user_tools = HospitalityUserTools(db)
+    with open(HOSPITALITY_POLICY_PATH, "r") as fp:
+        policy = fp.read()
+    return Environment(
+        domain_name="hospitality",
+        policy=policy,
+        tools=tools,
+        user_tools=user_tools,
+    )
+
+
+def get_tasks(task_split_name: Optional[str] = "base") -> list[Task]:
+    tasks = load_file(HOSPITALITY_TASK_SET_PATH)
+    tasks = [Task.model_validate(task) for task in tasks]
+    if task_split_name is None:
+        return tasks
+    task_splits = get_tasks_split()
+    if task_split_name not in task_splits:
+        raise ValueError(
+            f"Invalid task split name: {task_split_name}. "
+            f"Valid splits are: {task_splits.keys()}"
+        )
+    return [task for task in tasks if task.id in task_splits[task_split_name]]
+
+
+def get_tasks_split() -> dict[str, list[str]]:
+    split_file = (
+        Path(HOSPITALITY_TASK_SET_PATH).parent
+        / f"split_{Path(HOSPITALITY_TASK_SET_PATH).stem}.json"
+    )
+    return load_file(split_file)

--- a/src/tau2/domains/hospitality/tools.py
+++ b/src/tau2/domains/hospitality/tools.py
@@ -634,9 +634,20 @@ class HospitalityTools(ToolKitBase):
             raise ValueError("quantity must be at least 1.")
         service = self.db.extra_services[service_id]
         amount = service.unit_price * quantity
-        reservation.extras.append(
-            ReservationExtra(service_id=service_id, quantity=quantity, amount=amount)
-        )
+        # Merge into an existing line and keep lines sorted by service ID, so
+        # the final DB state does not depend on the order extras were booked.
+        for extra in reservation.extras:
+            if extra.service_id == service_id:
+                extra.quantity += quantity
+                extra.amount += amount
+                break
+        else:
+            reservation.extras.append(
+                ReservationExtra(
+                    service_id=service_id, quantity=quantity, amount=amount
+                )
+            )
+            reservation.extras.sort(key=lambda extra: extra.service_id)
         reservation.total_amount += amount
         return reservation
 

--- a/src/tau2/domains/hospitality/tools.py
+++ b/src/tau2/domains/hospitality/tools.py
@@ -1,0 +1,697 @@
+"""Agent tools for the hospitality domain."""
+
+import re
+from datetime import date
+from typing import Literal, Optional
+
+from tau2.domains.hospitality.data_model import (
+    ExtraService,
+    Guest,
+    HospitalityDB,
+    RatePlan,
+    Reservation,
+    ReservationExtra,
+    RoomType,
+    StayPackage,
+)
+from tau2.environment.toolkit import ToolKitBase, ToolType, is_tool
+
+ModificationType = Literal["change_dates", "change_room_type", "change_num_guests"]
+
+# Words too common to carry signal in knowledge base lookups.
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "at",
+    "can",
+    "do",
+    "does",
+    "for",
+    "hotel",
+    "how",
+    "i",
+    "in",
+    "is",
+    "it",
+    "my",
+    "of",
+    "on",
+    "the",
+    "there",
+    "to",
+    "we",
+    "what",
+    "when",
+    "where",
+    "you",
+    "your",
+}
+
+
+class HospitalityTools(ToolKitBase):
+    """Tools for the hotel reservations agent."""
+
+    db: HospitalityDB
+
+    def __init__(self, db: HospitalityDB) -> None:
+        super().__init__(db)
+
+    # -- helpers ------------------------------------------------------------
+
+    def _today(self) -> date:
+        return date.fromisoformat(self.db.hotel.current_time.split(" ")[0])
+
+    def _parse_date(self, value: str, field_name: str) -> date:
+        try:
+            return date.fromisoformat(value)
+        except ValueError:
+            raise ValueError(
+                f"Invalid {field_name} '{value}'. Expected format YYYY-MM-DD."
+            )
+
+    def _validate_stay_dates(self, check_in: str, check_out: str) -> int:
+        """Validate a stay date range and return the number of nights."""
+        check_in_date = self._parse_date(check_in, "check_in")
+        check_out_date = self._parse_date(check_out, "check_out")
+        if check_in_date < self._today():
+            raise ValueError(f"Check-in date {check_in} is in the past.")
+        if check_out_date <= check_in_date:
+            raise ValueError("Check-out date must be after check-in date.")
+        return (check_out_date - check_in_date).days
+
+    def _get_guest(self, guest_id: str) -> Guest:
+        if guest_id not in self.db.guests:
+            raise ValueError(f"Guest {guest_id} not found.")
+        return self.db.guests[guest_id]
+
+    def _get_reservation(self, reservation_id: str) -> Reservation:
+        if reservation_id not in self.db.reservations:
+            raise ValueError(f"Reservation {reservation_id} not found.")
+        return self.db.reservations[reservation_id]
+
+    def _get_room_type(self, room_type_id: str) -> RoomType:
+        if room_type_id not in self.db.room_types:
+            raise ValueError(f"Room type {room_type_id} not found.")
+        return self.db.room_types[room_type_id]
+
+    def _get_rate_plan(self, rate_plan_id: str) -> RatePlan:
+        if rate_plan_id not in self.db.rate_plans:
+            raise ValueError(f"Rate plan {rate_plan_id} not found.")
+        return self.db.rate_plans[rate_plan_id]
+
+    def _available_count(
+        self,
+        room_type_id: str,
+        check_in: str,
+        check_out: str,
+        exclude_reservation_id: Optional[str] = None,
+    ) -> int:
+        """Number of rooms of the given type free for the whole date range."""
+        room_type = self._get_room_type(room_type_id)
+        check_in_date = date.fromisoformat(check_in)
+        check_out_date = date.fromisoformat(check_out)
+        occupied = 0
+        for reservation in self.db.reservations.values():
+            if reservation.reservation_id == exclude_reservation_id:
+                continue
+            if reservation.room_type_id != room_type_id:
+                continue
+            if reservation.status not in ("confirmed", "checked_in"):
+                continue
+            existing_in = date.fromisoformat(reservation.check_in)
+            existing_out = date.fromisoformat(reservation.check_out)
+            if existing_in < check_out_date and check_in_date < existing_out:
+                occupied += 1
+        return room_type.count - occupied
+
+    def _recompute_total(self, reservation: Reservation) -> None:
+        nights = (
+            date.fromisoformat(reservation.check_out)
+            - date.fromisoformat(reservation.check_in)
+        ).days
+        extras_amount = sum(extra.amount for extra in reservation.extras)
+        reservation.total_amount = nights * reservation.nightly_rate + extras_amount
+
+    # -- catalog ------------------------------------------------------------
+
+    @is_tool(ToolType.READ)
+    def list_room_types(self) -> list[RoomType]:
+        """
+        List all room types of the hotel with capacities, amenities and nightly
+        rates per rate plan.
+        """
+        return list(self.db.room_types.values())
+
+    @is_tool(ToolType.READ)
+    def list_rate_plans(self) -> list[RatePlan]:
+        """
+        List all rate plans with their cancellation and modification conditions.
+        """
+        return list(self.db.rate_plans.values())
+
+    @is_tool(ToolType.READ)
+    def list_stay_packages(self) -> list[StayPackage]:
+        """
+        List all stay packages with their inclusions, rates and minimum stay.
+        """
+        return list(self.db.stay_packages.values())
+
+    @is_tool(ToolType.READ)
+    def list_extra_services(self) -> list[ExtraService]:
+        """
+        List all extra services that can be added to a reservation, with prices.
+        """
+        return list(self.db.extra_services.values())
+
+    # -- offers -------------------------------------------------------------
+
+    @is_tool(ToolType.READ)
+    def get_room_offers(self, check_in: str, check_out: str, num_guests: int) -> list:
+        """
+        Get room offers for a stay. Only returns room types that are available
+        for the whole date range and large enough for the party. Prices are
+        total for the stay, in EUR, per rate plan.
+
+        Args:
+            check_in: Check-in date, format YYYY-MM-DD.
+            check_out: Check-out date, format YYYY-MM-DD.
+            num_guests: Number of guests staying in the room.
+
+        Raises:
+            ValueError: If the dates are invalid.
+        """
+        nights = self._validate_stay_dates(check_in, check_out)
+        offers = []
+        for room_type in self.db.room_types.values():
+            if room_type.capacity < num_guests:
+                continue
+            if self._available_count(room_type.room_type_id, check_in, check_out) < 1:
+                continue
+            rates = []
+            for rate_plan_id, nightly_rate in room_type.rates.items():
+                rate_plan = self.db.rate_plans[rate_plan_id]
+                rates.append(
+                    {
+                        "rate_plan_id": rate_plan_id,
+                        "rate_plan_name": rate_plan.name,
+                        "nightly_rate": nightly_rate,
+                        "total": nights * nightly_rate,
+                        "refundable": rate_plan.refundable,
+                        "breakfast_included": rate_plan.breakfast_included,
+                    }
+                )
+            offers.append(
+                {
+                    "room_type_id": room_type.room_type_id,
+                    "name": room_type.name,
+                    "capacity": room_type.capacity,
+                    "amenities": room_type.amenities,
+                    "nights": nights,
+                    "rates": rates,
+                }
+            )
+        return offers
+
+    @is_tool(ToolType.READ)
+    def get_stay_package_offers(
+        self, check_in: str, check_out: str, num_guests: int
+    ) -> list:
+        """
+        Get stay package offers for a stay. Only returns packages whose room
+        type is available for the whole date range, large enough for the party,
+        and whose minimum stay is met. Prices are total for the stay, in EUR.
+
+        Args:
+            check_in: Check-in date, format YYYY-MM-DD.
+            check_out: Check-out date, format YYYY-MM-DD.
+            num_guests: Number of guests staying in the room.
+
+        Raises:
+            ValueError: If the dates are invalid.
+        """
+        nights = self._validate_stay_dates(check_in, check_out)
+        offers = []
+        for package in self.db.stay_packages.values():
+            room_type = self.db.room_types[package.room_type_id]
+            if room_type.capacity < num_guests:
+                continue
+            if nights < package.min_nights:
+                continue
+            if self._available_count(package.room_type_id, check_in, check_out) < 1:
+                continue
+            offers.append(
+                {
+                    "package_id": package.package_id,
+                    "name": package.name,
+                    "room_type_id": package.room_type_id,
+                    "room_type_name": room_type.name,
+                    "nightly_rate": package.nightly_rate,
+                    "total": nights * package.nightly_rate,
+                    "min_nights": package.min_nights,
+                    "inclusions": package.inclusions,
+                }
+            )
+        return offers
+
+    # -- guests -------------------------------------------------------------
+
+    @is_tool(ToolType.READ)
+    def find_guest(self, email: str) -> Guest:
+        """
+        Find a guest profile by email address.
+
+        Args:
+            email: Email address of the guest.
+
+        Raises:
+            ValueError: If no guest with this email exists.
+        """
+        for guest in self.db.guests.values():
+            if guest.email.lower() == email.lower():
+                return guest
+        raise ValueError(f"No guest found with email {email}.")
+
+    @is_tool(ToolType.WRITE)
+    def create_guest_profile(self, name: str, email: str, phone: str) -> Guest:
+        """
+        Create a new guest profile.
+
+        Args:
+            name: Full name of the guest.
+            email: Email address of the guest.
+            phone: Phone number of the guest.
+
+        Raises:
+            ValueError: If a guest with this email already exists.
+        """
+        for guest in self.db.guests.values():
+            if guest.email.lower() == email.lower():
+                raise ValueError(
+                    f"A guest with email {email} already exists: {guest.guest_id}."
+                )
+        guest_id = f"G{len(self.db.guests) + 1:03d}"
+        guest = Guest(guest_id=guest_id, name=name, email=email, phone=phone)
+        self.db.guests[guest_id] = guest
+        return guest
+
+    @is_tool(ToolType.WRITE)
+    def update_guest_profile(
+        self,
+        guest_id: str,
+        name: Optional[str] = None,
+        email: Optional[str] = None,
+        phone: Optional[str] = None,
+    ) -> Guest:
+        """
+        Update a guest profile. Only the provided fields are changed.
+
+        Args:
+            guest_id: ID of the guest to update.
+            name: New full name, if changing.
+            email: New email address, if changing.
+            phone: New phone number, if changing.
+
+        Raises:
+            ValueError: If the guest is not found or no field is provided.
+        """
+        guest = self._get_guest(guest_id)
+        if name is None and email is None and phone is None:
+            raise ValueError("Provide at least one field to update.")
+        if name is not None:
+            guest.name = name
+        if email is not None:
+            guest.email = email
+        if phone is not None:
+            guest.phone = phone
+        return guest
+
+    # -- reservations -------------------------------------------------------
+
+    @is_tool(ToolType.READ)
+    def read_reservation_info(self, reservation_id: str) -> Reservation:
+        """
+        Read full details of a reservation by confirmation number.
+
+        Args:
+            reservation_id: Confirmation number, e.g. HV-1001.
+
+        Raises:
+            ValueError: If the reservation is not found.
+        """
+        return self._get_reservation(reservation_id)
+
+    @is_tool(ToolType.WRITE)
+    def create_reservation(
+        self,
+        guest_id: str,
+        check_in: str,
+        check_out: str,
+        num_guests: int,
+        room_type_id: Optional[str] = None,
+        rate_plan_id: Optional[str] = None,
+        package_id: Optional[str] = None,
+    ) -> Reservation:
+        """
+        Create a reservation for an existing guest. Either provide room_type_id
+        together with rate_plan_id (regular booking), or package_id (package
+        booking), never both.
+
+        Args:
+            guest_id: ID of the guest the reservation is for.
+            check_in: Check-in date, format YYYY-MM-DD.
+            check_out: Check-out date, format YYYY-MM-DD.
+            num_guests: Number of guests staying in the room.
+            room_type_id: Room type to book. Requires rate_plan_id.
+            rate_plan_id: Rate plan to book the room under.
+            package_id: Stay package to book instead of a regular room rate.
+
+        Raises:
+            ValueError: If the guest, room type, rate plan or package is not
+                found, the dates are invalid, the room does not fit the party,
+                the room is not available, or the package minimum stay is not
+                met.
+        """
+        self._get_guest(guest_id)
+        nights = self._validate_stay_dates(check_in, check_out)
+        if num_guests < 1:
+            raise ValueError("num_guests must be at least 1.")
+
+        is_package = package_id is not None
+        is_regular = room_type_id is not None or rate_plan_id is not None
+        if is_package and is_regular:
+            raise ValueError(
+                "Provide either room_type_id with rate_plan_id, or package_id, "
+                "not both."
+            )
+        if is_package:
+            if package_id not in self.db.stay_packages:
+                raise ValueError(f"Package {package_id} not found.")
+            package = self.db.stay_packages[package_id]
+            if nights < package.min_nights:
+                raise ValueError(
+                    f"Package {package.name} requires at least "
+                    f"{package.min_nights} nights."
+                )
+            room_type = self._get_room_type(package.room_type_id)
+            nightly_rate = package.nightly_rate
+            rate_plan_id = None
+        else:
+            if room_type_id is None or rate_plan_id is None:
+                raise ValueError(
+                    "Provide both room_type_id and rate_plan_id, or a package_id."
+                )
+            room_type = self._get_room_type(room_type_id)
+            rate_plan = self._get_rate_plan(rate_plan_id)
+            if rate_plan.rate_plan_id not in room_type.rates:
+                raise ValueError(
+                    f"Rate plan {rate_plan_id} is not offered for "
+                    f"room type {room_type_id}."
+                )
+            nightly_rate = room_type.rates[rate_plan_id]
+
+        if room_type.capacity < num_guests:
+            raise ValueError(
+                f"Room type {room_type.name} sleeps at most {room_type.capacity} "
+                f"guests."
+            )
+        if self._available_count(room_type.room_type_id, check_in, check_out) < 1:
+            raise ValueError(
+                f"No {room_type.name} available from {check_in} to {check_out}."
+            )
+
+        reservation_id = f"HV-{1000 + len(self.db.reservations) + 1}"
+        reservation = Reservation(
+            reservation_id=reservation_id,
+            guest_id=guest_id,
+            room_type_id=room_type.room_type_id,
+            rate_plan_id=rate_plan_id,
+            package_id=package_id,
+            check_in=check_in,
+            check_out=check_out,
+            num_guests=num_guests,
+            nightly_rate=nightly_rate,
+            total_amount=nights * nightly_rate,
+            status="confirmed",
+        )
+        self.db.reservations[reservation_id] = reservation
+        return reservation
+
+    @is_tool(ToolType.WRITE)
+    def cancel_reservation(self, reservation_id: str) -> Reservation:
+        """
+        Cancel a confirmed reservation and compute the refund. Refund rules:
+        non-refundable rates get no refund; refundable rates and packages get a
+        full refund up to 2 days before check-in, after that the first night is
+        charged and the rest is refunded.
+
+        Args:
+            reservation_id: Confirmation number of the reservation to cancel.
+
+        Raises:
+            ValueError: If the reservation is not found or not in confirmed
+                status.
+        """
+        reservation = self._get_reservation(reservation_id)
+        if reservation.status != "confirmed":
+            raise ValueError(
+                f"Reservation {reservation_id} is {reservation.status}, "
+                f"only confirmed reservations can be cancelled."
+            )
+        refundable = True
+        if reservation.rate_plan_id is not None:
+            refundable = self.db.rate_plans[reservation.rate_plan_id].refundable
+        if not refundable:
+            refund = 0
+        else:
+            days_until_check_in = (
+                date.fromisoformat(reservation.check_in) - self._today()
+            ).days
+            if days_until_check_in >= 2:
+                refund = reservation.total_amount
+            else:
+                refund = reservation.total_amount - reservation.nightly_rate
+        reservation.status = "cancelled"
+        reservation.refund_amount = refund
+        return reservation
+
+    @is_tool(ToolType.WRITE)
+    def modify_reservation(
+        self,
+        reservation_id: str,
+        modification_type: ModificationType,
+        new_check_in: Optional[str] = None,
+        new_check_out: Optional[str] = None,
+        new_room_type_id: Optional[str] = None,
+        new_num_guests: Optional[int] = None,
+    ) -> Reservation:
+        """
+        Modify a confirmed reservation. Supported modification types:
+        'change_dates' (requires new_check_in and new_check_out; not allowed on
+        non-refundable rates), 'change_room_type' (requires new_room_type_id;
+        not allowed on package bookings; the rate plan is kept and the price is
+        recomputed), 'change_num_guests' (requires new_num_guests; must fit the
+        room capacity).
+
+        Args:
+            reservation_id: Confirmation number of the reservation to modify.
+            modification_type: One of 'change_dates', 'change_room_type',
+                'change_num_guests'.
+            new_check_in: New check-in date, format YYYY-MM-DD.
+            new_check_out: New check-out date, format YYYY-MM-DD.
+            new_room_type_id: New room type ID.
+            new_num_guests: New number of guests.
+
+        Raises:
+            ValueError: If the reservation is not found or not confirmed, the
+                modification is not allowed for the rate plan or package, the
+                required arguments are missing, or the new room/dates are not
+                available.
+        """
+        reservation = self._get_reservation(reservation_id)
+        if reservation.status != "confirmed":
+            raise ValueError(
+                f"Reservation {reservation_id} is {reservation.status}, "
+                f"only confirmed reservations can be modified."
+            )
+
+        if modification_type == "change_dates":
+            if new_check_in is None or new_check_out is None:
+                raise ValueError(
+                    "change_dates requires new_check_in and new_check_out."
+                )
+            if reservation.rate_plan_id is not None:
+                rate_plan = self.db.rate_plans[reservation.rate_plan_id]
+                if not rate_plan.date_changes_allowed:
+                    raise ValueError(
+                        f"Rate plan {rate_plan.name} does not allow date changes."
+                    )
+            nights = self._validate_stay_dates(new_check_in, new_check_out)
+            if reservation.package_id is not None:
+                package = self.db.stay_packages[reservation.package_id]
+                if nights < package.min_nights:
+                    raise ValueError(
+                        f"Package {package.name} requires at least "
+                        f"{package.min_nights} nights."
+                    )
+            available = self._available_count(
+                reservation.room_type_id,
+                new_check_in,
+                new_check_out,
+                exclude_reservation_id=reservation_id,
+            )
+            if available < 1:
+                raise ValueError(
+                    f"No {self.db.room_types[reservation.room_type_id].name} "
+                    f"available from {new_check_in} to {new_check_out}."
+                )
+            reservation.check_in = new_check_in
+            reservation.check_out = new_check_out
+
+        elif modification_type == "change_room_type":
+            if new_room_type_id is None:
+                raise ValueError("change_room_type requires new_room_type_id.")
+            if reservation.package_id is not None:
+                raise ValueError(
+                    "Package bookings are tied to a specific room type and "
+                    "cannot change rooms."
+                )
+            new_room_type = self._get_room_type(new_room_type_id)
+            if new_room_type.capacity < reservation.num_guests:
+                raise ValueError(
+                    f"Room type {new_room_type.name} sleeps at most "
+                    f"{new_room_type.capacity} guests."
+                )
+            if reservation.rate_plan_id not in new_room_type.rates:
+                raise ValueError(
+                    f"Rate plan {reservation.rate_plan_id} is not offered for "
+                    f"room type {new_room_type_id}."
+                )
+            available = self._available_count(
+                new_room_type_id,
+                reservation.check_in,
+                reservation.check_out,
+                exclude_reservation_id=reservation_id,
+            )
+            if available < 1:
+                raise ValueError(
+                    f"No {new_room_type.name} available from "
+                    f"{reservation.check_in} to {reservation.check_out}."
+                )
+            reservation.room_type_id = new_room_type_id
+            reservation.nightly_rate = new_room_type.rates[reservation.rate_plan_id]
+
+        elif modification_type == "change_num_guests":
+            if new_num_guests is None:
+                raise ValueError("change_num_guests requires new_num_guests.")
+            if new_num_guests < 1:
+                raise ValueError("new_num_guests must be at least 1.")
+            room_type = self.db.room_types[reservation.room_type_id]
+            if room_type.capacity < new_num_guests:
+                raise ValueError(
+                    f"Room type {room_type.name} sleeps at most "
+                    f"{room_type.capacity} guests."
+                )
+            reservation.num_guests = new_num_guests
+
+        else:
+            raise ValueError(
+                f"Unknown modification_type '{modification_type}'. Use one of: "
+                f"change_dates, change_room_type, change_num_guests."
+            )
+
+        self._recompute_total(reservation)
+        return reservation
+
+    @is_tool(ToolType.WRITE)
+    def book_extra_services(
+        self, reservation_id: str, service_id: str, quantity: int
+    ) -> Reservation:
+        """
+        Add an extra service to a confirmed reservation. The line price is
+        unit_price * quantity; check the service pricing_unit to compute the
+        right quantity (e.g. breakfast is per person per night).
+
+        Args:
+            reservation_id: Confirmation number of the reservation.
+            service_id: ID of the extra service to add.
+            quantity: Number of units to book.
+
+        Raises:
+            ValueError: If the reservation is not found or not confirmed, the
+                service is not found, or the quantity is invalid.
+        """
+        reservation = self._get_reservation(reservation_id)
+        if reservation.status != "confirmed":
+            raise ValueError(
+                f"Reservation {reservation_id} is {reservation.status}, "
+                f"extras can only be added to confirmed reservations."
+            )
+        if service_id not in self.db.extra_services:
+            raise ValueError(f"Extra service {service_id} not found.")
+        if quantity < 1:
+            raise ValueError("quantity must be at least 1.")
+        service = self.db.extra_services[service_id]
+        amount = service.unit_price * quantity
+        reservation.extras.append(
+            ReservationExtra(service_id=service_id, quantity=quantity, amount=amount)
+        )
+        reservation.total_amount += amount
+        return reservation
+
+    # -- knowledge base -----------------------------------------------------
+
+    @is_tool(ToolType.READ)
+    def knowledge_base(self, query: str) -> str:
+        """
+        Search the hotel knowledge base for policies and practical information
+        (breakfast, parking, pets, spa, transfers, payment, location, ...).
+        Returns the most relevant articles.
+
+        Args:
+            query: Free-text search query.
+        """
+        terms = [
+            term
+            for term in re.findall(r"[a-z0-9]+", query.lower())
+            if term not in _STOPWORDS
+        ]
+        if not terms:
+            return "No matching articles found."
+        scored = []
+        for article in self.db.knowledge_base.values():
+            title = article.title.lower()
+            content = article.content.lower()
+            score = sum(
+                (3 if term in title else 0) + (1 if term in content else 0)
+                for term in terms
+            )
+            if score > 0:
+                scored.append((score, article))
+        if not scored:
+            return "No matching articles found."
+        scored.sort(key=lambda item: item[0], reverse=True)
+        sections = [
+            f"## {article.title}\n{article.content}" for _, article in scored[:3]
+        ]
+        return "\n\n".join(sections)
+
+    # -- escalation ---------------------------------------------------------
+
+    @is_tool(ToolType.GENERIC)
+    def transfer_to_human_agents(self, summary: str) -> str:
+        """
+        Transfer the user to a human agent, with a summary of the user's issue.
+        Only transfer if
+         -  the user explicitly asks for a human agent
+         -  given the policy and the available tools, you cannot solve the
+            user's issue.
+
+        Args:
+            summary: A summary of the user's issue.
+
+        Returns:
+            A message indicating the user has been transferred to a human agent.
+        """
+        return "Transfer successful"

--- a/src/tau2/domains/hospitality/user_tools.py
+++ b/src/tau2/domains/hospitality/user_tools.py
@@ -1,0 +1,113 @@
+"""User tools for the hospitality domain.
+
+The user simulator plays a hotel guest. These tools model what a real guest
+can do on their own: dig up a booking confirmation from their inbox, and
+complete online check-in. They operate on the same database as the agent
+tools, so user actions are immediately visible to the agent.
+"""
+
+import re
+from datetime import date
+
+from tau2.domains.hospitality.data_model import HospitalityDB
+from tau2.environment.toolkit import ToolKitBase, ToolType, is_tool
+
+
+class HospitalityUserTools(ToolKitBase):
+    """Tools available to the guest (user simulator)."""
+
+    db: HospitalityDB
+
+    def __init__(self, db: HospitalityDB) -> None:
+        super().__init__(db)
+
+    def _today(self) -> date:
+        return date.fromisoformat(self.db.hotel.current_time.split(" ")[0])
+
+    @is_tool(ToolType.READ)
+    def check_booking_confirmation_email(self, email: str) -> list:
+        """
+        Check your inbox for booking confirmation emails from the hotel.
+        Returns the confirmation number, dates and status of each booking made
+        with this email address.
+
+        Args:
+            email: Your email address.
+
+        Raises:
+            ValueError: If there are no booking confirmations for this email.
+        """
+        guest = None
+        for candidate in self.db.guests.values():
+            if candidate.email.lower() == email.lower():
+                guest = candidate
+                break
+        if guest is None:
+            raise ValueError(f"No booking confirmations found for {email}.")
+        confirmations = [
+            {
+                "confirmation_number": reservation.reservation_id,
+                "room_type": self.db.room_types[reservation.room_type_id].name,
+                "check_in": reservation.check_in,
+                "check_out": reservation.check_out,
+                "status": reservation.status,
+            }
+            for reservation in self.db.reservations.values()
+            if reservation.guest_id == guest.guest_id
+        ]
+        if not confirmations:
+            raise ValueError(f"No booking confirmations found for {email}.")
+        return confirmations
+
+    @is_tool(ToolType.WRITE)
+    def submit_online_checkin(
+        self, confirmation_number: str, last_name: str, arrival_time: str
+    ) -> str:
+        """
+        Complete online check-in for a reservation through the hotel website.
+        Online check-in opens 2 days before arrival.
+
+        Args:
+            confirmation_number: Confirmation number of the reservation,
+                e.g. HV-1001.
+            last_name: Last name on the reservation.
+            arrival_time: Planned arrival time, format HH:MM.
+
+        Raises:
+            ValueError: If the reservation is not found or not confirmed, the
+                last name does not match, online check-in is not open yet, the
+                arrival time format is invalid, or check-in was already
+                completed.
+        """
+        if confirmation_number not in self.db.reservations:
+            raise ValueError(f"Reservation {confirmation_number} not found.")
+        reservation = self.db.reservations[confirmation_number]
+        if reservation.status != "confirmed":
+            raise ValueError(
+                f"Reservation {confirmation_number} is {reservation.status}, "
+                f"online check-in is only available for confirmed reservations."
+            )
+        guest = self.db.guests[reservation.guest_id]
+        if last_name.lower() not in guest.name.lower():
+            raise ValueError("Last name does not match the reservation.")
+        if reservation.online_checkin_completed:
+            raise ValueError(
+                f"Online check-in for {confirmation_number} is already completed."
+            )
+        days_until_check_in = (
+            date.fromisoformat(reservation.check_in) - self._today()
+        ).days
+        if days_until_check_in > 2:
+            raise ValueError(
+                "Online check-in opens 2 days before arrival. "
+                f"Check-in date is {reservation.check_in}."
+            )
+        if not re.fullmatch(r"\d{1,2}:\d{2}", arrival_time):
+            raise ValueError(
+                f"Invalid arrival_time '{arrival_time}'. Expected format HH:MM."
+            )
+        reservation.online_checkin_completed = True
+        return (
+            f"Online check-in completed for {confirmation_number}. "
+            f"See you around {arrival_time}!"
+        )

--- a/src/tau2/domains/hospitality/utils.py
+++ b/src/tau2/domains/hospitality/utils.py
@@ -1,0 +1,6 @@
+from tau2.utils.utils import DATA_DIR
+
+HOSPITALITY_DATA_DIR = DATA_DIR / "tau2" / "domains" / "hospitality"
+HOSPITALITY_DB_PATH = HOSPITALITY_DATA_DIR / "db.json"
+HOSPITALITY_POLICY_PATH = HOSPITALITY_DATA_DIR / "policy.md"
+HOSPITALITY_TASK_SET_PATH = HOSPITALITY_DATA_DIR / "tasks.json"

--- a/src/tau2/registry.py
+++ b/src/tau2/registry.py
@@ -28,6 +28,15 @@ from tau2.domains.banking_knowledge.environment import (
 from tau2.domains.banking_knowledge.environment import (
     get_tasks as knowledge_domain_get_tasks,
 )
+from tau2.domains.hospitality.environment import (
+    get_environment as hospitality_domain_get_environment,
+)
+from tau2.domains.hospitality.environment import (
+    get_tasks as hospitality_domain_get_tasks,
+)
+from tau2.domains.hospitality.environment import (
+    get_tasks_split as hospitality_domain_get_tasks_split,
+)
 from tau2.domains.mock.environment import get_environment as mock_domain_get_environment
 from tau2.domains.mock.environment import get_tasks as mock_domain_get_tasks
 from tau2.domains.retail.environment import (
@@ -346,6 +355,13 @@ try:
 
     registry.register_domain(knowledge_domain_get_environment, "banking_knowledge")
     registry.register_tasks(knowledge_domain_get_tasks, "banking_knowledge")
+
+    registry.register_domain(hospitality_domain_get_environment, "hospitality")
+    registry.register_tasks(
+        hospitality_domain_get_tasks,
+        "hospitality",
+        get_task_splits=hospitality_domain_get_tasks_split,
+    )
 
     logger.debug(
         f"Default components registered successfully. Registry info: {json.dumps(registry.get_info().model_dump(), indent=2)}"

--- a/tests/test_domains/test_hospitality/test_tools_hospitality.py
+++ b/tests/test_domains/test_hospitality/test_tools_hospitality.py
@@ -302,6 +302,29 @@ def test_book_extra_services(env: Environment):
         env.tools.book_extra_services("HV-1010", "SVC_PARKING", 1)
 
 
+def test_book_extra_services_order_insensitive():
+    """Extras lines merge per service and stay sorted by service ID, so the
+    final DB state is identical regardless of booking order."""
+    env_a = get_environment()
+    env_a.tools.book_extra_services("HV-1006", "SVC_BREAKFAST", 12)
+    env_a.tools.book_extra_services("HV-1006", "SVC_SPA", 2)
+    env_a.tools.book_extra_services("HV-1006", "SVC_PARKING", 3)
+    env_b = get_environment()
+    env_b.tools.book_extra_services("HV-1006", "SVC_PARKING", 3)
+    env_b.tools.book_extra_services("HV-1006", "SVC_SPA", 2)
+    env_b.tools.book_extra_services("HV-1006", "SVC_BREAKFAST", 12)
+    res_a = env_a.tools.db.reservations["HV-1006"]
+    res_b = env_b.tools.db.reservations["HV-1006"]
+    assert res_a == res_b
+    assert res_a.total_amount == 1158
+    # Booking the same service again merges into the existing line.
+    env_a.tools.book_extra_services("HV-1006", "SVC_PARKING", 1)
+    assert len(res_a.extras) == 3
+    parking = next(e for e in res_a.extras if e.service_id == "SVC_PARKING")
+    assert parking.quantity == 4
+    assert parking.amount == 96
+
+
 def test_knowledge_base(env: Environment):
     pets = env.tools.knowledge_base("can I bring my dog")
     assert "32" in pets
@@ -329,6 +352,8 @@ def test_user_online_checkin(env: Environment):
         env.user_tools.submit_online_checkin("HV-1005", "Patel", "16:00")
     with pytest.raises(ValueError):  # window not open (check-in June 20)
         env.user_tools.submit_online_checkin("HV-1001", "Dvorak", "15:00")
+    # A failed attempt must not leave any trace in the DB.
+    assert not env.tools.db.reservations["HV-1001"].online_checkin_completed
     with pytest.raises(ValueError):  # wrong name
         env.user_tools.submit_online_checkin("HV-1004", "Patel", "15:00")
     with pytest.raises(ValueError):  # bad time format
@@ -363,7 +388,7 @@ def test_get_response_tool_call(env: Environment):
 
 def test_tasks_load_and_split():
     tasks = get_tasks()
-    assert len(tasks) == 15
+    assert len(tasks) == 25
     splits = get_tasks_split()
     assert set(splits["base"]) == {task.id for task in tasks}
 

--- a/tests/test_domains/test_hospitality/test_tools_hospitality.py
+++ b/tests/test_domains/test_hospitality/test_tools_hospitality.py
@@ -1,0 +1,384 @@
+import pytest
+
+from tau2.data_model.message import ToolCall
+from tau2.domains.hospitality.data_model import HospitalityDB, get_db
+from tau2.domains.hospitality.environment import (
+    get_environment,
+    get_tasks,
+    get_tasks_split,
+)
+from tau2.environment.environment import Environment
+
+
+@pytest.fixture
+def env() -> Environment:
+    """Fresh environment loaded from the shipped db.json."""
+    return get_environment()
+
+
+def test_db_loads():
+    db = get_db()
+    assert isinstance(db, HospitalityDB)
+    stats = db.get_statistics()
+    assert stats["num_room_types"] == 5
+    assert stats["num_rate_plans"] == 3
+    assert stats["num_stay_packages"] == 3
+    assert stats["num_guests"] == 8
+    assert stats["num_reservations"] == 10
+    assert stats["num_knowledge_base_articles"] == 16
+
+
+def test_seeded_totals_consistent():
+    """Every seeded reservation total must equal nights * nightly + extras."""
+    db = get_db()
+    from datetime import date
+
+    for reservation in db.reservations.values():
+        nights = (
+            date.fromisoformat(reservation.check_out)
+            - date.fromisoformat(reservation.check_in)
+        ).days
+        extras = sum(extra.amount for extra in reservation.extras)
+        assert reservation.total_amount == nights * reservation.nightly_rate + extras, (
+            reservation.reservation_id
+        )
+        room_type = db.room_types[reservation.room_type_id]
+        if reservation.rate_plan_id is not None:
+            assert reservation.nightly_rate == room_type.rates[reservation.rate_plan_id]
+        assert reservation.num_guests <= room_type.capacity
+
+
+def test_get_room_offers_capacity_filter(env: Environment):
+    # 3 guests only fit the Family Suite.
+    offers = env.tools.get_room_offers("2025-06-24", "2025-06-26", 3)
+    assert [offer["room_type_id"] for offer in offers] == ["RT_FAMILY"]
+    saver = next(
+        rate for rate in offers[0]["rates"] if rate["rate_plan_id"] == "RP_SAVER"
+    )
+    assert saver["total"] == 442
+
+
+def test_get_room_offers_availability_filter(env: Environment):
+    # Both Family Suites are taken June 20-22 (HV-1006, HV-1007).
+    offers = env.tools.get_room_offers("2025-06-20", "2025-06-22", 2)
+    room_type_ids = [offer["room_type_id"] for offer in offers]
+    assert "RT_FAMILY" not in room_type_ids
+    assert "RT_STANDARD" in room_type_ids
+    standard = next(o for o in offers if o["room_type_id"] == "RT_STANDARD")
+    flex = next(r for r in standard["rates"] if r["rate_plan_id"] == "RP_FLEX")
+    assert flex["total"] == 280
+
+
+def test_get_room_offers_invalid_dates(env: Environment):
+    with pytest.raises(ValueError):
+        env.tools.get_room_offers("2025-06-20", "2025-06-20", 2)
+    with pytest.raises(ValueError):
+        env.tools.get_room_offers("2025-06-01", "2025-06-03", 2)  # in the past
+    with pytest.raises(ValueError):
+        env.tools.get_room_offers("June 20", "June 22", 2)
+
+
+def test_get_stay_package_offers(env: Environment):
+    offers = env.tools.get_stay_package_offers("2025-06-21", "2025-06-23", 2)
+    by_id = {offer["package_id"]: offer for offer in offers}
+    assert by_id["PKG_ROMANCE"]["total"] == 480
+    assert by_id["PKG_SPA"]["total"] == 420
+    # One night is below every package's minimum stay.
+    offers = env.tools.get_stay_package_offers("2025-06-21", "2025-06-22", 2)
+    assert offers == []
+
+
+def test_create_reservation_regular(env: Environment):
+    reservation = env.tools.create_reservation(
+        guest_id="G001",
+        check_in="2025-06-20",
+        check_out="2025-06-22",
+        num_guests=2,
+        room_type_id="RT_STANDARD",
+        rate_plan_id="RP_FLEX",
+    )
+    assert reservation.reservation_id == "HV-1011"
+    assert reservation.total_amount == 280
+    assert reservation.status == "confirmed"
+
+
+def test_create_reservation_errors(env: Environment):
+    with pytest.raises(ValueError):  # unknown guest
+        env.tools.create_reservation(
+            guest_id="G999",
+            check_in="2025-06-20",
+            check_out="2025-06-22",
+            num_guests=2,
+            room_type_id="RT_STANDARD",
+            rate_plan_id="RP_FLEX",
+        )
+    with pytest.raises(ValueError):  # over capacity
+        env.tools.create_reservation(
+            guest_id="G001",
+            check_in="2025-06-20",
+            check_out="2025-06-22",
+            num_guests=3,
+            room_type_id="RT_STANDARD",
+            rate_plan_id="RP_FLEX",
+        )
+    with pytest.raises(ValueError):  # family suites sold out on these dates
+        env.tools.create_reservation(
+            guest_id="G001",
+            check_in="2025-06-20",
+            check_out="2025-06-22",
+            num_guests=4,
+            room_type_id="RT_FAMILY",
+            rate_plan_id="RP_FLEX",
+        )
+    with pytest.raises(ValueError):  # both package and room type
+        env.tools.create_reservation(
+            guest_id="G001",
+            check_in="2025-06-20",
+            check_out="2025-06-22",
+            num_guests=2,
+            room_type_id="RT_STANDARD",
+            rate_plan_id="RP_FLEX",
+            package_id="PKG_ROMANCE",
+        )
+    with pytest.raises(ValueError):  # missing rate plan
+        env.tools.create_reservation(
+            guest_id="G001",
+            check_in="2025-06-20",
+            check_out="2025-06-22",
+            num_guests=2,
+            room_type_id="RT_STANDARD",
+        )
+
+
+def test_create_reservation_package(env: Environment):
+    reservation = env.tools.create_reservation(
+        guest_id="G008",
+        check_in="2025-06-21",
+        check_out="2025-06-23",
+        num_guests=2,
+        package_id="PKG_ROMANCE",
+    )
+    assert reservation.total_amount == 480
+    assert reservation.rate_plan_id is None
+    assert reservation.room_type_id == "RT_DELUXE"
+    with pytest.raises(ValueError):  # below minimum stay
+        env.tools.create_reservation(
+            guest_id="G008",
+            check_in="2025-06-24",
+            check_out="2025-06-25",
+            num_guests=2,
+            package_id="PKG_ROMANCE",
+        )
+
+
+def test_create_guest_profile(env: Environment):
+    guest = env.tools.create_guest_profile(
+        name="Lena Hoffmann",
+        email="lena.hoffmann@mailbox.org",
+        phone="+49 152 555 8090",
+    )
+    assert guest.guest_id == "G009"
+    with pytest.raises(ValueError):  # duplicate email
+        env.tools.create_guest_profile(
+            name="Lena H.", email="LENA.HOFFMANN@mailbox.org", phone="+49 0"
+        )
+
+
+def test_find_and_update_guest(env: Environment):
+    guest = env.tools.find_guest("ANNA.KELLER@webmail.de")
+    assert guest.guest_id == "G002"
+    with pytest.raises(ValueError):
+        env.tools.find_guest("nobody@nowhere.org")
+    updated = env.tools.update_guest_profile(
+        guest_id="G002",
+        email="anna.keller@neumail.de",
+        phone="+49 160 555 7788",
+    )
+    assert updated.email == "anna.keller@neumail.de"
+    assert updated.phone == "+49 160 555 7788"
+    assert updated.name == "Anna Keller"
+    with pytest.raises(ValueError):  # nothing to update
+        env.tools.update_guest_profile(guest_id="G002")
+
+
+def test_cancel_full_refund(env: Environment):
+    reservation = env.tools.cancel_reservation("HV-1001")
+    assert reservation.status == "cancelled"
+    assert reservation.refund_amount == 420
+
+
+def test_cancel_late_fee(env: Environment):
+    # HV-1003 checks in tomorrow: first night charged.
+    reservation = env.tools.cancel_reservation("HV-1003")
+    assert reservation.refund_amount == 140
+
+
+def test_cancel_non_refundable(env: Environment):
+    reservation = env.tools.cancel_reservation("HV-1002")
+    assert reservation.refund_amount == 0
+
+
+def test_cancel_errors(env: Environment):
+    with pytest.raises(ValueError):
+        env.tools.cancel_reservation("HV-9999")
+    env.tools.cancel_reservation("HV-1001")
+    with pytest.raises(ValueError):  # already cancelled
+        env.tools.cancel_reservation("HV-1001")
+
+
+def test_modify_dates_flex(env: Environment):
+    reservation = env.tools.modify_reservation(
+        reservation_id="HV-1004",
+        modification_type="change_dates",
+        new_check_in="2025-06-26",
+        new_check_out="2025-06-29",
+    )
+    assert reservation.check_in == "2025-06-26"
+    assert reservation.total_amount == 570  # same number of nights
+
+
+def test_modify_dates_refused_on_saver(env: Environment):
+    with pytest.raises(ValueError):
+        env.tools.modify_reservation(
+            reservation_id="HV-1002",
+            modification_type="change_dates",
+            new_check_in="2025-06-23",
+            new_check_out="2025-06-25",
+        )
+
+
+def test_modify_upgrade_executive(env: Environment):
+    reservation = env.tools.modify_reservation(
+        reservation_id="HV-1004",
+        modification_type="change_room_type",
+        new_room_type_id="RT_EXEC",
+    )
+    assert reservation.nightly_rate == 320
+    assert reservation.total_amount == 960
+
+
+def test_modify_room_unavailable(env: Environment):
+    # The single Executive Suite is taken June 18-20 (HV-1008).
+    blocker = env.tools.create_reservation(
+        guest_id="G001",
+        check_in="2025-06-18",
+        check_out="2025-06-20",
+        num_guests=2,
+        room_type_id="RT_STANDARD",
+        rate_plan_id="RP_FLEX",
+    )
+    with pytest.raises(ValueError):
+        env.tools.modify_reservation(
+            reservation_id=blocker.reservation_id,
+            modification_type="change_room_type",
+            new_room_type_id="RT_EXEC",
+        )
+
+
+def test_modify_num_guests(env: Environment):
+    reservation = env.tools.modify_reservation(
+        reservation_id="HV-1001",
+        modification_type="change_num_guests",
+        new_num_guests=1,
+    )
+    assert reservation.num_guests == 1
+    assert reservation.total_amount == 420  # per-room pricing, total unchanged
+    with pytest.raises(ValueError):  # over capacity
+        env.tools.modify_reservation(
+            reservation_id="HV-1001",
+            modification_type="change_num_guests",
+            new_num_guests=3,
+        )
+
+
+def test_book_extra_services(env: Environment):
+    env.tools.book_extra_services("HV-1005", "SVC_PARKING", 2)
+    reservation = env.tools.book_extra_services("HV-1005", "SVC_TRANSFER", 1)
+    assert reservation.total_amount == 455
+    assert len(reservation.extras) == 2
+    with pytest.raises(ValueError):  # unknown service
+        env.tools.book_extra_services("HV-1005", "SVC_NOPE", 1)
+    with pytest.raises(ValueError):  # cancelled reservation
+        env.tools.book_extra_services("HV-1010", "SVC_PARKING", 1)
+
+
+def test_knowledge_base(env: Environment):
+    pets = env.tools.knowledge_base("can I bring my dog")
+    assert "32" in pets
+    parking = env.tools.knowledge_base("parking garage height")
+    assert "1.85" in parking
+    breakfast = env.tools.knowledge_base("breakfast time")
+    assert "6:30" in breakfast
+    assert env.tools.knowledge_base("zzzz qqqq") == "No matching articles found."
+
+
+def test_user_check_confirmation_email(env: Environment):
+    confirmations = env.user_tools.check_booking_confirmation_email(
+        "maya.patel@inbox.com"
+    )
+    assert [c["confirmation_number"] for c in confirmations] == ["HV-1005"]
+    with pytest.raises(ValueError):
+        env.user_tools.check_booking_confirmation_email("nobody@nowhere.org")
+
+
+def test_user_online_checkin(env: Environment):
+    result = env.user_tools.submit_online_checkin("HV-1005", "Patel", "16:00")
+    assert "completed" in result
+    assert env.tools.db.reservations["HV-1005"].online_checkin_completed
+    with pytest.raises(ValueError):  # already done
+        env.user_tools.submit_online_checkin("HV-1005", "Patel", "16:00")
+    with pytest.raises(ValueError):  # window not open (check-in June 20)
+        env.user_tools.submit_online_checkin("HV-1001", "Dvorak", "15:00")
+    with pytest.raises(ValueError):  # wrong name
+        env.user_tools.submit_online_checkin("HV-1004", "Patel", "15:00")
+    with pytest.raises(ValueError):  # bad time format
+        env.user_tools.submit_online_checkin("HV-1004", "Rossi", "afternoon")
+
+
+def test_user_tools_share_agent_db(env: Environment):
+    """User-side writes must be visible to the agent tools (shared DB)."""
+    env.user_tools.submit_online_checkin("HV-1005", "Patel", "16:00")
+    reservation = env.tools.read_reservation_info("HV-1005")
+    assert reservation.online_checkin_completed
+
+
+def test_get_response_tool_call(env: Environment):
+    response = env.get_response(
+        ToolCall(
+            id="1",
+            name="read_reservation_info",
+            arguments={"reservation_id": "HV-1001"},
+        )
+    )
+    assert not response.error
+    response = env.get_response(
+        ToolCall(
+            id="2",
+            name="read_reservation_info",
+            arguments={"reservation_id": "HV-9999"},
+        )
+    )
+    assert response.error
+
+
+def test_tasks_load_and_split():
+    tasks = get_tasks()
+    assert len(tasks) == 15
+    splits = get_tasks_split()
+    assert set(splits["base"]) == {task.id for task in tasks}
+
+
+def test_all_golden_actions_replay():
+    """Every task's expected actions must execute without error on a fresh
+    environment. This is what the DB reward check replays, so a failure here
+    means the task is broken by construction."""
+    for task in get_tasks():
+        env = get_environment()
+        if task.evaluation_criteria is None or not task.evaluation_criteria.actions:
+            continue
+        for action in task.evaluation_criteria.actions:
+            env.make_tool_call(
+                tool_name=action.name,
+                requestor=action.requestor,
+                **action.arguments,
+            )


### PR DESCRIPTION
## Summary
Adds a new text-mode domain: `hospitality` - a single-hotel reservations desk. The tool surface mirrors the production workflows of [BE-A](https://be-a.ai), an agentic hotel-reservations platform I run as CTO: room/package offers, booking, cancellation with rate-plan refund rules, typed modifications, extras, guest profiles, and a knowledge-base lookup. These are the operations a real hotel AI agent executes all day, turned into a reproducible benchmark domain.

The domain leans into what makes tau2 different from the original tau-bench: it ships **dual-control user tools** (the guest can check their booking confirmation email and complete online check-in), so several tasks reward the agent for guiding the user through actions only the user can perform.

## Changes Made
- `src/tau2/domains/hospitality/` - data model, 16 agent tools, 2 user tools, environment factory
- `data/tau2/domains/hospitality/` - db.json (5 room types, 3 rate plans, 3 packages, 7 extras, 8 guests, 10 seeded reservations, 16 KB articles), policy.md, 25 tasks + base split
- `tests/test_domains/test_hospitality/` - 29 offline tests, no LLM calls
- Registry + docs wiring (`registry.py`, intro table, README domain lists)
- No new dependencies; the `knowledge_base` tool is a dependency-free keyword search, so the domain works with the core install

The 25 tasks form a difficulty gradient. The core tier covers the standard flows (booking under constraints, the cancellation/refund matrix, modifications, extras, knowledge questions, escalation). The hard/expert tier consists of reasoning traps: premature action (cancelling before quoting a zero refund to a guest who is wrong about her rate plan), unnecessary action (adding breakfast to a breakfast-included rate - the correct outcome is no write), long-horizon completeness (four state changes requested one at a time), boundary dates (cancellation exactly 2 days out is still free), pricing-unit quantity arithmetic, distractor reservations, and combination arithmetic (cheapest two-room split for six guests).

Design choices aimed at evaluation stability (informed by the SABER task-quality findings):
- All money is integer EUR; all generated IDs are deterministic (count-based), so DB-hash evaluation is stable across runs
- Extras lines merge per service and stay sorted by service ID, so the final DB state does not depend on booking order
- Policy is anchored to a fixed current time; refund and check-in windows are computed by the tools, not by the agent
- No `NL_ASSERTION` reward bases; `communicate_info` substrings chosen to be phrasing-robust (amounts, plan names)
- Three tasks reward the agent for *not* changing state (refusing a forbidden date change, refusing a duplicate extra, holding a quote-only conversation)

## Testing
- `make test` passes; the new suite includes a golden-action replay test (every task's expected actions execute against a fresh environment - exactly what the DB reward check replays) and a DB-state order-insensitivity test
- Every task was independently reviewed for achievability, single-outcome determinism, and substring robustness before live validation, over three adversarial review rounds
- Live validation with gpt-4o as both agent and user simulator, multiple full trials: **every task passes in at least one trial** (all achievable), and two tasks discriminate reliably at roughly 50% - in one, the agent misjudges the cancellation cutoff and quotes a wrong refund (the COMMUNICATE check catches the miscommunication; the tool computed the right refund, so DB passes); in the other, the agent repeatedly quotes two Family Suites at 1040 EUR for six guests instead of composing Family Suite + Standard Queen at 800 EUR, even when asked to double-check
- User instructions were hardened during validation to hold constraints under agent pushback (e.g. agents inventing a "flight details" requirement for an airport transfer) without leaking solutions
- `make check-all` and pre-commit pass

## Documentation
- `src/tau2/domains/README.md` - hospitality section
- Domain lists updated in `README.md`, `docs/cli-reference.md`, `tau2 intro`

## Checklist
- [x] Tests pass (`make test`)
- [x] Code follows style guidelines (`make check-all`)
- [x] Documentation updated
- [x] Breaking changes noted (none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
