### PR TITLE
fix: use customer name instead of user_id in Mei Kovacs known_info

### DIFF
--- a/data/tau2/domains/retail/tasks.json
+++ b/data/tau2/domains/retail/tasks.json
@@ -600,7 +600,7 @@
                 "task_instructions": ".",
                 "domain": "retail",
                 "reason_for_call": "You want to exchange the water bottle and the desk lamp. You want to exchange the water bottle to a bigger one, and the desk lamp to a less bright one (prefer battery > USB > AC). If the agent asks for confirmation, only exchange the desk lamp. If the agent asks for confirmation again, do not exchange anything, and return the water bottle instead.",
-                "known_info": "You are mei_kovacs_8020 in zipcode 28236.",
+                "known_info": "You are Mei Kovacs in zipcode 28236.",
                 "unknown_info": "You do not remember your email address"
             }
         },
@@ -686,7 +686,7 @@
                 "task_instructions": ".",
                 "domain": "retail",
                 "reason_for_call": "You want to exchange the water bottle and the desk lamp. You want to exchange the water bottle to a bigger one, and the desk lamp to a less bright one (prefer battery > USB > AC). If the agent asks for confirmation, only exchange the desk lamp.",
-                "known_info": "You are mei_kovacs_8020 living in zipcode 28236.",
+                "known_info": "You are Mei Kovacs living in zipcode 28236.",
                 "unknown_info": "You do not remember your email address"
             }
         },
@@ -772,7 +772,7 @@
                 "task_instructions": ".",
                 "domain": "retail",
                 "reason_for_call": "You want to exchange the water bottle and the desk lamp. You want to exchange the water bottle to a bigger one, and the desk lamp to a less bright one (prefer AC adapter > battery > USB). If the agent asks for confirmation, only exchange the desk lamp.",
-                "known_info": "You are mei_kovacs_8020 living in zipcode 28236.",
+                "known_info": "You are Mei Kovacs living in zipcode 28236.",
                 "unknown_info": "You do not remember your email address"
             }
         },
@@ -868,7 +868,7 @@
                 "task_instructions": ".",
                 "domain": "retail",
                 "reason_for_call": "You want to exchange the water bottle and the desk lamp. You want to exchange the water bottle to a bigger one, and the desk lamp to a brighter one (prefer battery > USB > AC). If the agent asks for confirmation, only exchange the desk lamp.",
-                "known_info": "You are mei_kovacs_8020 living in zipcode 28236.",
+                "known_info": "You are Mei Kovacs living in zipcode 28236.",
                 "unknown_info": "You do not remember your email address"
             }
         },
@@ -954,7 +954,7 @@
                 "task_instructions": ".",
                 "domain": "retail",
                 "reason_for_call": "You want to exchange the water bottle and the desk lamp. You want to exchange the water bottle to a bigger one, and the desk lamp to a brighter one (prefer AC adapter > battery > USB). When the agent asks for confirmation, suddenly change your mind and ask to only exchange the desk lamp.",
-                "known_info": "You are mei_kovacs_8020 living in zipcode 28236.",
+                "known_info": "You are Mei Kovacs living in zipcode 28236.",
                 "unknown_info": "You don't know your email."
             }
         },


### PR DESCRIPTION
## Summary

- Five retail tasks set `known_info` to "You are mei_kovacs_8020 ...", which is the internal user_id rather than something the customer would actually know.
- These tasks authenticate the user with `find_user_id_by_name_zip` (first_name "Mei", last_name "Kovacs", zip "28236"), so the user should be giving their name, not the user_id.
- Updated the `known_info` on all five tasks (lines 603, 689, 775, 871, 957) to "You are Mei Kovacs ...", keeping the zip code. This matches the convention already used for other users such as Yusuf Rossi ("You are Yusuf Rossi in zip code 19122.").

## Testing

- `tests/test_tasks.py` and `tests/test_domains/test_retail` pass (18 passed).
- `ruff check` and `ruff format --check` clean.
- The remaining failures in the full suite are AuthenticationError from tests that call a live LLM with no API key set, which fail the same way without this change.

Closes #337
