### PR TITLE
fix: secure second debit card in task 82

### DIFF
--- a/data/tau2/domains/banking_knowledge/tasks.json
+++ b/data/tau2/domains/banking_knowledge/tasks.json
@@ -11365,6 +11365,24 @@
           },
           "requestor": "assistant",
           "action_id": "082_14"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "close_debit_card_4721",
+            "arguments": "{\"card_id\": \"dbc_mc47a2b9e1_gff\", \"reason\": \"fraud_suspected\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "082_15"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "order_debit_card_5739",
+            "arguments": "{\"account_id\": \"chk_mc47a2b9e1_gff\", \"user_id\": \"mc47a2b9e1\", \"delivery_option\": \"STANDARD\", \"delivery_fee\": 0, \"card_design\": \"CLASSIC\", \"design_fee\": 0, \"shipping_address\": \"1847 Pine Street, Seattle, WA 98101\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "082_16"
         }
       ],
       "reward_basis": [

--- a/data/tau2/domains/banking_knowledge/tasks/task_082.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_082.json
@@ -401,6 +401,24 @@
         },
         "requestor": "assistant",
         "action_id": "082_14"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "close_debit_card_4721",
+          "arguments": "{\"card_id\": \"dbc_mc47a2b9e1_gff\", \"reason\": \"fraud_suspected\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "082_15"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "order_debit_card_5739",
+          "arguments": "{\"account_id\": \"chk_mc47a2b9e1_gff\", \"user_id\": \"mc47a2b9e1\", \"delivery_option\": \"STANDARD\", \"delivery_fee\": 0, \"card_design\": \"CLASSIC\", \"design_fee\": 0, \"shipping_address\": \"1847 Pine Street, Seattle, WA 98101\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "082_16"
       }
     ],
     "reward_basis": [

--- a/tests/test_domains/test_banking_knowledge/tasks/test_task_082.py
+++ b/tests/test_domains/test_banking_knowledge/tasks/test_task_082.py
@@ -1,0 +1,75 @@
+"""Regression tests for banking_knowledge task_082."""
+
+import json
+from pathlib import Path
+
+from tau2.data_model.message import ToolCall
+from tau2.domains.banking_knowledge.data_model import TransactionalDB
+from tau2.environment.environment import Environment
+
+from .conftest import create_environment
+
+TASK_PATH = (
+    Path(__file__).parents[4]
+    / "data/tau2/domains/banking_knowledge/tasks/task_082.json"
+)
+
+
+def _load_task_082() -> dict:
+    with TASK_PATH.open() as fp:
+        return json.load(fp)
+
+
+def _create_task_082_environment() -> Environment:
+    task = _load_task_082()
+    db_data = task["initial_state"]["initialization_data"]["agent_data"]
+    return create_environment(TransactionalDB.model_validate(db_data))
+
+
+def _run_gold_actions(environment: Environment, task: dict) -> None:
+    for action in task["evaluation_criteria"]["actions"]:
+        response = environment.get_response(
+            ToolCall(
+                id=action["action_id"],
+                name=action["name"],
+                arguments=action["arguments"],
+                requestor=action.get("requestor", "assistant"),
+            )
+        )
+        assert not response.error, f"{action['action_id']} failed: {response.content}"
+
+
+class TestTask082:
+    """Tests for T082's multi-card debit dispute remediation."""
+
+    def test_close_and_reissue_disputes_secure_each_affected_debit_card(self):
+        task = _load_task_082()
+        environment = _create_task_082_environment()
+
+        _run_gold_actions(environment, task)
+
+        db = environment.tools.db
+        close_and_reissue_card_ids = {
+            dispute["card_id"]
+            for dispute in db.debit_card_disputes.data.values()
+            if dispute["card_action"] == "close_and_reissue"
+        }
+        closed_card_ids = {
+            card_id
+            for card_id, card in db.debit_cards.data.items()
+            if card.get("status") == "CLOSED"
+        }
+        ordered_account_ids = {
+            order["account_id"] for order in db.debit_card_orders.data.values()
+        }
+        reissued_card_account_ids = {
+            db.debit_cards.data[card_id]["account_id"]
+            for card_id in close_and_reissue_card_ids
+        }
+
+        assert close_and_reissue_card_ids == {
+            "dbc_mc47a2b9e1_blue",
+            "dbc_mc47a2b9e1_gff",
+        }
+        assert close_and_reissue_card_ids <= closed_card_ids
+        assert reissued_card_account_ids <= ordered_account_ids


### PR DESCRIPTION
## Summary

Fixes #372.

T082 files four debit disputes across two debit cards. Two of those disputes have `card_action: close_and_reissue`: the Blue Account card and the Green Fee-Free card. The gold trajectory already closed and replaced the Blue card, but left the Green Fee-Free card active after a `card_not_present_fraud` dispute.

This updates the T082 gold trajectory to also close the Green Fee-Free debit card with `fraud_suspected` and order a replacement card for its account.

## Why

The banking policy maps both `card_present_fraud` and `card_not_present_fraud` to `close_and_reissue`, and notes that the `card_action` argument records metadata only; the agent must still perform the indicated card action separately. Because the Green Fee-Free card online fraud dispute already records `close_and_reissue`, the gold action sequence should perform the corresponding close/order steps for that card too.

## Tests

- `uv run --extra dev --extra knowledge pytest tests/test_domains/test_banking_knowledge/tasks/test_task_082.py tests/test_domains/test_banking_knowledge/tasks tests/test_domains/test_banking_knowledge/test_tools_knowledge.py -q`
- `uv run --extra dev --extra knowledge tau2 check-data`
- `uv run --extra dev --extra knowledge ruff format --check tests/test_domains/test_banking_knowledge/tasks/test_task_082.py`
- `uv run --extra dev --extra knowledge ruff check tests/test_domains/test_banking_knowledge/tasks/test_task_082.py`