### PR TITLE
fix(banking_knowledge): normalize nested JSON strings in action grader comparisons

### DIFF
--- a/src/tau2/data_model/tasks.py
+++ b/src/tau2/data_model/tasks.py
@@ -4,12 +4,35 @@ import json
 import textwrap
 import uuid
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
 
 from tau2.data_model.message import Message, ToolCall, ToolRequestor
+
+
+def _normalize_action_arg_value(value: Any) -> Any:
+    """
+    Normalize nested JSON argument strings for action comparison.
+
+    Some tools accept an `arguments` parameter that is itself a JSON string.
+    Compare those semantically so formatting differences such as whitespace or
+    object key order do not affect grader results.
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.startswith(("{", "[")):
+            try:
+                return _normalize_action_arg_value(json.loads(stripped))
+            except json.JSONDecodeError:
+                return value
+        return value
+    if isinstance(value, dict):
+        return {k: _normalize_action_arg_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_normalize_action_arg_value(v) for v in value]
+    return value
 
 
 class StructuredUserInstructions(BaseModel):
@@ -190,8 +213,16 @@ class Action(BaseModel):
             compare_args = self.compare_args
         if len(compare_args) == 0:
             return True
-        tool_args = {k: v for k, v in tool_call.arguments.items() if k in compare_args}
-        action_args = {k: v for k, v in self.arguments.items() if k in compare_args}
+        tool_args = {
+            k: _normalize_action_arg_value(v)
+            for k, v in tool_call.arguments.items()
+            if k in compare_args
+        }
+        action_args = {
+            k: _normalize_action_arg_value(v)
+            for k, v in self.arguments.items()
+            if k in compare_args
+        }
         return tool_args == action_args
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2,6 +2,8 @@ import json
 
 import pytest
 
+from tau2.data_model.message import ToolCall
+from tau2.data_model.tasks import Action
 from tau2.run import get_tasks
 from tau2.utils import DATA_DIR
 from tau2.utils.utils import get_dict_hash, show_dict_diff
@@ -72,3 +74,81 @@ def test_get_task_with_initial_state_initialization_data(
     print(json.dumps(task_instance_dict, indent=2))
     print(show_dict_diff(task_dict, task_instance_dict))
     assert get_dict_hash(task_dict) == get_dict_hash(task_instance_dict)
+
+
+def test_action_comparison_normalizes_nested_json_string_whitespace():
+    action = Action(
+        action_id="lookup_accounts",
+        name="call_discoverable_agent_tool",
+        arguments={
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": '{"user_id": "rp65a7b3c4"}',
+        },
+    )
+    tool_call = ToolCall(
+        id="call_1",
+        name="call_discoverable_agent_tool",
+        arguments={
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": '{"user_id":"rp65a7b3c4"}',
+        },
+    )
+
+    assert action.compare_with_tool_call(tool_call)
+
+
+def test_action_comparison_normalizes_nested_json_string_key_order():
+    action = Action(
+        action_id="open_account",
+        name="call_discoverable_agent_tool",
+        arguments={
+            "arguments": (
+                '{"user_id": "rp65a7b3c4", "account_type": "savings", '
+                '"account_class": "Green Account"}'
+            ),
+        },
+        compare_args=["arguments"],
+    )
+    tool_call = ToolCall(
+        id="call_1",
+        name="call_discoverable_agent_tool",
+        arguments={
+            "arguments": (
+                '{"account_class":"Green Account","account_type":"savings",'
+                '"user_id":"rp65a7b3c4"}'
+            ),
+        },
+    )
+
+    assert action.compare_with_tool_call(tool_call)
+
+
+def test_action_comparison_preserves_non_json_strings():
+    action = Action(
+        action_id="message",
+        name="send_message",
+        arguments={"message": "hello"},
+    )
+    tool_call = ToolCall(
+        id="call_1",
+        name="send_message",
+        arguments={"message": " hello "},
+    )
+
+    assert not action.compare_with_tool_call(tool_call)
+
+
+def test_action_comparison_rejects_different_nested_json_string_values():
+    action = Action(
+        action_id="lookup_accounts",
+        name="call_discoverable_agent_tool",
+        arguments={"arguments": '{"user_id": "rp65a7b3c4"}'},
+        compare_args=["arguments"],
+    )
+    tool_call = ToolCall(
+        id="call_1",
+        name="call_discoverable_agent_tool",
+        arguments={"arguments": '{"user_id":"other_user"}'},
+    )
+
+    assert not action.compare_with_tool_call(tool_call)


### PR DESCRIPTION
Fixes action grading for tool calls whose arguments include nested JSON strings.

We noticed this issue specifically while working on the `banking_knowledge` domain. Many discoverable tool call succeeded at runtime and returned the correct record, but the action checker marked it as incorrect because the nested JSON string used different whitespace than the golden action.

`Action.compare_with_tool_call()` currently compares selected tool arguments with plain Python dict equality. That works for normal structured arguments, but some tools, especially discoverable banking tools, pass a nested `arguments` field as a JSON string.

Because that nested value is compared as a raw string, semantically identical JSON can fail grading.

Examples that should match but previously did not:

1. '{"user_id":"rp65a7b3c4"}' and '{"user_id": "rp65a7b3c4"}'

2. '{"account_type":"savings","account_class":"Green Account"}' and '{"account_class": "Green Account", "account_type": "savings"}'

### Fix

Normalize action argument values before comparison:
- If a compared value is a string containing valid JSON object/array syntax, parse it and compare the parsed structure.
- Recursively normalize nested dicts/lists.
- Leave ordinary strings unchanged so non-JSON text comparisons remain strict.

This keeps the grader semantically correct for JSON-string tool parameters without weakening unrelated string matching.

Added regression coverage for:
- whitespace normalization in nested JSON strings
- key-order normalization in nested JSON strings
- preserving exact comparison for non-JSON strings
- rejecting semantically different nested JSON values