### PR TITLE
fix(banking_knowledge): make lost/stolen gold trajectories agent-realizable (T077–T086)

### DIFF
--- a/data/tau2/domains/banking_knowledge/tasks.json
+++ b/data/tau2/domains/banking_knowledge/tasks.json
@@ -8245,12 +8245,39 @@
           "action_id": "077_1"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"lj82d4f1a9\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "077_1a"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_debit_cards_by_account_id_7823"
           },
           "requestor": "assistant",
           "action_id": "077_1b"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_lj82d4f1a9\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "077_1c"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_538bfb9cba\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "077_1d"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -8279,21 +8306,12 @@
           "action_id": "077_4"
         },
         {
-          "name": "unlock_discoverable_agent_tool",
+          "name": "get_credit_card_accounts_by_user",
           "arguments": {
-            "agent_tool_name": "get_credit_card_accounts_by_user"
+            "user_id": "lj82d4f1a9"
           },
           "requestor": "assistant",
           "action_id": "077_4b"
-        },
-        {
-          "name": "call_discoverable_agent_tool",
-          "arguments": {
-            "agent_tool_name": "get_credit_card_accounts_by_user",
-            "arguments": "{\"user_id\": \"lj82d4f1a9\"}"
-          },
-          "requestor": "assistant",
-          "action_id": "077_4c"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -8732,6 +8750,15 @@
           },
           "requestor": "assistant",
           "action_id": "078_1"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"mc78a5b9d2\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "078_1a"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -9285,6 +9312,15 @@
           },
           "requestor": "assistant",
           "action_id": "079_1"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"cr89a2b3c4\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "079_1a"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -9950,12 +9986,48 @@
           "action_id": "080_1"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"tm92c4d7e8\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "080_1a"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_debit_cards_by_account_id_7823"
           },
           "requestor": "assistant",
           "action_id": "080_2"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_tm92c4d7e8_blue\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "080_2a"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_tm92c4d7e8_gff\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "080_2b"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_tm92c4d7e8_green\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "080_2c"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -10689,12 +10761,48 @@
           "action_id": "081_1"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"tm92c4d7e8\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "081_1a"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_debit_cards_by_account_id_7823"
           },
           "requestor": "assistant",
           "action_id": "081_2"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_tm92c4d7e8_blue\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "081_2a"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_tm92c4d7e8_gff\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "081_2b"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_tm92c4d7e8_green\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "081_2c"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -11256,6 +11364,15 @@
           "action_id": "082_1"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"mc47a2b9e1\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "082_1a"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_debit_cards_by_account_id_7823"
@@ -11264,12 +11381,48 @@
           "action_id": "082_2"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_mc47a2b9e1_blue\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "082_2a"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_mc47a2b9e1_gff\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "082_2b"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_bank_account_transactions_9173"
           },
           "requestor": "assistant",
           "action_id": "082_3"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_bank_account_transactions_9173",
+            "arguments": "{\"account_id\": \"chk_mc47a2b9e1_blue\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "082_3a"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_bank_account_transactions_9173",
+            "arguments": "{\"account_id\": \"chk_mc47a2b9e1_gff\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "082_3b"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -11972,6 +12125,15 @@
           "action_id": "084_1"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"a7c2f85d91\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "084_1a"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_debit_cards_by_account_id_7823"
@@ -11980,12 +12142,48 @@
           "action_id": "084_2"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_b8d92f4c17\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "084_2a"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_e5a31c7d82\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "084_2b"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_bank_account_transactions_9173"
           },
           "requestor": "assistant",
           "action_id": "084_3"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_bank_account_transactions_9173",
+            "arguments": "{\"account_id\": \"chk_b8d92f4c17\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "084_3a"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_bank_account_transactions_9173",
+            "arguments": "{\"account_id\": \"chk_e5a31c7d82\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "084_3b"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -12265,12 +12463,39 @@
           "action_id": "085_1"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"f7d3a82c91\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "085_1a"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_debit_cards_by_account_id_7823"
           },
           "requestor": "assistant",
           "action_id": "085_2"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_b4d92f7c28\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "085_2a"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_e8a31c9d47\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "085_2b"
         },
         {
           "name": "unlock_discoverable_agent_tool",
@@ -12752,12 +12977,39 @@
           "action_id": "086_1"
         },
         {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+            "arguments": "{\"user_id\": \"cr47f8d2a1\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "086_1a"
+        },
+        {
           "name": "unlock_discoverable_agent_tool",
           "arguments": {
             "agent_tool_name": "get_debit_cards_by_account_id_7823"
           },
           "requestor": "assistant",
           "action_id": "086_2"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_cr47f8d2a1_gff\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "086_2a"
+        },
+        {
+          "name": "call_discoverable_agent_tool",
+          "arguments": {
+            "agent_tool_name": "get_debit_cards_by_account_id_7823",
+            "arguments": "{\"account_id\": \"chk_cr47f8d2a1_evergreen\"}"
+          },
+          "requestor": "assistant",
+          "action_id": "086_2b"
         },
         {
           "name": "unlock_discoverable_agent_tool",

--- a/data/tau2/domains/banking_knowledge/tasks/task_077.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_077.json
@@ -39,12 +39,39 @@
         "action_id": "077_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"lj82d4f1a9\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "077_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_debit_cards_by_account_id_7823"
         },
         "requestor": "assistant",
         "action_id": "077_1b"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_lj82d4f1a9\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "077_1c"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_538bfb9cba\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "077_1d"
       },
       {
         "name": "unlock_discoverable_agent_tool",
@@ -73,21 +100,12 @@
         "action_id": "077_4"
       },
       {
-        "name": "unlock_discoverable_agent_tool",
+        "name": "get_credit_card_accounts_by_user",
         "arguments": {
-          "agent_tool_name": "get_credit_card_accounts_by_user"
+          "user_id": "lj82d4f1a9"
         },
         "requestor": "assistant",
         "action_id": "077_4b"
-      },
-      {
-        "name": "call_discoverable_agent_tool",
-        "arguments": {
-          "agent_tool_name": "get_credit_card_accounts_by_user",
-          "arguments": "{\"user_id\": \"lj82d4f1a9\"}"
-        },
-        "requestor": "assistant",
-        "action_id": "077_4c"
       },
       {
         "name": "unlock_discoverable_agent_tool",

--- a/data/tau2/domains/banking_knowledge/tasks/task_078.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_078.json
@@ -286,6 +286,15 @@
         "action_id": "078_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"mc78a5b9d2\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "078_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "freeze_debit_card_3892"

--- a/data/tau2/domains/banking_knowledge/tasks/task_079.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_079.json
@@ -367,6 +367,15 @@
         "action_id": "079_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"cr89a2b3c4\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "079_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "freeze_debit_card_3892"

--- a/data/tau2/domains/banking_knowledge/tasks/task_080.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_080.json
@@ -450,12 +450,48 @@
         "action_id": "080_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"tm92c4d7e8\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "080_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_debit_cards_by_account_id_7823"
         },
         "requestor": "assistant",
         "action_id": "080_2"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_tm92c4d7e8_blue\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "080_2a"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_tm92c4d7e8_gff\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "080_2b"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_tm92c4d7e8_green\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "080_2c"
       },
       {
         "name": "unlock_discoverable_agent_tool",

--- a/data/tau2/domains/banking_knowledge/tasks/task_081.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_081.json
@@ -464,12 +464,48 @@
         "action_id": "081_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"tm92c4d7e8\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "081_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_debit_cards_by_account_id_7823"
         },
         "requestor": "assistant",
         "action_id": "081_2"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_tm92c4d7e8_blue\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "081_2a"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_tm92c4d7e8_gff\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "081_2b"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_tm92c4d7e8_green\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "081_2c"
       },
       {
         "name": "unlock_discoverable_agent_tool",

--- a/data/tau2/domains/banking_knowledge/tasks/task_082.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_082.json
@@ -292,6 +292,15 @@
         "action_id": "082_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"mc47a2b9e1\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "082_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_debit_cards_by_account_id_7823"
@@ -300,12 +309,48 @@
         "action_id": "082_2"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_mc47a2b9e1_blue\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "082_2a"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_mc47a2b9e1_gff\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "082_2b"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_bank_account_transactions_9173"
         },
         "requestor": "assistant",
         "action_id": "082_3"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_bank_account_transactions_9173",
+          "arguments": "{\"account_id\": \"chk_mc47a2b9e1_blue\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "082_3a"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_bank_account_transactions_9173",
+          "arguments": "{\"account_id\": \"chk_mc47a2b9e1_gff\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "082_3b"
       },
       {
         "name": "unlock_discoverable_agent_tool",

--- a/data/tau2/domains/banking_knowledge/tasks/task_084.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_084.json
@@ -199,6 +199,15 @@
         "action_id": "084_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"a7c2f85d91\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "084_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_debit_cards_by_account_id_7823"
@@ -207,12 +216,48 @@
         "action_id": "084_2"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_b8d92f4c17\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "084_2a"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_e5a31c7d82\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "084_2b"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_bank_account_transactions_9173"
         },
         "requestor": "assistant",
         "action_id": "084_3"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_bank_account_transactions_9173",
+          "arguments": "{\"account_id\": \"chk_b8d92f4c17\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "084_3a"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_bank_account_transactions_9173",
+          "arguments": "{\"account_id\": \"chk_e5a31c7d82\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "084_3b"
       },
       {
         "name": "unlock_discoverable_agent_tool",

--- a/data/tau2/domains/banking_knowledge/tasks/task_085.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_085.json
@@ -184,12 +184,39 @@
         "action_id": "085_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"f7d3a82c91\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "085_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_debit_cards_by_account_id_7823"
         },
         "requestor": "assistant",
         "action_id": "085_2"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_b4d92f7c28\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "085_2a"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_e8a31c9d47\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "085_2b"
       },
       {
         "name": "unlock_discoverable_agent_tool",

--- a/data/tau2/domains/banking_knowledge/tasks/task_086.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_086.json
@@ -397,12 +397,39 @@
         "action_id": "086_1"
       },
       {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_all_user_accounts_by_user_id_3847",
+          "arguments": "{\"user_id\": \"cr47f8d2a1\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "086_1a"
+      },
+      {
         "name": "unlock_discoverable_agent_tool",
         "arguments": {
           "agent_tool_name": "get_debit_cards_by_account_id_7823"
         },
         "requestor": "assistant",
         "action_id": "086_2"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_cr47f8d2a1_gff\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "086_2a"
+      },
+      {
+        "name": "call_discoverable_agent_tool",
+        "arguments": {
+          "agent_tool_name": "get_debit_cards_by_account_id_7823",
+          "arguments": "{\"account_id\": \"chk_cr47f8d2a1_evergreen\"}"
+        },
+        "requestor": "assistant",
+        "action_id": "086_2b"
       },
       {
         "name": "unlock_discoverable_agent_tool",


### PR DESCRIPTION
Closes #370 (the gold-data half; the scorer half was addressed by #329).

## Problem

Gold trajectories in the lost/stolen debit-card family **unlocked** the discoverable reads that expose account and card IDs (`get_all_user_accounts_by_user_id_3847`, `get_debit_cards_by_account_id_7823`, and in 082/084 `get_bank_account_transactions_9173`) but never **called** them — then froze/closed card IDs those reads would have returned.

## Fix

- Insert the missing `call_discoverable_agent_tool` actions directly after their unlocks in tasks **077, 078, 079, 080, 081, 082, 084, 085, 086**, covering the accounts each trajectory acts on.

Tasks **087–092** already called both reads and are unchanged. Task **083** is ACTION-based and unaffected by `db_match` 

## Interaction with #329

#329 derives the read-log allowlist from gold actions, so adding these reads to gold also puts them in the allowlist. That is the intended semantics: these reads are genuinely mandatory (the only path to the IDs the task acts on), so their presence in the table should discriminate.

## Verification

Replayed old vs new gold for all of 077–092 through the real eval path on top of current `main` (including #329's allowlist derivation and #397's numeric normalization):

- Zero tool errors in every repaired trajectory (old task_077 had 2 `Unknown agent tool` errors, now gone).
- Per-task before/after DB diffs: the **only** changed table is `agent_discoverable_tools`, with exactly the expected read rows added — accounts, cards, orders, disputes, and balances are byte-identical.
- 087–092 replay byte-identical DBs before and after.
- `tests/test_domains/test_banking_knowledge`: 28 passed, 1 pre-existing failure (`test_all_variants_table_matches_registry`) that fails identically on clean `origin/main`.
