### PR TITLE
Add gpt-realtime-2 standard voice submission (gpt-4.1 v1.0 user sim)

### DIFF
--- a/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-29/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2_openai_2026-06-29/submission.json
@@ -1,0 +1,52 @@
+{
+  "model_name": "gpt-realtime-2",
+  "model_organization": "OpenAI",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-06-29",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "soham@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 47.368421052631575
+    },
+    "airline": {
+      "pass_1": 57.99999999999999
+    },
+    "telecom": {
+      "pass_1": 21.929824561403507
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "gpt-realtime-2_voice_xhigh_airline",
+    "retail": "gpt-realtime-2_voice_xhigh_retail",
+    "telecom": "gpt-realtime-2_voice_xhigh_telecom"
+  },
+  "methodology": {
+    "evaluation_date": "2026-06-24",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "v1.0",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "openai",
+    "model": "gpt-realtime-2",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "model_release": {
+    "release_date": "2026-05-07",
+    "announcement_url": "https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/",
+    "announcement_title": "Advancing voice intelligence with new models in the API"
+  },
+  "reasoning_effort": "xhigh"
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -30,7 +30,8 @@
     "gemini-3-1-flash-live-preview-thinking-minimal_google_2026-04-13",
     "gpt-realtime-1-0_openai_2026-04-13",
     "livekit-cascaded_livekit_2026-05-19",
-    "gpt-realtime-2_openai_2026-06-24"
+    "gpt-realtime-2_openai_2026-06-24",
+    "gpt-realtime-2_openai_2026-06-29"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",

--- a/web/leaderboard/src/components/TrajectoryVisualizer.jsx
+++ b/web/leaderboard/src/components/TrajectoryVisualizer.jsx
@@ -152,6 +152,8 @@ const TrajectoryVisualizer = () => {
                 model_name: sub.model_name,
                 model_organization: sub.model_organization || '',
                 reasoning_effort: sub.reasoning_effort || null,
+                submission_type: sub.submission_type || 'standard',
+                user_simulator: sub.methodology?.user_simulator || null,
                 trajectory_files: sub.trajectory_files,
                 availableDomains: Object.keys(sub.trajectory_files),
                 modality,
@@ -576,7 +578,7 @@ const TrajectoryVisualizer = () => {
                   <optgroup label="τ-voice (Voice)">
                     {submissions.filter(s => s.modality === 'voice').map(s => (
                       <option key={s.dir} value={s.dir}>
-                        {s.model_name} ({s.model_organization})
+                        {s.model_name} ({s.model_organization}){s.submission_type === 'custom' ? ' [Custom]' : ''}{s.user_simulator ? ` — user sim: ${s.user_simulator}` : ''}
                       </option>
                     ))}
                   </optgroup>

--- a/web/leaderboard/src/components/TrajectoryVisualizer.jsx
+++ b/web/leaderboard/src/components/TrajectoryVisualizer.jsx
@@ -578,7 +578,7 @@ const TrajectoryVisualizer = () => {
                   <optgroup label="τ-voice (Voice)">
                     {submissions.filter(s => s.modality === 'voice').map(s => (
                       <option key={s.dir} value={s.dir}>
-                        {s.model_name} ({s.model_organization}){s.submission_type === 'custom' ? ' [Custom]' : ''}{s.user_simulator ? ` — user sim: ${s.user_simulator}` : ''}
+                        {s.model_name} ({s.model_organization}){s.submission_type === 'custom' ? ` [Custom]${s.user_simulator ? ` — user sim: ${s.user_simulator}` : ''}` : ''}
                       </option>
                     ))}
                   </optgroup>


### PR DESCRIPTION
## Summary
Adds the **standard** gpt-realtime-2 voice submission — companion to the custom gpt-5.5 entry (#369). Same agent (gpt-realtime-2, `reasoning_effort=xhigh`, audio-native, regular speech complexity), evaluated with the **leaderboard-standard voice user simulator v1.0 (gpt-4.1)**.

### Results (Pass^1)
| Domain | gpt-realtime-2 (standard) | gpt-realtime-1.0 |
|---|---|---|
| retail | **47.37%** | 35.96% |
| airline | **58.00%** | 36.00% |
| telecom | **21.93%** | 19.30% |

### Run configuration
- Agent: gpt-realtime-2, `reasoning_effort=xhigh`
- User simulator: **v1.0** (gpt-4.1-2025-04-14), ElevenLabs `eleven_v3` TTS
- `max_steps_seconds=1200`, `tick_duration=0.2`, `--max-concurrency 10`, pass^1
- Full task sets: retail 114, airline 50, telecom 114

### Trajectories
Uploaded to S3 under `submissions/gpt-realtime-2_openai_2026-06-29/trajectories/` (per-domain `results.json` + `simulations/` + `artifacts/` audio).

## Notes
This is the `submission_type: standard` entry; the existing `gpt-realtime-2_openai_2026-06-24` entry is the `custom` (gpt-5.5 xhigh user-sim) variant. Both share `model_name: gpt-realtime-2` and render in their respective leaderboard sections.

## Status
- [x] retail / airline / telecom pass^1 (standard v1.0 user sim)
- [x] manifest updated (voice_submissions)
- [x] schema validation passes
- [x] trajectories uploaded to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)