### PR TITLE
Add gpt-realtime-2 minimal voice submission (standard, gpt-4.1 v1.0 user sim)

### DIFF
--- a/web/leaderboard/public/submissions/gpt-realtime-2-minimal_openai_2026-07-01/submission.json
+++ b/web/leaderboard/public/submissions/gpt-realtime-2-minimal_openai_2026-07-01/submission.json
@@ -1,0 +1,52 @@
+{
+  "model_name": "gpt-realtime-2",
+  "model_organization": "OpenAI",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-07-01",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "soham@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 39.473684210526315
+    },
+    "airline": {
+      "pass_1": 56.00000000000001
+    },
+    "telecom": {
+      "pass_1": 20.175438596491226
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "gpt-realtime-2_voice_minimal_airline",
+    "retail": "gpt-realtime-2_voice_minimal_retail",
+    "telecom": "gpt-realtime-2_voice_minimal_telecom"
+  },
+  "methodology": {
+    "evaluation_date": "2026-07-01",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "v1.0",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "openai",
+    "model": "gpt-realtime-2",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "model_release": {
+    "release_date": "2026-05-07",
+    "announcement_url": "https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/",
+    "announcement_title": "Advancing voice intelligence with new models in the API"
+  },
+  "reasoning_effort": "minimal"
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -30,7 +30,8 @@
     "gemini-3-1-flash-live-preview-thinking-minimal_google_2026-04-13",
     "gpt-realtime-1-0_openai_2026-04-13",
     "livekit-cascaded_livekit_2026-05-19",
-    "gpt-realtime-2_openai_2026-06-24"
+    "gpt-realtime-2_openai_2026-06-24",
+    "gpt-realtime-2-minimal_openai_2026-07-01"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",


### PR DESCRIPTION
## Summary
Adds the **minimal-reasoning** standard voice submission for gpt-realtime-2 — a reasoning-effort variant of the xhigh standard entry (#378). Same agent (gpt-realtime-2, audio-native, regular speech complexity) and the **leaderboard-standard voice user simulator v1.0 (gpt-4.1-2025-04-14)**; only the agent `reasoning_effort` differs (**minimal** vs xhigh).

Follows the established `gpt-5.2` / `gpt-5-2-none` convention: same `model_name`, distinguished by the `reasoning_effort` field.

### Results (Pass^1, standard v1.0 user sim)
| Domain | minimal | xhigh (ref, #378) |
|---|---|---|
| retail | **39.47%** | 47.37% |
| airline | **56.00%** | 58.00% |
| telecom | **20.18%** | 21.93% |

### Run configuration
- Agent: gpt-realtime-2, `reasoning_effort=minimal`
- User simulator: **v1.0** (gpt-4.1-2025-04-14), ElevenLabs `eleven_v3` TTS
- `max_steps_seconds=1200`, `tick_duration=0.2`, `--max-concurrency 10`, pass^1
- Full task sets: retail 114, airline 50, telecom 114

### Trajectories
Uploaded to S3 under `submissions/gpt-realtime-2-minimal_openai_2026-07-01/trajectories/`.

## Notes
- `submission_type: standard`, `reasoning_effort: minimal`. `model_name` stays `gpt-realtime-2`; the leaderboard's reasoning-effort column distinguishes this from the xhigh standard entry.
- Depends on / complements #378 (the xhigh standard entry). Both append to `voice_submissions`, so a trivial manifest rebase may be needed depending on merge order.

## Status
- [x] retail / airline / telecom pass^1 (standard v1.0 user sim, minimal reasoning)
- [x] manifest updated (voice_submissions)
- [x] schema validation passes
- [x] trajectories uploaded to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)