### PR TITLE
Fix gpt-realtime-2 voice user_simulator label rendering

### DIFF
--- a/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-24/submission.json
@@ -31,7 +31,7 @@
   "methodology": {
     "evaluation_date": "2026-06-29",
     "tau2_bench_version": "1.0.0",
-    "user_simulator": "gpt-5.5-2026-04-23 (reasoning_effort=xhigh) — non-standard custom user simulator (the standard voice user simulator is v1.0 / gpt-4.1)",
+    "user_simulator": "gpt-5.5-2026-04-23 (xhigh)",
     "notes": "Custom submission: identical to the standard gpt-realtime-2 voice evaluation (audio-native, regular speech complexity, ElevenLabs eleven_v3 TTS, agent reasoning_effort=xhigh) EXCEPT the user simulator LLM is gpt-5.5-2026-04-23 run at reasoning_effort=xhigh instead of the leaderboard-standard v1.0 (gpt-4.1). Because telecom's user simulator uses function tools, gpt-5.5 rejects reasoning_effort=none with tools, so all domains use xhigh for consistency. Not comparable to standard-user-simulator leaderboard entries.",
     "verification": {
       "modified_prompts": false,


### PR DESCRIPTION
## Summary
Follow-up to #369. The custom gpt-realtime-2 voice submission's `methodology.user_simulator` field held a long sentence, which the leaderboard rendered as a multi-line paragraph in the user-simulator column (looked broken).

Shortens it to a concise label — **`gpt-5.5-2026-04-23 (xhigh)`** — that fits the column. No information is lost: the full explanation of the non-standard custom user simulator (gpt-5.5 xhigh vs the standard v1.0/gpt-4.1, and the telecom tools/xhigh rationale) already lives in `methodology.notes`.

Before:
> `gpt-5.5-2026-04-23 (reasoning_effort=xhigh) — non-standard custom user simulator (the standard voice user simulator is v1.0 / gpt-4.1)`

After:
> `gpt-5.5-2026-04-23 (xhigh)`

Schema validation passes. Submission scores and trajectories are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)