### PR TITLE
fix: emit OpenAI-compliant tool_calls in to_litellm_messages

### DIFF
--- a/src/tau2/utils/llm_utils.py
+++ b/src/tau2/utils/llm_utils.py
@@ -179,7 +179,6 @@ def to_litellm_messages(messages: list[Message]) -> list[dict]:
                 tool_calls = [
                     {
                         "id": tc.id,
-                        "name": tc.name,
                         "function": {
                             "name": tc.name,
                             "arguments": json.dumps(tc.arguments),

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,14 +1,17 @@
+import json
+
 import pytest
 
 from tau2.data_model.message import (
     AssistantMessage,
     Message,
     SystemMessage,
+    ToolCall,
     ToolMessage,
     UserMessage,
 )
 from tau2.environment.tool import Tool, as_tool
-from tau2.utils.llm_utils import generate
+from tau2.utils.llm_utils import generate, to_litellm_messages
 
 
 @pytest.fixture
@@ -49,6 +52,36 @@ def tool_call_messages() -> list[Message]:
         ),
     ]
     return messages
+
+
+def test_to_litellm_messages_tool_call_is_openai_compliant():
+    """Assistant tool_calls must match the OpenAI chat-completion schema.
+
+    A tool_call object only allows ``id``, ``type`` and ``function`` (which holds
+    ``name`` and ``arguments``). The previous conversion also emitted a top-level
+    ``name`` key, which is not part of the spec and trips strict validators in
+    downstream consumers that parse these messages with the OpenAI SDK.
+    """
+    message = AssistantMessage(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            ToolCall(id="call_1", name="get_weather", arguments={"city": "Paris"})
+        ],
+    )
+
+    litellm_messages = to_litellm_messages([message])
+
+    tool_calls = litellm_messages[0]["tool_calls"]
+    assert len(tool_calls) == 1
+    tool_call = tool_calls[0]
+    assert set(tool_call.keys()) == {"id", "function", "type"}
+    assert tool_call["id"] == "call_1"
+    assert tool_call["type"] == "function"
+    assert tool_call["function"] == {
+        "name": "get_weather",
+        "arguments": json.dumps({"city": "Paris"}),
+    }
 
 
 def test_generate_no_tool_call(model: str, messages: list[Message]):


### PR DESCRIPTION
## Summary

`to_litellm_messages` built each assistant tool_call with a top-level `name` key in addition to the spec-correct `function.name`. The OpenAI chat-completion tool_call object only allows `id`, `type`, and `function` (which holds `name` and `arguments`), so the extra top-level `name` is not valid. litellm silently ignores it, which is why tau2's own runs are unaffected, but downstream apps that re-validate these messages with the OpenAI SDK fail, as reported in #169.

`function.name` already carries the tool name, so dropping the redundant key leaves behavior unchanged and makes the output validate against the OpenAI schema.

Fixes #169.

## Validation

- `uv run --extra dev python -m pytest tests/test_llm_utils.py::test_to_litellm_messages_tool_call_is_openai_compliant`