### PR TITLE
Include reasoning content in message formatting

### DIFF
--- a/src/tau2/utils/llm_utils.py
+++ b/src/tau2/utils/llm_utils.py
@@ -195,6 +195,11 @@ def to_litellm_messages(messages: list[Message]) -> list[dict]:
                     "tool_calls": tool_calls,
                 }
             )
+            # add interleaved thinking content if exists
+            if message.raw_data is not None and message.raw_data.get("message") is not None:
+                reasoning_content = message.raw_data["message"].get("reasoning_content")
+                if reasoning_content:
+                    messages_formatted[-1]["reasoning_content"] = reasoning_content
         elif isinstance(message, ToolMessage):
             litellm_messages.append(
                 {


### PR DESCRIPTION
Add support for including reasoning content in formatted messages when available.  

This is essential for models with thinking capabilities (e.g., `glm-5.2`, `deepseek-v4`, `kimi-k2.6`, `qwen3.7-max`, etc.) to evaluate their full performance. Thanks for considering!