### PR TITLE
fix: preserve user tool calls in LiteLLM messages

### DIFF
--- a/src/tau2/utils/llm_utils.py
+++ b/src/tau2/utils/llm_utils.py
@@ -172,7 +172,21 @@ def to_litellm_messages(messages: list[Message]) -> list[dict]:
     litellm_messages = []
     for message in messages:
         if isinstance(message, UserMessage):
-            litellm_messages.append({"role": "user", "content": message.content})
+            litellm_message = {"role": "user", "content": message.content}
+            if message.is_tool_call():
+                litellm_message["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "name": tc.name,
+                        "function": {
+                            "name": tc.name,
+                            "arguments": json.dumps(tc.arguments),
+                        },
+                        "type": "function",
+                    }
+                    for tc in message.tool_calls
+                ]
+            litellm_messages.append(litellm_message)
         elif isinstance(message, AssistantMessage):
             tool_calls = None
             if message.is_tool_call():

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -4,11 +4,12 @@ from tau2.data_model.message import (
     AssistantMessage,
     Message,
     SystemMessage,
+    ToolCall,
     ToolMessage,
     UserMessage,
 )
 from tau2.environment.tool import Tool, as_tool
-from tau2.utils.llm_utils import generate
+from tau2.utils.llm_utils import generate, to_litellm_messages
 
 
 @pytest.fixture
@@ -49,6 +50,41 @@ def tool_call_messages() -> list[Message]:
         ),
     ]
     return messages
+
+
+def test_to_litellm_messages_preserves_user_tool_calls():
+    message = UserMessage(
+        role="user",
+        content=None,
+        tool_calls=[
+            ToolCall(
+                id="call_user_1",
+                name="verify_identity",
+                arguments={"last_four_digits": "1234"},
+                requestor="user",
+            )
+        ],
+    )
+
+    litellm_messages = to_litellm_messages([message])
+
+    assert litellm_messages == [
+        {
+            "role": "user",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_user_1",
+                    "name": "verify_identity",
+                    "function": {
+                        "name": "verify_identity",
+                        "arguments": '{"last_four_digits": "1234"}',
+                    },
+                    "type": "function",
+                }
+            ],
+        }
+    ]
 
 
 def test_generate_no_tool_call(model: str, messages: list[Message]):


### PR DESCRIPTION
## Summary
- Preserve `tool_calls` when `to_litellm_messages` converts `UserMessage` instances.
- Add a regression test covering user-requested tool calls, which can appear in telecom/user-side trajectories.

Fixes #139.

## Verification
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy uv run --extra dev python -m pytest tests/test_llm_utils.py::test_to_litellm_messages_preserves_user_tool_calls -q`
- `uv run --extra dev ruff check src/tau2/utils/llm_utils.py tests/test_llm_utils.py`
- `uv run --extra dev ruff format --check src/tau2/utils/llm_utils.py tests/test_llm_utils.py`
- `git diff --check`

## Notes
- This is separate from #359, which fixes assistant tool-call schema output for #169. This PR only addresses user-side tool calls being dropped during conversion.