### PR TITLE
Submission: Add evaluation result of RAFT-27B on retail domain

### DIFF
--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -20,7 +20,7 @@
     "grok-4-1-fast_sierra_2026-05-05",
     "grok-4-2_sierra_2026-05-05",
     "glm5-2_zai_2026-06-21",
-    "raft-27b_northeastern-university-hai-lab_2026-06-23"
+    "raft-27b_northeastern-university-hai-lab_2026-06-25"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -19,7 +19,8 @@
     "grok-4-fast_sierra_2026-05-05",
     "grok-4-1-fast_sierra_2026-05-05",
     "grok-4-2_sierra_2026-05-05",
-    "glm5-2_zai_2026-06-21"
+    "glm5-2_zai_2026-06-21",
+    "raft-27b_northeastern-university-hai-lab_2026-06-23"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",

--- a/web/leaderboard/public/submissions/raft-27b_northeastern-university-hai-lab_2026-06-23/submission.json
+++ b/web/leaderboard/public/submissions/raft-27b_northeastern-university-hai-lab_2026-06-23/submission.json
@@ -1,0 +1,44 @@
+{
+  "model_name": "RAFT-27B",
+  "model_organization": "Northeastern University HAI Lab",
+  "submitting_organization": "Northeastern University HAI Lab",
+  "submission_date": "2026-06-23",
+  "submission_type": "custom",
+  "modality": "text",
+  "contact_info": {
+    "email": "wang.ziyi19@northeastern.edu",
+    "name": "Ziyi Wang",
+    "github": "Ziyiii0-0"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 86.40350877192982,
+      "pass_2": 79.23976608187135,
+      "pass_3": 74.56140350877193,
+      "pass_4": 71.05263157894737,
+      "cost": 0.0
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "retail": "retail_results.json"
+  },
+  "references": [
+    {
+      "title": "Learning from Failures: Error-Driven Reinforcement Learning for Tool Use",
+      "url": "https://raft.hailab.io/",
+      "type": "blog_post"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-06-22",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "claude-sonnet-4.5-20250929",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "reasoning_effort": "enabled"
+}

--- a/web/leaderboard/public/submissions/raft-27b_northeastern-university-hai-lab_2026-06-25/submission.json
+++ b/web/leaderboard/public/submissions/raft-27b_northeastern-university-hai-lab_2026-06-25/submission.json
@@ -2,7 +2,7 @@
   "model_name": "RAFT-27B",
   "model_organization": "Northeastern University HAI Lab",
   "submitting_organization": "Northeastern University HAI Lab",
-  "submission_date": "2026-06-23",
+  "submission_date": "2026-06-25",
   "submission_type": "custom",
   "modality": "text",
   "contact_info": {
@@ -12,10 +12,10 @@
   },
   "results": {
     "retail": {
-      "pass_1": 86.40350877192982,
-      "pass_2": 79.23976608187135,
-      "pass_3": 74.56140350877193,
-      "pass_4": 71.05263157894737,
+      "pass_1": 89.25438596491229,
+      "pass_2": 84.7953216374269,
+      "pass_3": 81.35964912280701,
+      "pass_4": 78.94736842105263,
       "cost": 0.0
     }
   },
@@ -32,9 +32,9 @@
     }
   ],
   "methodology": {
-    "evaluation_date": "2026-06-22",
+    "evaluation_date": "2026-06-24",
     "tau2_bench_version": "1.0.0",
-    "user_simulator": "claude-sonnet-4.5-20250929",
+    "user_simulator": "claude-sonnet-4-6",
     "verification": {
       "modified_prompts": false,
       "omitted_questions": false


### PR DESCRIPTION
## Submission: RAFT-27B
This submission is a follow-up to #255. We finetune a Qwen3.6-27B model using the same training methodology and evaluate it on the retail domain.
### Overview
- **Model**: RAFT-27B
- **Base model**: Qwen3.6-27B, fine-tuned on synthetic retail-domain trajectories
- **Submission date**: 2026-06-25
- **Domain**: Retail
### Results — Retail Domain
| Metric   | Score   |
|----------|---------|
| pass^1   | 89.25%  |
| pass^2   | 84.76%  |
| pass^3   | 81.36%  |
| pass^4   | 78.95%  |
### Link to Trajectory
https://huggingface.co/datasets/Ziyiii0-0/RAFT-27B
### Evaluation Setup
- **Trials**: 4
- **User simulator**: `claude-sonnet-4-6`
- **Agent LLM**: `Qwen3.6-27B` fine-tuned checkpoint (hosted via vLLM)
### Methodology Notes
Training data was collected on a fully synthetic retail database whose entities (users, products, orders) are **disjoint** from the τ-bench evaluation database.
- Modified prompts: No
- Omitted questions: No
