### PR TITLE
Add gpt-realtime-2 to voice leaderboard (custom: gpt-5.5 xhigh user sim)

### DIFF
--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -260,7 +260,7 @@ def add_run_args(parser):
     parser.add_argument(
         "--reasoning-effort",
         type=str,
-        choices=["minimal", "low", "medium", "high"],
+        choices=["minimal", "low", "medium", "high", "xhigh"],
         default=None,
         help="Reasoning effort for thinking models. Only applies to providers that support it (e.g. OpenAI).",
     )

--- a/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
@@ -11,15 +11,16 @@
   },
   "results": {
     "retail": {
-      "pass_1": 0.0
+      "pass_1": 47.36842105263158
     },
     "airline": {
-      "pass_1": 0.0
+      "pass_1": 58.0
     },
     "telecom": {
-      "pass_1": 0.0
+      "pass_1": 21.92982456140351
     }
   },
+  "reasoning_effort": "xhigh",
   "is_new": true,
   "trajectories_available": true,
   "trajectory_files": {

--- a/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
@@ -1,0 +1,51 @@
+{
+  "model_name": "gpt-realtime-2",
+  "model_organization": "OpenAI",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-06-24",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "victor@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 0.0
+    },
+    "airline": {
+      "pass_1": 0.0
+    },
+    "telecom": {
+      "pass_1": 0.0
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_regular_openai_gpt-realtime-2",
+    "retail": "retail_regular_openai_gpt-realtime-2",
+    "telecom": "telecom_regular_openai_gpt-realtime-2"
+  },
+  "methodology": {
+    "evaluation_date": "2026-06-24",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "v1.0",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "OpenAI",
+    "model": "gpt-realtime-2",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "model_release": {
+    "release_date": "2026-05-07",
+    "announcement_url": "https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/",
+    "announcement_title": "Advancing voice intelligence with new models in the API"
+  }
+}

--- a/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
@@ -6,7 +6,7 @@
   "submission_type": "custom",
   "modality": "voice",
   "contact_info": {
-    "email": "victor@sierra.ai",
+    "email": "soham@sierra.ai",
     "name": "Sierra Research Team"
   },
   "results": {

--- a/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
@@ -24,9 +24,9 @@
   "is_new": true,
   "trajectories_available": true,
   "trajectory_files": {
-    "airline": "airline_regular_openai_gpt-realtime-2_usersim-gpt-5.5-xhigh",
-    "retail": "retail_regular_openai_gpt-realtime-2_usersim-gpt-5.5-xhigh",
-    "telecom": "telecom_regular_openai_gpt-realtime-2_usersim-gpt-5.5-xhigh"
+    "airline": "gpt-realtime-2_voice_xhigh_usersim-gpt55xhigh_airline",
+    "retail": "gpt-realtime-2_voice_xhigh_usersim-gpt55xhigh_retail",
+    "telecom": "gpt-realtime-2_voice_xhigh_usersim-gpt55_telecom"
   },
   "methodology": {
     "evaluation_date": "2026-06-29",

--- a/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
@@ -2,8 +2,8 @@
   "model_name": "gpt-realtime-2",
   "model_organization": "OpenAI",
   "submitting_organization": "Sierra",
-  "submission_date": "2026-06-24",
-  "submission_type": "standard",
+  "submission_date": "2026-06-29",
+  "submission_type": "custom",
   "modality": "voice",
   "contact_info": {
     "email": "victor@sierra.ai",
@@ -11,27 +11,28 @@
   },
   "results": {
     "retail": {
-      "pass_1": 47.36842105263158
+      "pass_1": 50.0
     },
     "airline": {
-      "pass_1": 58.0
+      "pass_1": 66.0
     },
     "telecom": {
-      "pass_1": 21.92982456140351
+      "pass_1": 37.719298245614034
     }
   },
   "reasoning_effort": "xhigh",
   "is_new": true,
   "trajectories_available": true,
   "trajectory_files": {
-    "airline": "airline_regular_openai_gpt-realtime-2",
-    "retail": "retail_regular_openai_gpt-realtime-2",
-    "telecom": "telecom_regular_openai_gpt-realtime-2"
+    "airline": "airline_regular_openai_gpt-realtime-2_usersim-gpt-5.5-xhigh",
+    "retail": "retail_regular_openai_gpt-realtime-2_usersim-gpt-5.5-xhigh",
+    "telecom": "telecom_regular_openai_gpt-realtime-2_usersim-gpt-5.5-xhigh"
   },
   "methodology": {
-    "evaluation_date": "2026-06-24",
+    "evaluation_date": "2026-06-29",
     "tau2_bench_version": "1.0.0",
-    "user_simulator": "v1.0",
+    "user_simulator": "gpt-5.5-2026-04-23 (reasoning_effort=xhigh) — non-standard custom user simulator (the standard voice user simulator is v1.0 / gpt-4.1)",
+    "notes": "Custom submission: identical to the standard gpt-realtime-2 voice evaluation (audio-native, regular speech complexity, ElevenLabs eleven_v3 TTS, agent reasoning_effort=xhigh) EXCEPT the user simulator LLM is gpt-5.5-2026-04-23 run at reasoning_effort=xhigh instead of the leaderboard-standard v1.0 (gpt-4.1). Because telecom's user simulator uses function tools, gpt-5.5 rejects reasoning_effort=none with tools, so all domains use xhigh for consistency. Not comparable to standard-user-simulator leaderboard entries.",
     "verification": {
       "modified_prompts": false,
       "omitted_questions": false

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -28,7 +28,8 @@
     "gemini-3-1-flash-live-preview-thinking-high_google_2026-04-02",
     "gemini-3-1-flash-live-preview-thinking-minimal_google_2026-04-13",
     "gpt-realtime-1-0_openai_2026-04-13",
-    "livekit-cascaded_livekit_2026-05-19"
+    "livekit-cascaded_livekit_2026-05-19",
+    "gpt-realtime-2_openai_2026-06-24"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",


### PR DESCRIPTION
## Summary
Adds OpenAI **gpt-realtime-2** to the **voice** leaderboard as a **custom** submission. The agent is the standard audio-native gpt-realtime-2 (reasoning_effort=xhigh); the only deviation from a standard run is the **user simulator**, which is **gpt-5.5-2026-04-23 at reasoning_effort=xhigh** instead of the leaderboard-standard v1.0 (gpt-4.1). Marked `submission_type: custom`, so it renders in the leaderboard's custom section.

### Model
- API id: `gpt-realtime-2`
- Announced 2026-05-07 — [Advancing voice intelligence with new models in the API](https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/)
- Configurable reasoning effort (normal/high/xhigh); evaluated at xhigh

### Results (Pass^1, regular speech complexity, custom gpt-5.5-xhigh user simulator)
| Domain | gpt-realtime-2 (custom) |
|---|---|
| retail | **50.00%** |
| airline | **66.00%** |
| telecom | **37.72%** |

### Why custom
The user simulator is non-standard (gpt-5.5 xhigh, not the pinned v1.0/gpt-4.1). Because telecom's user simulator uses function tools, gpt-5.5 rejects `reasoning_effort=none` with tools, so all three domains use **xhigh** for consistency. These numbers are **not comparable** to standard-user-simulator leaderboard entries.

### Run configuration
- Agent: gpt-realtime-2, `reasoning_effort=xhigh`
- User simulator: **gpt-5.5-2026-04-23, `reasoning_effort=xhigh`** (custom; standard is v1.0/gpt-4.1), ElevenLabs `eleven_v3` TTS
- `max_steps_seconds=1200`, `tick_duration=0.2`, `--max-concurrency 10`, pass^1
- Full task sets: retail 114, airline 50, telecom 114

> Note: OpenAI audio-native requires no Deepgram — it uses provider-supplied transcripts plus in-session `gpt-4o-transcribe`.

## Status
- [x] retail / airline / telecom pass^1 scores (custom user sim)
- [x] submission_type: custom + reasoning_effort + evaluation_date
- [x] schema validation passes
- [ ] trajectory data link (uploaded to S3 by maintainer after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)