### PR TITLE
fix: drop temperature for reasoning models that reject it

### DIFF
--- a/src/tau2/utils/llm_utils.py
+++ b/src/tau2/utils/llm_utils.py
@@ -352,6 +352,19 @@ def _write_llm_log(
         json.dump(call_data, f, indent=2)
 
 
+def _is_unsupported_temperature_error(error: Exception) -> bool:
+    """
+    Check whether an exception is the API rejecting the temperature value.
+
+    Reasoning models only allow the default temperature and return a 400 such as:
+    "Unsupported value: 'temperature' does not support 0.0 with this model.
+    Only the default (1) value is supported."
+    """
+    if not isinstance(error, litellm.BadRequestError):
+        return False
+    return "temperature" in str(error).lower()
+
+
 def generate(
     model: str,
     messages: list[Message],
@@ -414,8 +427,26 @@ def generate(
             **kwargs,
         )
     except Exception as e:
-        logger.error(e)
-        raise e
+        # Reasoning models (o-series, gpt-5.x, etc.) reject any temperature other
+        # than the default. litellm.drop_params handles this for models it
+        # recognizes, but newer or custom-named models slip through and the API
+        # returns a 400. Drop temperature and retry once so these models work.
+        if _is_unsupported_temperature_error(e) and "temperature" in kwargs:
+            logger.warning(
+                f"Model {model} rejected temperature={kwargs['temperature']}. "
+                "Retrying without temperature."
+            )
+            kwargs.pop("temperature")
+            response = completion(
+                model=model,
+                messages=litellm_messages,
+                tools=tools_schema,
+                tool_choice=tool_choice,
+                **kwargs,
+            )
+        else:
+            logger.error(e)
+            raise e
     generation_time_seconds = time.perf_counter() - start_time
     cost = get_response_cost(response)
     usage = get_response_usage(response)

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+import litellm
 import pytest
 
 from tau2.data_model.message import (
@@ -8,7 +11,7 @@ from tau2.data_model.message import (
     UserMessage,
 )
 from tau2.environment.tool import Tool, as_tool
-from tau2.utils.llm_utils import generate
+from tau2.utils.llm_utils import _is_unsupported_temperature_error, generate
 
 
 @pytest.fixture
@@ -49,6 +52,70 @@ def tool_call_messages() -> list[Message]:
         ),
     ]
     return messages
+
+
+def _temperature_error() -> litellm.BadRequestError:
+    return litellm.BadRequestError(
+        message=(
+            "Unsupported value: 'temperature' does not support 0.0 with this "
+            "model. Only the default (1) value is supported."
+        ),
+        model="gpt-5.2",
+        llm_provider="openai",
+    )
+
+
+def _ok_response(model: str) -> litellm.ModelResponse:
+    return litellm.ModelResponse(
+        model=model,
+        choices=[
+            {
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "hi",
+                    "tool_calls": None,
+                },
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+
+def test_is_unsupported_temperature_error():
+    assert _is_unsupported_temperature_error(_temperature_error())
+    other = litellm.BadRequestError(
+        message="Invalid 'messages': too long.",
+        model="gpt-5.2",
+        llm_provider="openai",
+    )
+    assert not _is_unsupported_temperature_error(other)
+    assert not _is_unsupported_temperature_error(ValueError("temperature"))
+
+
+def test_generate_drops_temperature_on_reasoning_model(messages: list[Message]):
+    """Reasoning models reject temperature; generate should drop it and retry."""
+    with patch("tau2.utils.llm_utils.completion") as mock_completion:
+        mock_completion.side_effect = [_temperature_error(), _ok_response("gpt-5.2")]
+        response = generate("gpt-5.2", messages, temperature=0.0)
+
+    assert isinstance(response, AssistantMessage)
+    assert mock_completion.call_count == 2
+    assert "temperature" not in mock_completion.call_args_list[1].kwargs
+
+
+def test_generate_reraises_unrelated_bad_request(messages: list[Message]):
+    other = litellm.BadRequestError(
+        message="Invalid 'messages': too long.",
+        model="gpt-5.2",
+        llm_provider="openai",
+    )
+    with patch("tau2.utils.llm_utils.completion") as mock_completion:
+        mock_completion.side_effect = other
+        with pytest.raises(litellm.BadRequestError):
+            generate("gpt-5.2", messages, temperature=0.0)
+    assert mock_completion.call_count == 1
 
 
 def test_generate_no_tool_call(model: str, messages: list[Message]):


### PR DESCRIPTION
## Summary

- `tau2 run` with any reasoning model (o-series, gpt-5.x, etc.) fails immediately with a `400 BadRequestError`: "Unsupported value: 'temperature' does not support 0.0 with this model. Only the default (1) value is supported." The defaults send `temperature=0.0`.
- `litellm.drop_params = True` is already set, but it only strips `temperature` for models the installed litellm version recognizes as not supporting it. Newer or custom-named models (gpt-5.2, custom Azure deployment names) are not in that map, so the param is sent and the request fails.
- Fixed in `generate()`, the single choke point all agent, user, and assertion calls pass through. When the API returns that specific temperature error, drop `temperature` and retry once. This is model-list-free, so it keeps working for future models without code changes.

## Testing

- Added three unit tests in `tests/test_llm_utils.py` (mocked, no API key needed): the retry drops `temperature` and succeeds, unrelated 400s are re-raised untouched, and the error detector does not false-positive on other errors.
- `uv run pytest tests/test_llm_utils.py::test_is_unsupported_temperature_error tests/test_llm_utils.py::test_generate_drops_temperature_on_reasoning_model tests/test_llm_utils.py::test_generate_reraises_unrelated_bad_request` passes (3 passed).
- `ruff check` and `ruff format --check` clean.
- A live `tau2 run` against a reasoning model needs an API key that is not set in this environment. The mocked tests reproduce the exact `BadRequestError` from the issue and verify the retry path.

Closes #166
