### PR TITLE
fix(evaluator): don't let one simulation's error abort a batch run (#387)

### DIFF
--- a/src/tau2/evaluator/evaluator.py
+++ b/src/tau2/evaluator/evaluator.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Optional
 
+from loguru import logger
+
 from tau2.data_model.simulation import RewardInfo, SimulationRun, TerminationReason
 from tau2.data_model.tasks import RewardType, Task
 from tau2.environment.toolkit import ToolType, get_tool_types
@@ -85,7 +87,76 @@ class EvaluationType(str, Enum):
     ALL_WITH_NL_ASSERTIONS_IGNORE_BASIS = "all_with_nl_assertions_ignore_basis"
 
 
+class EvaluationCriteriaError(ValueError):
+    """A task's ``reward_basis`` references a reward type the chosen
+    ``evaluation_type`` does not compute.
+
+    This signals a task/configuration error, not a per-simulation grading
+    failure, so ``evaluate_simulation`` re-raises it rather than swallowing it
+    in the graceful-degradation guard.
+    """
+
+
 def evaluate_simulation(
+    simulation: SimulationRun,
+    task: Task,
+    evaluation_type: EvaluationType,
+    solo_mode: bool,
+    domain: str,
+    mode: CommunicationMode = CommunicationMode.HALF_DUPLEX,
+    env_kwargs: dict = None,
+) -> RewardInfo:
+    """Evaluate a simulation, degrading gracefully on unexpected errors.
+
+    This is a thin guard around :func:`_evaluate_simulation`. Grading replays the
+    recorded trajectory against a fresh environment; if an environment tool is
+    non-deterministic (e.g. its result depends on wall-clock time), the replay can
+    diverge and raise. Such an exception would otherwise propagate out and abort an
+    entire multi-task run (see issue #387). Here it is caught and returned as a
+    ``reward=0.0`` result with the error recorded in ``info`` so a single bad
+    simulation cannot take down the batch. Genuine configuration errors
+    (:class:`EvaluationCriteriaError`) are re-raised so they still surface loudly.
+    """
+    try:
+        return _evaluate_simulation(
+            simulation=simulation,
+            task=task,
+            evaluation_type=evaluation_type,
+            solo_mode=solo_mode,
+            domain=domain,
+            mode=mode,
+            env_kwargs=env_kwargs,
+        )
+    except EvaluationCriteriaError:
+        raise
+    except Exception as e:
+        logger.warning(
+            f"Evaluation raised {type(e).__name__} for task "
+            f"{getattr(task, 'id', '<unknown>')}; grading as reward=0.0 to avoid "
+            f"aborting the run: {e}"
+        )
+        reward_basis = (
+            task.evaluation_criteria.reward_basis
+            if task.evaluation_criteria is not None
+            else None
+        )
+        return RewardInfo(
+            reward=0.0,
+            reward_basis=reward_basis,
+            info={
+                "error": f"{type(e).__name__}: {e}",
+                "note": (
+                    "Evaluation raised an unexpected exception and was graded as "
+                    "reward=0.0 so a single simulation cannot abort a batch run. "
+                    "This can happen when an environment tool is non-deterministic "
+                    "(e.g. time-dependent state) and replay-based grading diverges. "
+                    "See issue #387."
+                ),
+            },
+        )
+
+
+def _evaluate_simulation(
     simulation: SimulationRun,
     task: Task,
     evaluation_type: EvaluationType,
@@ -224,7 +295,7 @@ def evaluate_simulation(
             evaluated_bases |= nl_bases
         unevaluated = task_reward_basis - evaluated_bases
         if unevaluated:
-            raise ValueError(
+            raise EvaluationCriteriaError(
                 f"Task reward_basis includes {unevaluated} but these were "
                 f"not evaluated. evaluation_type={evaluation_type.value}"
             )

--- a/tests/test_evaluator_guard.py
+++ b/tests/test_evaluator_guard.py
@@ -1,0 +1,72 @@
+"""Regression tests for evaluate_simulation's graceful-degradation guard (issue #387).
+
+Replay-based grading can raise when an environment tool is non-deterministic
+(e.g. a dispute status that advances with wall-clock time), and that exception
+used to propagate out of ``evaluate_simulation`` and abort an entire batch run.
+These tests pin the contract of the guard without needing the retrieval/LLM
+stack: the inner implementation is monkeypatched to raise or return, and the
+public wrapper's behavior is asserted.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tau2.data_model.simulation import RewardInfo
+from tau2.evaluator import evaluator as evaluator_module
+from tau2.evaluator.evaluator import (
+    EvaluationCriteriaError,
+    EvaluationType,
+    evaluate_simulation,
+)
+
+
+def _call():
+    return evaluate_simulation(
+        simulation=None,
+        task=SimpleNamespace(id="test_task", evaluation_criteria=None),
+        evaluation_type=EvaluationType.ALL,
+        solo_mode=False,
+        domain="mock",
+    )
+
+
+def test_unexpected_error_is_graded_as_failure(monkeypatch):
+    """A raising evaluator yields reward=0.0 with the error recorded, not a crash."""
+
+    def boom(**kwargs):
+        # Mimics environment.set_state diverging on a non-deterministic tool
+        # during replay-based grading (issue #387).
+        raise ValueError("Returned RESOLVED, expected SUBMITTED")
+
+    monkeypatch.setattr(evaluator_module, "_evaluate_simulation", boom)
+
+    reward_info = _call()
+
+    assert isinstance(reward_info, RewardInfo)
+    assert reward_info.reward == 0.0
+    assert reward_info.info is not None
+    assert "ValueError" in reward_info.info["error"]
+
+
+def test_configuration_error_is_reraised(monkeypatch):
+    """A genuine config error must still surface loudly, not be swallowed."""
+
+    def bad_config(**kwargs):
+        raise EvaluationCriteriaError("reward_basis includes {RewardType.DB}")
+
+    monkeypatch.setattr(evaluator_module, "_evaluate_simulation", bad_config)
+
+    with pytest.raises(EvaluationCriteriaError):
+        _call()
+
+
+def test_successful_result_passes_through(monkeypatch):
+    """The guard is transparent when the inner evaluation succeeds."""
+    sentinel = RewardInfo(reward=1.0)
+
+    monkeypatch.setattr(
+        evaluator_module, "_evaluate_simulation", lambda **kwargs: sentinel
+    )
+
+    assert _call() is sentinel


### PR DESCRIPTION
Fixes #387 (the harness-abort part).

## Problem

Replay-based grading re-runs the recorded trajectory against a fresh environment. When an environment tool is non-deterministic — e.g. the `banking_knowledge` `submit_cash_back_dispute_0589` tool, whose status advances SUBMITTED → RESOLVED with wall-clock time — the replayed `ToolMessage` no longer matches the recorded one, and `environment.set_state` raises `ValueError`. That exception propagated out of `evaluate_simulation`, so a **single** affected simulation aborted an entire multi-task run (per the issue, a 388-sim run died at `task_026`).

## Fix

Implements the issue's suggested option 3 (the general safety net). `evaluate_simulation` is now a thin guard around the existing logic (moved to `_evaluate_simulation`):

- an unexpected evaluator exception is caught and returned as `RewardInfo(reward=0.0, info={"error": ..., "note": ...})` — mirroring the existing `terminated prematurely` / `no evaluation criteria` early-return pattern — plus a `logger.warning`, so one bad simulation can no longer take down the batch;
- genuine configuration errors (a task's `reward_basis` referencing a type the chosen `evaluation_type` doesn't compute) are raised as a dedicated `EvaluationCriteriaError` and re-raised through the guard, so they still surface loudly instead of being silently graded 0.

This is complementary to making the specific dispute tool deterministic (options 1/2); I'm happy to follow up on that separately.

## Tests

`tests/test_evaluator_guard.py` (offline — no LLM/retrieval deps; monkeypatches the inner impl) covers the contract:
- unexpected error → graded `reward=0.0` with the error captured, no raise;
- `EvaluationCriteriaError` → re-raised;
- success → passed through unchanged.

Verified: `pytest tests/test_evaluator_guard.py` → 3 passed. `ruff check` and `ruff format --check` clean on both files. Confirmed no regression against `tests/test_run.py` (the remaining failures there are pre-existing and environmental — live-LLM calls without keys — identical with and without this change).