### PR TITLE
fix: classify context-window failures instead of retrying them as infra errors

### DIFF
--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -1244,6 +1244,15 @@ class TerminationReason(str, Enum):
     UNEXPECTED_ERROR = "unexpected_error"
 
 
+# Termination reasons for simulations that never produced an evaluable rollout
+# (they failed before or during execution rather than completing). These are
+# excluded from metric denominators.
+NON_EVALUABLE_TERMINATION_REASONS: tuple[TerminationReason, ...] = (
+    TerminationReason.INFRASTRUCTURE_ERROR,
+    TerminationReason.CONTEXT_WINDOW_EXCEEDED,
+)
+
+
 class SimulationRun(BaseModel):
     """
     Simulation run for the given task.

--- a/src/tau2/metrics/agent_metrics.py
+++ b/src/tau2/metrics/agent_metrics.py
@@ -6,7 +6,11 @@ import pandas as pd
 from loguru import logger
 from pydantic import BaseModel
 
-from tau2.data_model.simulation import Results, TerminationReason
+from tau2.data_model.simulation import (
+    NON_EVALUABLE_TERMINATION_REASONS,
+    Results,
+    TerminationReason,
+)
 
 
 def is_successful(reward: float) -> bool:
@@ -135,14 +139,16 @@ def get_metrics_df(results: Results) -> tuple[pd.DataFrame, int]:
     """
     df = results.to_df()
 
-    infra_count = (
-        df.termination_reason == TerminationReason.INFRASTRUCTURE_ERROR
-    ).sum()
-    if infra_count > 0:
+    non_evaluable_mask = df.termination_reason.apply(
+        lambda r: r in NON_EVALUABLE_TERMINATION_REASONS
+    )
+    non_evaluable_count = int(non_evaluable_mask.sum())
+    if non_evaluable_count > 0:
         logger.warning(
-            f"Excluding {infra_count} infrastructure error simulation(s) from metrics."
+            f"Excluding {non_evaluable_count} non-evaluable simulation(s) "
+            "(infrastructure or context-window errors) from metrics."
         )
-        df = df[df.termination_reason != TerminationReason.INFRASTRUCTURE_ERROR]
+        df = df[~non_evaluable_mask]
 
     if df.empty:
         df["success"] = pd.Series(dtype=bool)
@@ -222,7 +228,7 @@ def compute_metrics(results: Results) -> AgentMetrics:
     evaluated_sims = [
         sim
         for sim in results.simulations
-        if sim.termination_reason != TerminationReason.INFRASTRUCTURE_ERROR
+        if sim.termination_reason not in NON_EVALUABLE_TERMINATION_REASONS
     ]
 
     if not evaluated_sims:

--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -21,6 +21,7 @@ from contextvars import ContextVar
 from pathlib import Path
 from typing import Optional
 
+import litellm
 from loguru import logger
 
 from tau2.data_model.persona import InterruptTendency, PersonaConfig, Verbosity
@@ -312,9 +313,14 @@ class _TaskLogContext:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type is not None and self.task_log_dir and self.task_log_dir.exists():
+            reason = (
+                "context_window_exceeded"
+                if isinstance(exc_val, litellm.ContextWindowExceededError)
+                else "infrastructure_error"
+            )
             status = {
                 "status": "failed",
-                "reason": "infrastructure_error",
+                "reason": reason,
                 "error": str(exc_val),
                 "error_type": exc_type.__name__,
             }

--- a/src/tau2/runner/progress.py
+++ b/src/tau2/runner/progress.py
@@ -8,6 +8,7 @@ import traceback
 import uuid
 from typing import Callable, Optional
 
+import litellm
 from loguru import logger
 
 from tau2.data_model.simulation import Results, SimulationRun, TerminationReason
@@ -32,7 +33,9 @@ def run_with_retry(
     """Run a simulation function with retry logic.
 
     Retries on any exception. If all retries are exhausted, returns a failed
-    SimulationRun with INFRASTRUCTURE_ERROR instead of raising.
+    SimulationRun with INFRASTRUCTURE_ERROR instead of raising. A
+    ContextWindowExceededError is deterministic, so it is not retried and is
+    surfaced with the CONTEXT_WINDOW_EXCEEDED reason.
 
     Args:
         run_fn: A callable that produces a SimulationRun.
@@ -93,6 +96,12 @@ def run_with_retry(
             last_exception = e
             last_error_reason = str(e)
             last_traceback = traceback.format_exc()
+            # A context-window-exceeded error is deterministic: retrying the
+            # same task hits the same limit, so stop now instead of burning
+            # retries, and surface it with its own termination reason.
+            if isinstance(e, litellm.ContextWindowExceededError):
+                logger.error(f"Task {task.id} exceeded the context window: {e}")
+                break
             if attempt < max_attempts - 1:
                 logger.warning(
                     f"Task {task.id} failed (attempt {attempt + 1}/{max_attempts}): {e}"
@@ -102,11 +111,21 @@ def run_with_retry(
                     f"Task {task.id} failed after {max_attempts} attempts: {e}"
                 )
 
-    # All retries exhausted
-    error_text = Text(
-        text=f"  Task {task.id} failed permanently after {max_attempts} attempts: {last_error_reason}",
-        style="bold red",
-    )
+    # Retries exhausted (or stopped early for a deterministic failure)
+    if isinstance(last_exception, litellm.ContextWindowExceededError):
+        termination_reason = TerminationReason.CONTEXT_WINDOW_EXCEEDED
+        attempts_made = attempt + 1
+        error_text = Text(
+            text=f"  Task {task.id} terminated after {attempts_made} attempt(s): context window exceeded (not retried)",
+            style="bold red",
+        )
+    else:
+        termination_reason = TerminationReason.INFRASTRUCTURE_ERROR
+        attempts_made = max_attempts
+        error_text = Text(
+            text=f"  Task {task.id} failed permanently after {max_attempts} attempts: {last_error_reason}",
+            style="bold red",
+        )
     ConsoleDisplay.console.print(error_text)
 
     now = get_now()
@@ -117,7 +136,7 @@ def run_with_retry(
         start_time=now,
         end_time=now,
         duration=0.0,
-        termination_reason=TerminationReason.INFRASTRUCTURE_ERROR,
+        termination_reason=termination_reason,
         messages=[],
         trial=trial,
         seed=seed,
@@ -125,7 +144,7 @@ def run_with_retry(
             "error": str(last_exception),
             "error_type": type(last_exception).__name__,
             "error_traceback": last_traceback,
-            "failed_after_attempts": max_attempts,
+            "failed_after_attempts": attempts_made,
         },
     )
     if save_fn:

--- a/tests/test_agent_metrics.py
+++ b/tests/test_agent_metrics.py
@@ -1,0 +1,94 @@
+"""Tests for non-evaluable termination handling in agent metrics."""
+
+from tau2.data_model.simulation import (
+    Info,
+    Results,
+    RewardInfo,
+    SimulationRun,
+    TerminationReason,
+    UserInfo,
+)
+from tau2.data_model.tasks import EvaluationCriteria, Task, UserScenario
+from tau2.environment.environment import EnvironmentInfo
+from tau2.metrics.agent_metrics import compute_metrics
+
+
+def _make_info() -> Info:
+    return Info(
+        git_commit="abc123",
+        num_trials=1,
+        max_steps=100,
+        max_errors=10,
+        user_info=UserInfo(implementation="user_simulator"),
+        agent_info={"implementation": "llm_agent"},
+        environment_info=EnvironmentInfo(domain_name="mock", policy="test policy"),
+    )
+
+
+def _make_task(task_id: str) -> Task:
+    return Task(
+        id=task_id,
+        user_scenario=UserScenario(instructions="test instruction"),
+        evaluation_criteria=EvaluationCriteria(),
+    )
+
+
+def _make_sim(
+    task_id: str,
+    termination_reason: TerminationReason,
+    reward: float | None = None,
+) -> SimulationRun:
+    return SimulationRun(
+        id=f"sim-{task_id}",
+        task_id=task_id,
+        start_time="2026-01-01T00:00:00",
+        end_time="2026-01-01T00:01:00",
+        duration=60.0,
+        termination_reason=termination_reason,
+        reward_info=RewardInfo(reward=reward) if reward is not None else None,
+        messages=[],
+        trial=0,
+        seed=42,
+    )
+
+
+def test_context_window_sims_excluded_from_metrics_like_infra():
+    """CONTEXT_WINDOW_EXCEEDED simulations never produced an evaluable rollout, so
+    they are excluded from metric denominators, the same as INFRASTRUCTURE_ERROR."""
+    results = Results(
+        info=_make_info(),
+        tasks=[_make_task("t0"), _make_task("t1")],
+        simulations=[
+            _make_sim("t0", TerminationReason.INFRASTRUCTURE_ERROR),
+            _make_sim("t1", TerminationReason.CONTEXT_WINDOW_EXCEEDED),
+        ],
+    )
+
+    metrics = compute_metrics(results)
+
+    # Both sims are non-evaluable, so nothing is left to score.
+    assert metrics.total_simulations == 0
+    # infra_error_count still tracks infrastructure errors specifically.
+    assert metrics.infra_error_count == 1
+
+
+def test_metrics_score_only_evaluable_sims_in_mixed_run():
+    """With a mix of evaluable and non-evaluable sims, only the evaluable ones
+    reach the denominator. Both infrastructure and context-window failures are
+    dropped, so they cannot drag down or inflate the reported metrics."""
+    results = Results(
+        info=_make_info(),
+        tasks=[_make_task("t0"), _make_task("t1"), _make_task("t2")],
+        simulations=[
+            _make_sim("t0", TerminationReason.AGENT_STOP, reward=1.0),
+            _make_sim("t1", TerminationReason.INFRASTRUCTURE_ERROR),
+            _make_sim("t2", TerminationReason.CONTEXT_WINDOW_EXCEEDED),
+        ],
+    )
+
+    metrics = compute_metrics(results)
+
+    # Only the AGENT_STOP sim is evaluable.
+    assert metrics.total_simulations == 1
+    assert metrics.avg_reward == 1.0
+    assert metrics.infra_error_count == 1

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,72 @@
+"""Tests for run_with_retry termination-reason classification."""
+
+import litellm
+
+from tau2.data_model.simulation import SimulationRun, TerminationReason
+from tau2.data_model.tasks import EvaluationCriteria, Task, UserScenario
+from tau2.runner.progress import run_with_retry
+
+
+def _make_task(task_id: str = "t0") -> Task:
+    return Task(
+        id=task_id,
+        user_scenario=UserScenario(instructions="test instruction"),
+        evaluation_criteria=EvaluationCriteria(),
+    )
+
+
+def _context_window_error() -> litellm.ContextWindowExceededError:
+    return litellm.ContextWindowExceededError(
+        message="This model's maximum context length is 8192 tokens.",
+        model="gpt-4o",
+        llm_provider="openai",
+    )
+
+
+def test_context_window_error_is_not_retried_and_labeled():
+    """A context-window error is deterministic, so it should not be retried and
+    should be surfaced as CONTEXT_WINDOW_EXCEEDED rather than INFRASTRUCTURE_ERROR."""
+    calls = {"n": 0}
+
+    def run_fn() -> SimulationRun:
+        calls["n"] += 1
+        raise _context_window_error()
+
+    sim = run_with_retry(
+        run_fn,
+        _make_task(),
+        trial=0,
+        seed=42,
+        max_retries=3,
+        retry_delay=0.0,
+        console_display=False,
+    )
+
+    assert sim.termination_reason == TerminationReason.CONTEXT_WINDOW_EXCEEDED
+    assert calls["n"] == 1  # deterministic error: stopped after the first attempt
+    assert sim.info["error_type"] == "ContextWindowExceededError"
+    assert sim.info["failed_after_attempts"] == 1
+
+
+def test_generic_error_is_retried_and_labeled_infrastructure():
+    """Unchanged behavior: a generic error is retried up to max_attempts and then
+    labeled INFRASTRUCTURE_ERROR."""
+    calls = {"n": 0}
+
+    def run_fn() -> SimulationRun:
+        calls["n"] += 1
+        raise RuntimeError("transient boom")
+
+    sim = run_with_retry(
+        run_fn,
+        _make_task(),
+        trial=0,
+        seed=42,
+        max_retries=2,
+        retry_delay=0.0,
+        console_display=False,
+    )
+
+    assert sim.termination_reason == TerminationReason.INFRASTRUCTURE_ERROR
+    assert calls["n"] == 3  # initial attempt + 2 retries
+    assert sim.info["failed_after_attempts"] == 3


### PR DESCRIPTION
## Summary

When an agent or user turn exceeds the model's context window, litellm raises `ContextWindowExceededError`. tau2 treated this like any other failure: `run_with_retry` retried the whole simulation up to 3 more times (the limit is deterministic, so every retry hit it again) and then labeled the run `INFRASTRUCTURE_ERROR`, which reads as a transient API problem.

This change detects `ContextWindowExceededError` in `run_with_retry`, stops retrying immediately (the error is deterministic, so re-running the simulation cannot help), and records the already-defined-but-unused `CONTEXT_WINDOW_EXCEEDED` termination reason. For metrics, context-window runs are excluded from the denominators the same way infrastructure errors are (neither produced an evaluable rollout), via a new `NON_EVALUABLE_TERMINATION_REASONS` constant. The debug `sim_status.json` sidecar now reports the matching reason too.

Note: litellm may still retry the request internally (`num_retries`) before raising, so this does not eliminate every redundant call. It removes tau2's own redundant full-simulation retries and gives the failure an accurate, distinct label.

Fixes #159.

## Validation

- `uv run --extra dev python -m pytest tests/test_progress.py tests/test_agent_metrics.py`
- Regression (unchanged): `uv run --extra dev python -m pytest tests/test_checkpoint.py tests/test_results_format.py`