### PR TITLE
fix(banking_knowledge): normalize numeric tool arguments so DB hashes don't depend on int vs float spelling

### DIFF
--- a/src/tau2/domains/banking_knowledge/tools.py
+++ b/src/tau2/domains/banking_knowledge/tools.py
@@ -1993,6 +1993,13 @@ For deposits without available images, the dispute will proceed based on custome
         ):
             return "Error: Missing required parameters."
 
+        # Normalize to int (the documented type) so the stored record and the
+        # response render identically whether the caller sent 2500 or 2500.0
+        try:
+            requested_increase_amount = int(requested_increase_amount)
+        except (TypeError, ValueError):
+            return "Error: Invalid requested_increase_amount. Must be a whole number."
+
         if requested_increase_amount <= 0:
             return "Error: Requested increase amount must be positive."
 

--- a/src/tau2/domains/banking_knowledge/tools.py
+++ b/src/tau2/domains/banking_knowledge/tools.py
@@ -1994,11 +1994,15 @@ For deposits without available images, the dispute will proceed based on custome
             return "Error: Missing required parameters."
 
         # Normalize to int (the documented type) so the stored record and the
-        # response render identically whether the caller sent 2500 or 2500.0
+        # response render identically whether the caller sent 2500 or 2500.0.
+        # Fractional values are rejected rather than truncated.
         try:
-            requested_increase_amount = int(requested_increase_amount)
+            requested_increase_amount = float(requested_increase_amount)
         except (TypeError, ValueError):
             return "Error: Invalid requested_increase_amount. Must be a whole number."
+        if not requested_increase_amount.is_integer():
+            return "Error: Invalid requested_increase_amount. Must be a whole number of dollars."
+        requested_increase_amount = int(requested_increase_amount)
 
         if requested_increase_amount <= 0:
             return "Error: Requested increase amount must be positive."
@@ -3961,10 +3965,15 @@ For deposits without available images, the dispute will proceed based on custome
         if new_limit is None:
             return "Error: Missing required parameter: new_limit."
 
+        # Reject fractional values rather than truncating them to the
+        # documented integer type.
         try:
-            new_limit = int(new_limit)
+            new_limit = float(new_limit)
         except (ValueError, TypeError):
             return f"Error: new_limit must be an integer, got '{new_limit}'."
+        if not new_limit.is_integer():
+            return f"Error: new_limit must be an integer, got '{new_limit}'."
+        new_limit = int(new_limit)
 
         if new_limit <= 0:
             return "Error: new_limit must be a positive amount."

--- a/src/tau2/domains/banking_knowledge/tools.py
+++ b/src/tau2/domains/banking_knowledge/tools.py
@@ -655,9 +655,12 @@ class KnowledgeTools(ToolKitBase):
                 f"You must first use `unlock_discoverable_agent_tool` to unlock this tool before calling it."
             )
 
-        # Parse arguments
+        # Parse arguments. JSON does not distinguish ints from floats (33 and 33.0
+        # are the same JSON number), so normalize all numbers to float. Otherwise
+        # deterministic IDs and DB-state hashes would depend on how the caller
+        # happened to spell the number.
         try:
-            args_dict = json.loads(arguments)
+            args_dict = json.loads(arguments, parse_int=float)
         except json.JSONDecodeError as e:
             return f"Error: Invalid JSON in arguments: {e}"
 
@@ -2711,6 +2714,12 @@ For deposits without available images, the dispute will proceed based on custome
         if not account_id or amount is None or not credit_type:
             return "Error: Missing required parameters."
 
+        # Validate amount is a positive number
+        try:
+            amount = float(amount)
+        except (TypeError, ValueError):
+            return "Error: Invalid credit amount. Must be a number."
+
         if amount <= 0:
             return "Error: Credit amount must be positive."
 
@@ -2789,6 +2798,12 @@ For deposits without available images, the dispute will proceed based on custome
         """
         if not account_id or amount is None or not credit_type:
             return "Error: Missing required parameters."
+
+        # Validate amount is a positive number
+        try:
+            amount = float(amount)
+        except (TypeError, ValueError):
+            return "Error: Invalid credit amount. Must be a number."
 
         if amount <= 0:
             return "Error: Credit amount must be positive."
@@ -4344,6 +4359,13 @@ class KnowledgeUserTools(ToolKitBase):
                 f"Must be one of: {self.VALID_CREDIT_CARD_TYPES}"
             )
 
+        # Normalize to float so the deterministic application ID and stored record
+        # do not depend on whether the caller sent 100000 or 100000.0
+        try:
+            annual_income = float(annual_income)
+        except (TypeError, ValueError):
+            return "Error: Invalid annual_income. Must be a number."
+
         # Generate a deterministic application ID from the input parameters
         # This ensures the same inputs produce the same ID for environment evaluation
         application_id = generate_application_id(
@@ -4451,9 +4473,12 @@ class KnowledgeUserTools(ToolKitBase):
         if not self.has_discoverable_tool(discoverable_tool_name):
             return f"Error: Unknown discoverable tool '{discoverable_tool_name}'."
 
-        # Parse arguments
+        # Parse arguments. JSON does not distinguish ints from floats (33 and 33.0
+        # are the same JSON number), so normalize all numbers to float. Otherwise
+        # deterministic IDs and DB-state hashes would depend on how the caller
+        # happened to spell the number.
         try:
-            args_dict = json.loads(arguments)
+            args_dict = json.loads(arguments, parse_int=float)
         except json.JSONDecodeError as e:
             return f"Error: Invalid JSON in arguments: {e}"
 

--- a/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
+++ b/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
@@ -3370,5 +3370,117 @@ class TestApplyCreditCardAccountFlagParity:
         assert "not found" in resp.content.lower()
 
 
+class TestNumericArgumentNormalization:
+    """DB state must not depend on how a caller spells a JSON number.
+
+    JSON does not distinguish ints from floats (33, 33.0, and 33.00 are the
+    same number), so two calls differing only in numeric spelling must produce
+    identical deterministic IDs and identical DB hashes. Gold trajectories are
+    replayed through the same code paths at evaluation time, so any spelling
+    sensitivity here directly mis-scores DB-basis tasks.
+    """
+
+    @staticmethod
+    def _fresh_env(base_db: TransactionalDB) -> Environment:
+        return _create_test_environment(base_db.model_copy(deep=True))
+
+    def _env_after_agent_call(
+        self, base_db: TransactionalDB, tool_name: str, arguments_json: str
+    ) -> Environment:
+        env = self._fresh_env(base_db)
+        resp = call(
+            env, "unlock_discoverable_agent_tool", {"agent_tool_name": tool_name}
+        )
+        assert not resp.error, resp.content
+        resp = call(
+            env,
+            "call_discoverable_agent_tool",
+            {"agent_tool_name": tool_name, "arguments": arguments_json},
+        )
+        assert not resp.error and "Error" not in resp.content, resp.content
+        return env
+
+    def _env_after_user_call(
+        self, base_db: TransactionalDB, tool_name: str, arguments_json: str
+    ) -> Environment:
+        env = self._fresh_env(base_db)
+        resp = call(
+            env, "give_discoverable_user_tool", {"discoverable_tool_name": tool_name}
+        )
+        assert not resp.error, resp.content
+        resp = call(
+            env,
+            "call_discoverable_user_tool",
+            {"discoverable_tool_name": tool_name, "arguments": arguments_json},
+            requestor="user",
+        )
+        assert not resp.error and "Error" not in resp.content, resp.content
+        return env
+
+    def test_savings_credit_amount_spelling(self, base_knowledge_db: TransactionalDB):
+        env_float = self._env_after_agent_call(
+            base_knowledge_db,
+            "apply_savings_account_credit_6831",
+            '{"account_id": "sav_001", "amount": 33.00, "credit_type": "interest_correction"}',
+        )
+        env_int = self._env_after_agent_call(
+            base_knowledge_db,
+            "apply_savings_account_credit_6831",
+            '{"account_id": "sav_001", "amount": 33, "credit_type": "interest_correction"}',
+        )
+        assert env_float.get_db_hash() == env_int.get_db_hash()
+
+    def test_checking_credit_amount_spelling(self, base_knowledge_db: TransactionalDB):
+        env_float = self._env_after_agent_call(
+            base_knowledge_db,
+            "apply_checking_account_credit_5829",
+            '{"account_id": "chk_001", "amount": 14.00, "credit_type": "fee_refund"}',
+        )
+        env_int = self._env_after_agent_call(
+            base_knowledge_db,
+            "apply_checking_account_credit_5829",
+            '{"account_id": "chk_001", "amount": 14, "credit_type": "fee_refund"}',
+        )
+        assert env_float.get_db_hash() == env_int.get_db_hash()
+
+    def test_user_check_deposit_amount_spelling(
+        self, base_knowledge_db: TransactionalDB
+    ):
+        env_int = self._env_after_user_call(
+            base_knowledge_db,
+            "deposit_check_3847",
+            '{"account_id": "chk_001", "check_amount": 1500}',
+        )
+        env_float = self._env_after_user_call(
+            base_knowledge_db,
+            "deposit_check_3847",
+            '{"account_id": "chk_001", "check_amount": 1500.0}',
+        )
+        assert env_int.get_db_hash() == env_float.get_db_hash()
+
+    def test_credit_card_application_income_spelling(
+        self, base_knowledge_db: TransactionalDB
+    ):
+        # apply_for_credit_card is a regular (non-discoverable) user tool, so
+        # its arguments arrive as parsed values rather than a JSON string.
+        hashes = []
+        for income in (100000, 100000.0):
+            env = self._fresh_env(base_knowledge_db)
+            resp = call(
+                env,
+                "apply_for_credit_card",
+                {
+                    "card_type": "Gold Rewards Card",
+                    "customer_name": "Amara Okonkwo",
+                    "annual_income": income,
+                    "rho_bank_subscription": False,
+                },
+                requestor="user",
+            )
+            assert not resp.error and "Error" not in resp.content, resp.content
+            hashes.append(env.get_db_hash())
+        assert hashes[0] == hashes[1]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
+++ b/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
@@ -3486,6 +3486,68 @@ class TestNumericArgumentNormalization:
         assert responses[0] == responses[1]
         assert "$2,500" in responses[0] and "$2,500.0" not in responses[0]
 
+    def test_cli_request_fractional_amount_rejected(
+        self, base_knowledge_db: TransactionalDB
+    ):
+        # A fractional amount is a wrong value, not an alternate spelling:
+        # truncating it to the documented int would silently match a gold
+        # whole-dollar request. It must error and leave the DB untouched.
+        env = self._fresh_env(base_knowledge_db)
+        resp = call(
+            env,
+            "unlock_discoverable_agent_tool",
+            {"agent_tool_name": "submit_credit_limit_increase_request_7392"},
+        )
+        assert not resp.error, resp.content
+        records_before = dict(env.tools.db.credit_limit_increase_requests.data)
+        resp = call(
+            env,
+            "call_discoverable_agent_tool",
+            {
+                "agent_tool_name": "submit_credit_limit_increase_request_7392",
+                "arguments": '{"credit_card_account_id": "cc_001", "user_id": "user_001", "requested_increase_amount": 2500.5}',
+            },
+        )
+        assert "Error" in resp.content and "whole number" in resp.content
+        assert env.tools.db.credit_limit_increase_requests.data == records_before
+
+    def test_debit_limit_fractional_amount_rejected(
+        self, base_knowledge_db: TransactionalDB
+    ):
+        env = self._fresh_env(base_knowledge_db)
+        env.tools.db.debit_cards.data["dbc_002"]["daily_atm_limit"] = 500
+        resp = call(
+            env,
+            "unlock_discoverable_agent_tool",
+            {"agent_tool_name": "request_temporary_debit_card_limit_increase_8374"},
+        )
+        assert not resp.error, resp.content
+        resp = call(
+            env,
+            "call_discoverable_agent_tool",
+            {
+                "agent_tool_name": "request_temporary_debit_card_limit_increase_8374",
+                "arguments": '{"card_id": "dbc_002", "limit_type": "atm", "new_limit": 700.5}',
+            },
+        )
+        assert "Error" in resp.content and "must be an integer" in resp.content
+        card = env.tools.db.debit_cards.data["dbc_002"]
+        assert card["daily_atm_limit"] == 500
+        assert "temporary_atm_limit_increase" not in card
+
+        # A whole-valued float is just an alternate spelling and must still
+        # succeed, storing the documented int.
+        resp = call(
+            env,
+            "call_discoverable_agent_tool",
+            {
+                "agent_tool_name": "request_temporary_debit_card_limit_increase_8374",
+                "arguments": '{"card_id": "dbc_002", "limit_type": "atm", "new_limit": 700.0}',
+            },
+        )
+        assert not resp.error and "Error" not in resp.content, resp.content
+        assert env.tools.db.debit_cards.data["dbc_002"]["daily_atm_limit"] == 700
+
     def test_credit_card_application_income_spelling(
         self, base_knowledge_db: TransactionalDB
     ):

--- a/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
+++ b/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
@@ -3458,6 +3458,34 @@ class TestNumericArgumentNormalization:
         )
         assert env_int.get_db_hash() == env_float.get_db_hash()
 
+    def test_cli_request_amount_spelling(self, base_knowledge_db: TransactionalDB):
+        responses = []
+        hashes = []
+        for spelling in ("2500", "2500.0"):
+            env = self._fresh_env(base_knowledge_db)
+            resp = call(
+                env,
+                "unlock_discoverable_agent_tool",
+                {"agent_tool_name": "submit_credit_limit_increase_request_7392"},
+            )
+            assert not resp.error, resp.content
+            resp = call(
+                env,
+                "call_discoverable_agent_tool",
+                {
+                    "agent_tool_name": "submit_credit_limit_increase_request_7392",
+                    "arguments": f'{{"credit_card_account_id": "cc_001", "user_id": "user_001", "requested_increase_amount": {spelling}}}',
+                },
+            )
+            assert not resp.error and "Error" not in resp.content, resp.content
+            responses.append(resp.content)
+            hashes.append(env.get_db_hash())
+        assert hashes[0] == hashes[1]
+        # The tool normalizes to int (its documented type), so the rendered
+        # response must not leak the caller's spelling either.
+        assert responses[0] == responses[1]
+        assert "$2,500" in responses[0] and "$2,500.0" not in responses[0]
+
     def test_credit_card_application_income_spelling(
         self, base_knowledge_db: TransactionalDB
     ):


### PR DESCRIPTION
## Problem

JSON does not distinguish ints from floats — `33`, `33.0`, and `33.00` are the same JSON number. But `json.loads` maps them to different Python types, and several banking_knowledge tools feed the raw parsed value into deterministic ID seeds and stored DB records. As a result, a semantically identical tool call can produce a different DB hash than the gold trajectory and score 0 on DB-basis tasks.

Concrete example (task_093): the gold action sends `"amount": 33.00` to `apply_savings_account_credit_6831`. An agent sending `"amount": 33` — fully compliant with the documented parameter type, `amount (number)` — gets a different deterministic transaction ID (the seed interpolates the raw value: `"33"` vs `"33.0"`) and a different stored `amount`, so the DB hash mismatches and the task fails despite a correct solution.

The exposure is inconsistent across tools: some already normalize (`float()` casts in `pay_credit_card_from_checking_9182`, `transfer_funds_between_bank_accounts_7291`, `submit_interest_discrepancy_report_7294`; `:.2f` seeds in the shared ID generators), while others don't. Affected tasks include 093, 072–074 (account credits), 055/057/061 (check deposits — authored by the *user simulator*, so outside the graded agent's control), and the 19 DB-basis credit card application tasks (`annual_income`).

## Fix

- Parse discoverable-tool arguments with `json.loads(..., parse_int=float)` at both dispatch boundaries (`call_discoverable_agent_tool`, `call_discoverable_user_tool`). Gold trajectories replay through the same code path at evaluation time, so this normalizes both sides — a code-only fix with no task data changes.
- Add `float()` casts with explicit error messages for invalid values to `apply_savings_account_credit_6831` and `apply_checking_account_credit_5829` (matching the existing convention in sibling tools) and to `apply_for_credit_card`, a regular tool that bypasses the discoverable dispatch.
- For integer-documented parameters (`submit_credit_limit_increase_request_7392`, `request_temporary_debit_card_limit_increase_8374`), reject fractional values with an error instead of truncating — `int(2500.5)` → 2500 would silently match a whole-dollar gold; for the debit tool this changes pre-existing behavior (fractional inputs previously truncated silently).

Float-spelled gold behavior is unchanged: the task_093 gold DB hash is byte-identical before and after this change; the int spelling now converges to it.

Coverage note: we also audited all 20 regular (non-discoverable) tools, since they bypass the dispatch normalization. `apply_for_credit_card` was the only exposed one (hence its in-tool cast); the rest are read-only, take string-only parameters, or are already spelling-independent because their ID seeds and stored records go through `:.2f` formatting (e.g. `submit_transaction` via `generate_transaction_id`). `give_discoverable_user_tool` parses an arguments string but persists only the tool name, so it needs no change.

## Testing

- New `TestNumericArgumentNormalization` regression tests: spelling-equivalence for savings credit, checking credit, user check deposit, CLI request, and credit card application (all fail without the fix), plus fractional-value rejection for the two integer-documented tools.
- Full banking_knowledge suite on this branch: 562 passed; the one failure (`test_all_variants_table_matches_registry`) also fails on clean `main` and is unrelated.
- Task_093 end-to-end repro: replaying the gold actions with `33` vs `33.00` now produces identical DB hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
