### PR TITLE
Add submission: Humains Nemotron-ultra Agent — airline (humains.com)

### DIFF
--- a/web/leaderboard/public/submissions/humains-nemotron-ultra-agent_humains-com_2026-06-23/submission.json
+++ b/web/leaderboard/public/submissions/humains-nemotron-ultra-agent_humains-com_2026-06-23/submission.json
@@ -1,0 +1,43 @@
+{
+  "model_name": "Humains Nemotron-ultra Agent",
+  "model_organization": "humains.com",
+  "submitting_organization": "humains.com",
+  "submission_date": "2026-06-23",
+  "submission_type": "custom",
+  "modality": "text",
+  "contact_info": {
+    "email": "nissan@humains.com",
+    "name": "Nissan"
+  },
+  "results": {
+    "airline": {
+      "pass_1": 85.0,
+      "pass_2": 76.66666666666666,
+      "pass_3": 70.0,
+      "pass_4": 64.0
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_results.json"
+  },
+  "references": [
+    {
+      "title": "Trajectory Data (GitHub release)",
+      "url": "https://github.com/Nisyron/tau2-bench-airline-trajectories/releases/download/v1.0/airline_results.json",
+      "type": "trajectories"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-06-23",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "openai/gpt-5.2",
+    "notes": "The submitted system is a Humains agent - a cognitive architecture by Humains.com - running on NVIDIA's base LLM nvidia/nemotron-3-ultra-550b-a55b (developed by NVIDIA; NOT a Humains model). Agent served via a local guarded bCortex (temperature 0.5, top_p 0.95, max_tokens 8192). User simulator openai/gpt-5.2 (reasoning_effort=low), identical to the baseline for maximum compatibility; seed 17000, 4 trials/task, base airline split (50 tasks).",
+    "verification": {
+      "modified_prompts": true,
+      "omitted_questions": false,
+      "details": "The submitted system is a Humains agent - a cognitive architecture designed by Humains.com (a proprietary multi-state bCortex architecture with custom per-state system prompts). The base LLM is NVIDIA's nvidia/nemotron-3-ultra-550b-a55b, developed by NVIDIA and not by Humains; only the agent layer is Humains'. System prompt averages ~22K tokens (range ~6K-56K per state; tiktoken-proxy count); prompt content and internal state design are proprietary and not disclosed - only the system prompt size is reported. Only the agent prompts were customized: no user-simulator or task/environment prompts were modified, and no tasks were omitted (all 50 base airline tasks, 4 trials each). The user simulator (openai/gpt-5.2) is identical to the baseline for maximum compatibility."
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/humains-nemotron-ultra-agent_humains-com_2026-06-23/submission.json
+++ b/web/leaderboard/public/submissions/humains-nemotron-ultra-agent_humains-com_2026-06-23/submission.json
@@ -27,13 +27,18 @@
       "title": "Trajectory Data (GitHub release)",
       "url": "https://github.com/Nisyron/tau2-bench-airline-trajectories/releases/download/v1.0/airline_results.json",
       "type": "trajectories"
+    },
+    {
+      "title": "Architecture Overview - Humains cognitive agent (implementation reference)",
+      "url": "https://github.com/Nisyron/tau2-bench-airline-trajectories/blob/main/ARCHITECTURE.md",
+      "type": "documentation"
     }
   ],
   "methodology": {
     "evaluation_date": "2026-06-23",
     "tau2_bench_version": "1.0.0",
     "user_simulator": "openai/gpt-5.2",
-    "notes": "The submitted system is a Humains agent - a cognitive architecture by Humains.com - running on NVIDIA's base LLM nvidia/nemotron-3-ultra-550b-a55b (developed by NVIDIA; NOT a Humains model). Agent served via a local guarded bCortex (temperature 0.5, top_p 0.95, max_tokens 8192). User simulator openai/gpt-5.2 (reasoning_effort=low), identical to the baseline for maximum compatibility; seed 17000, 4 trials/task, base airline split (50 tasks).",
+    "notes": "The submitted system is a Humains agent - a cognitive architecture by Humains.com - running on NVIDIA's base LLM nvidia/nemotron-3-ultra-550b-a55b (developed by NVIDIA; NOT a Humains model). Agent served via a local guarded bCortex (temperature 0.5, top_p 0.95, max_tokens 8192). User simulator openai/gpt-5.2 (reasoning_effort=low), identical to the baseline for maximum compatibility; seed 17000, 4 trials/task, base airline split (50 tasks). User-simulator serving path: openai/gpt-5.2 was served through an Azure AI Foundry deployment (humains-new-models-resource.services.ai.azure.com/openai/v1) rather than the OpenAI API, with reasoning_effort=low and no other parameter changes; the reasoning_effort setting applies to the user simulator (per the recommended baseline), not to the agent's base LLM, which has no such parameter.",
     "verification": {
       "modified_prompts": true,
       "omitted_questions": false,

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -19,7 +19,8 @@
     "grok-4-fast_sierra_2026-05-05",
     "grok-4-1-fast_sierra_2026-05-05",
     "grok-4-2_sierra_2026-05-05",
-    "glm5-2_zai_2026-06-21"
+    "glm5-2_zai_2026-06-21",
+    "humains-nemotron-ultra-agent_humains-com_2026-06-23"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",


### PR DESCRIPTION
## Submission: Humains Nemotron-ultra Agent — airline

**Submitting organization:** humains.com
**Submission type:** custom
**Modality:** text
**Domain:** airline (base split, 50 tasks × 4 trials, **k=4**)

### Attribution
The submitted system is a **Humains agent** (a cognitive architecture by **humains.com**) running on the base LLM **`nvidia/nemotron-3-ultra-550b-a55b`, developed by NVIDIA**. The base model is NVIDIA's; only the agent / cognitive-architecture layer is Humains'.

### Results (airline)
| metric | value |
|---|---|
| pass^1 | 85.0 |
| pass^2 | 76.7 |
| pass^3 | 70.0 |
| pass^4 | 64.0 |

### Trajectories (externally hosted)
`airline_results.json` (50×4, scrubbed of API keys, no prompt content):
https://github.com/Nisyron/tau2-bench-airline-trajectories/releases/download/v1.0/airline_results.json

### Methodology
Agent served via a local guarded bCortex (Nemotron-3-Ultra at temperature 0.5, top_p 0.95). **User simulator `openai/gpt-5.2` (reasoning_effort=low) — identical to the recommended baseline for maximum compatibility.** Seed 17000, 4 trials/task.

`modified_prompts: true` — only the **agent** prompts were customized (proprietary multi-state architecture; system-prompt size ~6K–56K tokens/state, content not disclosed). No user-simulator or task/environment prompts modified; **no tasks omitted**.

### Notes for review
- Public **model name** ("Humains Nemotron-ultra Agent") differs from the agent label in the trajectories (`humains-bcortex-cloud`) — expect a benign name-mismatch warning.
- **`cost` omitted** (local serving path not metered).
- `manifest.json` updated: added the submission dir to `submissions`.

---

### Baseline comparison (NVIDIA-published figure)

This submission is about the **agent layer**, not the base model. Reference point is NVIDIA's own published τ³ airline figure for the same base LLM (`nvidia/nemotron-3-ultra-550b-a55b`):

| System | τ³ Airline | Source |
| --- | --- | --- |
| Nemotron-3-Ultra (NVIDIA eval, BF16) | 81.5 | NVIDIA model card |
| **Humains Nemotron-ultra Agent** | **85.0 (pass^1)** | this submission |

Same base LLM; the agent layer is the only thing that changes. Lift from the Humains cognitive architecture: **≥ +3.5 pts** vs NVIDIA's highest published airline figure.

**Caveats (stated for transparency):**
- We anchor to NVIDIA's **BF16** figure (their highest published airline result, 81.5), so the lift is a conservative floor. Our base LLM was served via Together AI at undisclosed precision; since NVIDIA's lower-precision (NVFP4) airline result is *below* BF16, any such serving would only widen the true lift.
- NVIDIA's τ³ numbers come from their own (not-yet-open-sourced) scaffolding via the NeMo Evaluator SDK; the user simulator, trial count, and exact metric definition are not disclosed. This is a comparison against NVIDIA's **published figure**, not a controlled same-harness ablation.
- Our number is **pass^1** over the τ³ airline base split (50 tasks × 4 trials), user simulator `gpt-5.2` (reasoning_effort=low), seed 17000. Full reliability curve: 85.0 / 76.7 / 70.0 / 64.0.
- A controlled baseline (identical harness + user-sim, standard scaffold vs Humains agent) is the clean isolation and is planned as a follow-up.
