### PR TITLE
fix: drain buffered full-duplex agent audio

### DIFF
--- a/src/tau2/orchestrator/full_duplex_orchestrator.py
+++ b/src/tau2/orchestrator/full_duplex_orchestrator.py
@@ -13,6 +13,7 @@ from loguru import logger
 
 from tau2.agent.base.streaming import compute_responsiveness_info
 from tau2.agent.base_agent import FullDuplexAgent
+from tau2.data_model.audio import audio_bytes_to_string
 from tau2.data_model.message import (
     AssistantMessage,
     Message,
@@ -537,6 +538,51 @@ class FullDuplexOrchestrator(BaseOrchestrator[StreamingAgentT, StreamingUserT, T
             self.termination_reason = TerminationReason.TOO_MANY_ERRORS
         self._check_timeout()
 
+    def _drain_buffered_agent_audio(self) -> None:
+        """Append any unplayed adapter audio to the last recorded tick."""
+        adapter = getattr(self.agent, "adapter", None)
+        buffered_audio = getattr(adapter, "_buffered_agent_audio", None)
+        if not buffered_audio:
+            return
+
+        drain_audio = b"".join(chunk for chunk, _ in buffered_audio)
+        if not drain_audio:
+            buffered_audio.clear()
+            return
+
+        if not self.ticks:
+            logger.warning("No ticks available to drain buffered agent audio")
+            buffered_audio.clear()
+            return
+
+        logger.info(
+            f"Draining {len(drain_audio)} bytes of buffered agent audio into the final tick"
+        )
+
+        last_tick = self.ticks[-1]
+        if last_tick.agent_chunk is None:
+            last_tick.agent_chunk = AssistantMessage(
+                role="assistant",
+                content=None,
+                is_audio=False,
+                audio_content=audio_bytes_to_string(drain_audio),
+                audio_format=getattr(self.agent, "audio_format", None),
+                timestamp=get_now(),
+                contains_speech=True,
+            )
+        else:
+            current_audio = last_tick.agent_chunk.get_audio_bytes() or b""
+            last_tick.agent_chunk.audio_content = audio_bytes_to_string(
+                current_audio + drain_audio
+            )
+            if last_tick.agent_chunk.audio_format is None:
+                last_tick.agent_chunk.audio_format = getattr(
+                    self.agent, "audio_format", None
+                )
+            last_tick.agent_chunk.contains_speech = True
+
+        buffered_audio.clear()
+
     def _finalize(self) -> SimulationRun:
         """
         Finalize the full-duplex simulation and create the SimulationRun result.
@@ -546,6 +592,8 @@ class FullDuplexOrchestrator(BaseOrchestrator[StreamingAgentT, StreamingUserT, T
         Returns:
             SimulationRun with all simulation data.
         """
+        self._drain_buffered_agent_audio()
+
         # Send stop signals to agent and user, forwarding any pending tool results
         try:
             self.agent.stop(

--- a/tests/test_streaming/test_streaming_integration.py
+++ b/tests/test_streaming/test_streaming_integration.py
@@ -1,9 +1,15 @@
+import time
+from types import SimpleNamespace
+
 import pytest
 
 from tau2 import LLMAgent, Orchestrator, UserSimulator
-from tau2.data_model.message import AssistantMessage, UserMessage
+from tau2.data_model.audio import audio_bytes_to_string
+from tau2.data_model.message import AssistantMessage, Tick, UserMessage
+from tau2.data_model.simulation import TerminationReason
 from tau2.orchestrator.full_duplex_orchestrator import FullDuplexOrchestrator
 from tau2.orchestrator.modes import CommunicationMode
+from tau2.utils.utils import get_now
 
 
 class TestBackwardCompatibility:
@@ -131,6 +137,74 @@ class TestMessageEnhancements:
 
         assert chunk.chunk_id == 0
         assert not chunk.is_final_chunk
+
+
+class TestFullDuplexAudioDrain:
+    """Test final buffered audio handling for full-duplex runs."""
+
+    def test_drain_buffered_agent_audio_appends_to_last_tick(self):
+        orchestrator = FullDuplexOrchestrator.__new__(FullDuplexOrchestrator)
+        orchestrator.agent = SimpleNamespace(
+            adapter=SimpleNamespace(
+                _buffered_agent_audio=[(b" tail", "item_1"), (b" audio", "item_1")]
+            ),
+            audio_format=None,
+        )
+        orchestrator.ticks = [
+            Tick(
+                tick_id=0,
+                timestamp=get_now(),
+                agent_chunk=AssistantMessage(
+                    role="assistant",
+                    audio_content=audio_bytes_to_string(b"heard"),
+                    contains_speech=True,
+                ),
+            )
+        ]
+
+        orchestrator._drain_buffered_agent_audio()
+
+        assert (
+            orchestrator.ticks[-1].agent_chunk.get_audio_bytes() == b"heard tail audio"
+        )
+        assert orchestrator.agent.adapter._buffered_agent_audio == []
+        assert orchestrator.ticks[-1].agent_chunk.contains_speech
+
+    def test_finalize_drains_buffer_before_agent_stop_clears_it(self):
+        class Agent:
+            def __init__(self):
+                self.adapter = SimpleNamespace(
+                    _buffered_agent_audio=[(b"final words", "item_1")]
+                )
+                self.audio_format = None
+                self.saw_buffer_during_stop = None
+
+            def stop(self, *args, **kwargs):
+                self.saw_buffer_during_stop = list(self.adapter._buffered_agent_audio)
+                self.adapter._buffered_agent_audio.clear()
+
+        agent = Agent()
+        orchestrator = FullDuplexOrchestrator.__new__(FullDuplexOrchestrator)
+        orchestrator.agent = agent
+        orchestrator.user = SimpleNamespace(stop=lambda *args, **kwargs: None)
+        orchestrator.agent_state = object()
+        orchestrator.user_state = object()
+        orchestrator.pending_agent_tool_results = None
+        orchestrator.pending_user_tool_results = None
+        orchestrator._run_start_perf = time.perf_counter()
+        orchestrator._run_start_time = get_now()
+        orchestrator.simulation_id = "sim"
+        orchestrator.task = SimpleNamespace(id="task")
+        orchestrator.termination_reason = TerminationReason.USER_STOP
+        orchestrator.seed = None
+        orchestrator.mode = CommunicationMode.FULL_DUPLEX
+        orchestrator.ticks = [Tick(tick_id=0, timestamp=get_now())]
+
+        simulation_run = orchestrator._finalize()
+
+        assert agent.saw_buffer_during_stop == []
+        assert simulation_run.ticks[-1].agent_chunk.get_audio_bytes() == b"final words"
+        assert agent.adapter._buffered_agent_audio == []
 
 
 # Fixtures


### PR DESCRIPTION
## Summary
- Drains unplayed adapter agent audio into the final full-duplex tick before `agent.stop()` clears provider buffers.
- Appends drained bytes to the existing final agent chunk when present, or creates an audio-bearing agent chunk when the final tick has none.
- Adds regression coverage for direct drain behavior and finalize ordering.

## Verification
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy PYTHONPATH=src uv run pytest tests/test_streaming/test_streaming_integration.py -q` - 9 passed
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy uv run ruff check src/tau2/orchestrator/full_duplex_orchestrator.py tests/test_streaming/test_streaming_integration.py` - passed
- `env -u ALL_PROXY -u all_proxy -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy uv run ruff format --check src/tau2/orchestrator/full_duplex_orchestrator.py tests/test_streaming/test_streaming_integration.py` - passed

## Notes
- Related to #241.
- I also tried `uv sync --extra dev --extra voice` to run a wider audio-native test slice, but local setup failed building `pyaudio` because `portaudio.h` is not installed. The added regression tests avoid external voice providers and system audio libraries.
