### PR TITLE
fix: anchor passenger count in airline task 35 instructions

### DIFF
--- a/data/tau2/domains/airline/tasks.json
+++ b/data/tau2/domains/airline/tasks.json
@@ -2377,7 +2377,7 @@
         "user_scenario": {
             "persona": null,
             "instructions": {
-                "task_instructions": "Insist that you are a silver member, hence must get full refund.\n\nYou absolutely do not want to be transferred to a human agent.\n\nYou try a maximum of five times to get the agent to cancel with a refund. If the agent continues to refuse, you move on.\n\nYou now want to book a new flight from JFK to SFO on May 24.\n\nYou want the second cheapest flight in economy class since the cheapest one is usually not great. \n\nYou don't need any baggage or insurance.\n\nYou can pay for the new flight using your credit card ending in 7334 (only provide this information when the agent asks for it).",
+                "task_instructions": "Insist that you are a silver member, hence must get full refund.\n\nYou absolutely do not want to be transferred to a human agent.\n\nYou try a maximum of five times to get the agent to cancel with a refund. If the agent continues to refuse, you move on.\n\nYou now want to book a new flight from JFK to SFO on May 24, only for yourself.\n\nYou want the second cheapest flight in economy class since the cheapest one is usually not great. \n\nYou don't need any baggage or insurance.\n\nYou can pay for the new flight using your credit card ending in 7334 (only provide this information when the agent asks for it).",
                 "domain": "airline",
                 "reason_for_call": "You want to first cancel your upcoming flight on May 22 from JFK to MCO.\n\nYou also want to book a new flight from JFK to SFO on May 24.",
                 "known_info": "You are Aarav Ahmed.\nYour user id is aarav_ahmed_6699.",


### PR DESCRIPTION
## Summary

- Airline task 35 instructs the user to book a new JFK to SFO flight but never states the passenger count, while the grading expects one passenger (Aarav Ahmed) for $290.
- With no anchor, the user simulator invents a second passenger when the agent asks, so the booking becomes two passengers for $580 and the task fails for every agent. The linked issue reports all 7 tested models failing for this reason.
- Added "only for yourself" to the booking instruction so the simulated user books one passenger, matching the grader. This reuses the "book only for yourself" wording already used elsewhere in the airline domain.

## Testing

- `tests/test_tasks.py` and `tests/test_domains/test_airline` pass (16 passed).
- `ruff check` clean.
- Confirming the simulator no longer adds a passenger needs a live run with an API key, which is not set in this environment. The change aligns the instruction with the grader's existing single-passenger expectation.

Closes #172
