### PR TITLE
fix: release airline seats on cancellation

### DIFF
--- a/src/tau2/domains/airline/tools.py
+++ b/src/tau2/domains/airline/tools.py
@@ -364,7 +364,15 @@ class AirlineTools(ToolKitBase):  # Tools
         reservation.status = "cancelled"
         logger.debug(self._get_reservation(reservation_id).model_dump_json(indent=4))
         # Release seats
-        logger.warning("Seats release not implemented for cancellation!!!")
+        for flight in reservation.flights:
+            flight_date_data = self._get_flight_instance(
+                flight_number=flight.flight_number,
+                date=flight.date,
+            )
+            if isinstance(flight_date_data, FlightDateStatusAvailable):
+                flight_date_data.available_seats[reservation.cabin] += len(
+                    reservation.passengers
+                )
         return reservation
 
     @is_tool(ToolType.READ)

--- a/tests/test_domains/test_airline/test_tools_airline.py
+++ b/tests/test_domains/test_airline/test_tools_airline.py
@@ -198,6 +198,34 @@ def test_cancel_reservation(
     )
 
 
+def test_cancel_reservation_releases_booked_seats(
+    environment: Environment, reservation_call: ToolCall
+):
+    flight_info = reservation_call.arguments["flights"][0]
+    cabin = reservation_call.arguments["cabin"]
+    passenger_count = len(reservation_call.arguments["passengers"])
+    flight = environment.tools._get_flight_instance(
+        flight_info.flight_number, flight_info.date
+    )
+    starting_seats = flight.available_seats[cabin]
+
+    booking_response = environment.get_response(reservation_call)
+    assert not booking_response.error
+    booked_reservation = json.loads(booking_response.content)
+    assert flight.available_seats[cabin] == starting_seats - passenger_count
+
+    cancellation_response = environment.get_response(
+        ToolCall(
+            id="cancel-booked-reservation",
+            name="cancel_reservation",
+            arguments={"reservation_id": booked_reservation["reservation_id"]},
+        )
+    )
+
+    assert not cancellation_response.error
+    assert flight.available_seats[cabin] == starting_seats
+
+
 @pytest.fixture
 def reservation_details_call():
     return ToolCall(


### PR DESCRIPTION
## Summary
- Fixes #153 by returning booked seats to airline flight inventory when a reservation is cancelled.
- Adds a regression test that books a reservation, verifies seat inventory is decremented, cancels it, and verifies the seats are restored.

## Changes Made
- Update `AirlineTools.cancel_reservation` to release passenger seats for each available flight segment in the cancelled reservation.
- Add focused airline tool coverage for book-then-cancel seat inventory restoration.

## Verification
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy uv run pytest tests/test_domains/test_airline/test_tools_airline.py::test_cancel_reservation_releases_booked_seats -q` — passed
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy uv run pytest tests/test_domains/test_airline/test_tools_airline.py -q` — passed, 14 tests
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy uv run pytest tests/test_domains/test_airline -q` — passed, 14 tests
- `env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy make check-all` — passed

## Notes
- I also attempted `make test`; local non-domain LLM tests failed because this environment has no `OPENAI_API_KEY`, while the airline/domain tests relevant to this fix passed.
- No documentation changes needed.

## Checklist
- [x] Tests pass for the touched airline domain
- [x] Code follows style guidelines (`make check-all`)
- [x] Documentation updated (not needed)
- [x] Breaking changes noted (none)
