### PR TITLE
fix: disambiguate banking duplicate transactions

### DIFF
--- a/data/tau2/domains/banking_knowledge/tasks.json
+++ b/data/tau2/domains/banking_knowledge/tasks.json
@@ -11629,7 +11629,8 @@
                 "description": "AUSTIN COFFEE ROASTERS",
                 "amount": -67.25,
                 "type": "debit_card_purchase",
-                "status": "posted"
+                "status": "posted",
+                "posting_sequence": 2
               },
               "btxn_d937eaa1d21d": {
                 "transaction_id": "btxn_d937eaa1d21d",
@@ -11638,7 +11639,8 @@
                 "description": "AUSTIN COFFEE ROASTERS",
                 "amount": -67.25,
                 "type": "debit_card_purchase",
-                "status": "posted"
+                "status": "posted",
+                "posting_sequence": 1
               },
               "btxn_1c520c1a1fc9": {
                 "transaction_id": "btxn_1c520c1a1fc9",
@@ -11892,7 +11894,8 @@
                 "description": "BELLAS BISTRO CHICAGO IL",
                 "amount": -47.5,
                 "type": "debit_card_purchase",
-                "status": "posted"
+                "status": "posted",
+                "posting_sequence": 2
               },
               "btxn_e8c3b09d2c45": {
                 "transaction_id": "btxn_e8c3b09d2c45",
@@ -11901,7 +11904,8 @@
                 "description": "BELLAS BISTRO CHICAGO IL",
                 "amount": -47.5,
                 "type": "debit_card_purchase",
-                "status": "posted"
+                "status": "posted",
+                "posting_sequence": 1
               },
               "btxn_f9d4c10e3d56": {
                 "transaction_id": "btxn_f9d4c10e3d56",

--- a/data/tau2/domains/banking_knowledge/tasks/task_083.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_083.json
@@ -236,7 +236,8 @@
               "description": "AUSTIN COFFEE ROASTERS",
               "amount": -67.25,
               "type": "debit_card_purchase",
-              "status": "posted"
+              "status": "posted",
+              "posting_sequence": 2
             },
             "btxn_d937eaa1d21d": {
               "transaction_id": "btxn_d937eaa1d21d",
@@ -245,7 +246,8 @@
               "description": "AUSTIN COFFEE ROASTERS",
               "amount": -67.25,
               "type": "debit_card_purchase",
-              "status": "posted"
+              "status": "posted",
+              "posting_sequence": 1
             },
             "btxn_1c520c1a1fc9": {
               "transaction_id": "btxn_1c520c1a1fc9",

--- a/data/tau2/domains/banking_knowledge/tasks/task_084.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_084.json
@@ -119,7 +119,8 @@
               "description": "BELLAS BISTRO CHICAGO IL",
               "amount": -47.5,
               "type": "debit_card_purchase",
-              "status": "posted"
+              "status": "posted",
+              "posting_sequence": 2
             },
             "btxn_e8c3b09d2c45": {
               "transaction_id": "btxn_e8c3b09d2c45",
@@ -128,7 +129,8 @@
               "description": "BELLAS BISTRO CHICAGO IL",
               "amount": -47.5,
               "type": "debit_card_purchase",
-              "status": "posted"
+              "status": "posted",
+              "posting_sequence": 1
             },
             "btxn_f9d4c10e3d56": {
               "transaction_id": "btxn_f9d4c10e3d56",

--- a/tests/test_domains/test_banking_knowledge/test_task_data_regressions.py
+++ b/tests/test_domains/test_banking_knowledge/test_task_data_regressions.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+BANKING_DATA_DIR = Path("data/tau2/domains/banking_knowledge")
+
+
+def _load_task(task_id: str, source: Path) -> dict:
+    with source.open() as fp:
+        data = json.load(fp)
+
+    if isinstance(data, list):
+        return next(task for task in data if task["id"] == task_id)
+    return data
+
+
+def _duplicate_dispute_transaction_id(task: dict) -> str:
+    for action in task["evaluation_criteria"]["actions"]:
+        if action["name"] != "call_discoverable_agent_tool":
+            continue
+        args = action["arguments"]
+        if args["agent_tool_name"] != "file_debit_card_transaction_dispute_6281":
+            continue
+        dispute_args = json.loads(args["arguments"])
+        if dispute_args["dispute_category"] == "duplicate_charge":
+            return dispute_args["transaction_id"]
+
+    raise AssertionError("Task has no duplicate_charge dispute action")
+
+
+def _transactions(task: dict) -> dict:
+    return task["initial_state"]["initialization_data"]["agent_data"][
+        "bank_account_transaction_history"
+    ]["data"]
+
+
+def _matching_duplicate_transactions(
+    task: dict, *, description: str, date: str, amount: float
+) -> list[dict]:
+    return [
+        transaction
+        for transaction in _transactions(task).values()
+        if transaction["description"] == description
+        and transaction["date"] == date
+        and transaction["amount"] == amount
+    ]
+
+
+def test_duplicate_charge_gold_transactions_have_observable_ordering():
+    cases = [
+        (
+            "task_083",
+            "AUSTIN COFFEE ROASTERS",
+            "11/11/2025",
+            -67.25,
+        ),
+        (
+            "task_084",
+            "BELLAS BISTRO CHICAGO IL",
+            "11/06/2025",
+            -47.5,
+        ),
+    ]
+    sources = [
+        BANKING_DATA_DIR / "tasks.json",
+        BANKING_DATA_DIR / "tasks" / "task_083.json",
+        BANKING_DATA_DIR / "tasks" / "task_084.json",
+    ]
+
+    for task_id, description, date, amount in cases:
+        for source in sources:
+            if source.name.startswith("task_") and source.stem != task_id:
+                continue
+
+            task = _load_task(task_id, source)
+            duplicate_transactions = _matching_duplicate_transactions(
+                task, description=description, date=date, amount=amount
+            )
+
+            assert len(duplicate_transactions) == 2
+            assert all(
+                "posting_sequence" in transaction
+                for transaction in duplicate_transactions
+            )
+
+            sequences = {
+                transaction["posting_sequence"] for transaction in duplicate_transactions
+            }
+            assert len(sequences) == len(duplicate_transactions)
+
+            earliest_transaction = min(
+                duplicate_transactions,
+                key=lambda transaction: transaction["posting_sequence"],
+            )
+            assert _duplicate_dispute_transaction_id(task) == earliest_transaction[
+                "transaction_id"
+            ]


### PR DESCRIPTION
## Summary

Addresses the duplicate-transaction portion of #371 for banking_knowledge tasks `task_083` and `task_084`.

The policy says to dispute the earliest transaction when duplicate charges exist, but these task fixtures previously had duplicate records with identical date, merchant, amount, type, and status. This made the gold `transaction_id` underdetermined from the data exposed to the agent.

## Changes Made

- Added `posting_sequence` to the duplicate transaction pairs in:
  - `data/tau2/domains/banking_knowledge/tasks/task_083.json`
  - `data/tau2/domains/banking_knowledge/tasks/task_084.json`
  - mirrored aggregate `data/tau2/domains/banking_knowledge/tasks.json`
- Preserved the existing gold `transaction_id` choices by assigning them `posting_sequence: 1`.
- Added a regression test asserting duplicate-charge tasks expose a unique ordering signal and that the gold dispute uses the earliest duplicate.

## Testing

- `PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/test_domains/test_banking_knowledge/test_task_data_regressions.py -q`  
  Result: `1 passed`
- `PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/test_domains/test_banking_knowledge/test_task_data_regressions.py tests/test_domains/test_banking_knowledge/test_tools_knowledge.py -q`  
  Result: `205 passed`
- `PYTHONPATH=$PWD/src .venv/bin/python -m pytest tests/test_domains/test_banking_knowledge/tasks -q`  
  Result: `28 passed`
- `make lint`  
  Result: `All checks passed!`

I also ran `make test-knowledge`; it reached `506 passed, 50 skipped`, with one failure in `tests/test_domains/test_banking_knowledge/test_retrieval_e2e.py::TestAllVariantsToolPresence::test_all_variants_table_matches_registry` because registered variant `alltools-qwen` is missing from `_ALL_VARIANTS`. This PR does not touch retrieval variants or that test, so I left that pre-existing registry/test drift out of scope.

## Notes

This intentionally does not attempt to solve every ambiguity listed in #371. It keeps the change narrow to the two duplicate-charge fixtures where the policy already defines a tie-breaker, but the fixture data did not expose one.
