### PR TITLE
test: cover text imports without optional dependencies

### DIFF
--- a/tests/test_text_imports.py
+++ b/tests/test_text_imports.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_text_runner_imports_without_optional_dependencies():
+    project_root = Path(__file__).resolve().parents[1]
+    script = """
+import builtins
+
+real_import = builtins.__import__
+
+
+def guarded_import(name, *args, **kwargs):
+    if name.split('.', 1)[0] in {'rank_bm25', 'scipy'}:
+        raise ModuleNotFoundError(f'blocked optional dependency: {name}')
+    return real_import(name, *args, **kwargs)
+
+
+builtins.__import__ = guarded_import
+from tau2.runner import run_simulation
+
+assert run_simulation.__name__ == 'run_simulation'
+"""
+    subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        check=True,
+    )


### PR DESCRIPTION
## Summary

- add a subprocess regression for the core text runner import
- explicitly block `scipy` and `rank_bm25` so future eager optional imports fail the core test tier
- follow up on the import fix merged in #197

The failure is still reproducible on tag `v1.0.0`; current `main` passes after #197. This test prevents that boundary from regressing.

## Test plan

- `pytest tests/test_text_imports.py -q`
- `ruff check tests/test_text_imports.py`
- `ruff format --check tests/test_text_imports.py`