### PR TITLE
[banking_knowledge] Fix contradictory cash-back rate in doc_credit_cards_platinum_rewards_card_002 (title said 4%, content/DB say 10%)

### DIFF
--- a/data/tau2/domains/banking_knowledge/documents/doc_credit_cards_platinum_rewards_card_002.json
+++ b/data/tau2/domains/banking_knowledge/documents/doc_credit_cards_platinum_rewards_card_002.json
@@ -1,5 +1,5 @@
 {
   "id": "doc_credit_cards_platinum_rewards_card_002",
-  "title": "Platinum Rewards Card: Earning 4% Cash Back",
+  "title": "Platinum Rewards Card: Earning 10% Cash Back",
   "content": "## How You Earn\n- You earn 10.0% cash back on all eligible purchases.\n- Returns or credits reduce previously earned rewards on a per-transaction basis.\n\n## Eligible and Ineligible Transactions\n- Eligible: point-of-sale and online purchases posted to your account.\n- Not eligible: cash advances, balance transfers, fees, interest, and other cash-equivalent transactions.\n\n## Posting Timeline\n- Rewards accrue when transactions post to your account and typically become available after the purchase posts and clears any return window.\n\n## Redeeming Your Rewards\n- You can redeem once your available rewards balance reaches at least $15.\n- Common redemption options include statement credits or other available channels in your account dashboard.\n\n## Tips to Maximize Earnings\n- Use the card for everyday spend to capture 10.0% on all categories.\n- Set the card as your default payment at frequently used merchants.\n- Consider your net rewards after the $200.00 annual fee when planning large purchases."
 }


### PR DESCRIPTION
## What

One-line fix in the `banking_knowledge` domain: change the title of `doc_credit_cards_platinum_rewards_card_002.json` from **"Earning 4% Cash Back"** to **"Earning 10% Cash Back"** so it matches the document's own content.

## Why

The document currently contradicts itself — the title says **4%**, while the content says **10.0%** (twice):

```json
{
  "id": "doc_credit_cards_platinum_rewards_card_002",
  "title": "Platinum Rewards Card: Earning 4% Cash Back",
  "content": "## How You Earn\n- You earn 10.0% cash back on all eligible purchases.\n...
              - Use the card for everyday spend to capture 10.0% on all categories.\n..."
}
```

This is the only document in the corpus that states a cash-back rate for the (consumer) Platinum Rewards Card, so nothing else in the knowledge base disambiguates it.

### Evidence that 10% is the intended value

`db.json` → `credit_card_transaction_history` encodes rewards at a fixed points-per-dollar rate per card, where points-per-dollar matches the documented percentage (1 point = $0.01). E.g. Gold Rewards Card transactions earn 2.5 pts/$, matching its documented 2.5% rate (`txn_8d1aa1219382`: $156.78 → 391 points).

For the Platinum Rewards Card, **60 of 63 transactions earn exactly 10 pts/$** (e.g. `txn_3b2b6a3f7420`: $424.45 → 4244 points), i.e. 10%, matching the document content and not the title. (The remaining 3, all belonging to user `c7d8e9f0a1`, earn 1 pt/$ and appear to be deliberately planted anomalies.)

```python
import json, re
db = json.load(open("data/tau2/domains/banking_knowledge/db.json"))
for t in db["credit_card_transaction_history"]["data"].values():
    if t["credit_card_type"] == "Platinum Rewards Card":
        amt = float(t["transaction_amount"].strip("$").replace(",", ""))
        pts = float(re.match(r"[\d.]+", t["rewards_earned"]).group())
        print(t["transaction_id"], round(pts / amt, 1))  # -> 10.0 for 60/63 txns
```

The stray "4%" likely came from the parallel *Business* Platinum Rewards Card doc (`doc_business_credit_cards_business_platinum_rewards_card_002.json`), which is titled "Earning 4% Cash Back" and is internally consistent (4.0% on travel/software/media in its content) — that one is untouched by this PR.

### Impact of the bug

The document is in `required_documents` for `task_002`, `task_023`, and `task_044`. In `task_002` specifically, the simulated user asks for "the card that gives you the highest cash back" and the expected action is applying for the Platinum Rewards Card, so agents reliably retrieve this document and quote a rate. Because title and body disagree, which figure the agent trusts is effectively arbitrary — in our runs, different harnesses/prompts consistently resolve the conflict in different directions (some report 4%, others 10%), adding noise that reflects the data contradiction rather than agent capability.

No task's ground truth depends on the 4% figure for this card (the "4%" mentions in `task_045`/`task_047` refer to the Business Platinum card), so this title fix is the minimal change that makes document, DB, and tasks mutually consistent. The alternative — making the rate 4% everywhere — would require regenerating `rewards_earned` for all Platinum Rewards Card transactions in `db.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
