### PR TITLE
Fix banking_knowledge transaction ordering to match documented contract (issue #371a)

### DIFF
--- a/data/tau2/domains/banking_knowledge/tasks.json
+++ b/data/tau2/domains/banking_knowledge/tasks.json
@@ -12193,8 +12193,8 @@
                 "type": "atm_withdrawal",
                 "status": "posted"
               },
-              "btxn_b2c3d4e5f602": {
-                "transaction_id": "btxn_b2c3d4e5f602",
+              "btxn_c3d4e5f6g703": {
+                "transaction_id": "btxn_c3d4e5f6g703",
                 "account_id": "chk_b4d92f7c28",
                 "date": "11/06/2025",
                 "description": "CITYFIT GYM MONTHLY DENVER",
@@ -12202,8 +12202,8 @@
                 "type": "debit_card_purchase",
                 "status": "posted"
               },
-              "btxn_c3d4e5f6g703": {
-                "transaction_id": "btxn_c3d4e5f6g703",
+              "btxn_b2c3d4e5f602": {
+                "transaction_id": "btxn_b2c3d4e5f602",
                 "account_id": "chk_b4d92f7c28",
                 "date": "11/06/2025",
                 "description": "CITYFIT GYM MONTHLY DENVER",

--- a/data/tau2/domains/banking_knowledge/tasks/task_085.json
+++ b/data/tau2/domains/banking_knowledge/tasks/task_085.json
@@ -112,8 +112,8 @@
               "type": "atm_withdrawal",
               "status": "posted"
             },
-            "btxn_b2c3d4e5f602": {
-              "transaction_id": "btxn_b2c3d4e5f602",
+            "btxn_c3d4e5f6g703": {
+              "transaction_id": "btxn_c3d4e5f6g703",
               "account_id": "chk_b4d92f7c28",
               "date": "11/06/2025",
               "description": "CITYFIT GYM MONTHLY DENVER",
@@ -121,8 +121,8 @@
               "type": "debit_card_purchase",
               "status": "posted"
             },
-            "btxn_c3d4e5f6g703": {
-              "transaction_id": "btxn_c3d4e5f6g703",
+            "btxn_b2c3d4e5f602": {
+              "transaction_id": "btxn_b2c3d4e5f602",
               "account_id": "chk_b4d92f7c28",
               "date": "11/06/2025",
               "description": "CITYFIT GYM MONTHLY DENVER",

--- a/src/tau2/domains/banking_knowledge/tools.py
+++ b/src/tau2/domains/banking_knowledge/tools.py
@@ -9,6 +9,7 @@ from tau2.domains.banking_knowledge.data_model import TransactionalDB
 from tau2.domains.banking_knowledge.db_query import (
     add_to_db,
     query_database_tool,
+    query_db,
     update_record_in_db,
 )
 from tau2.domains.banking_knowledge.utils import (
@@ -2934,12 +2935,17 @@ For deposits without available images, the dispute will proceed based on custome
     def get_bank_account_transactions_9173(self, account_id: str) -> str:
         """Retrieve the transaction history for a bank account.
 
+        Transactions are returned in reverse chronological order (most recent
+        first).
+
         Args:
             account_id (string): The bank account ID to retrieve transactions for
 
         Returns:
             Bank account transactions retrieved successfully.
         """
+        from datetime import datetime
+
         if not account_id:
             return "Error: Missing required parameter: account_id"
 
@@ -2947,11 +2953,28 @@ For deposits without available images, the dispute will proceed based on custome
         if account_id not in self.db.accounts.data:
             return f"Error: Account '{account_id}' not found."
 
-        txn_result = query_database_tool(
+        txns = query_db(
             "bank_account_transaction_history",
-            f'{{"account_id": "{account_id}"}}',
             db=self.db,
+            return_ids=True,
+            account_id=account_id,
         )
+
+        # The knowledge doc for this tool guarantees reverse chronological
+        # order (most recent first). The sort must stay stable: same-date
+        # records keep their stored order, which under the most-recent-first
+        # contract identifies the later-listed record as the earlier one
+        # (tie-breaker for duplicate-charge disputes).
+        def txn_sort_key(item):
+            date_str = str(item[1].get("date", ""))
+            for fmt in ("%m/%d/%Y %H:%M:%S", "%m/%d/%Y"):
+                try:
+                    return datetime.strptime(date_str, fmt)
+                except ValueError:
+                    continue
+            return datetime.min
+
+        txns = sorted(txns, key=txn_sort_key, reverse=True)
 
         result_parts = [
             "Bank account transactions retrieved successfully.",
@@ -2960,11 +2983,16 @@ For deposits without available images, the dispute will proceed based on custome
             f"Transactions for account {account_id}:",
         ]
 
-        if (
-            "No records found" not in txn_result
-            and "No results found" not in txn_result
-        ):
-            result_parts.append(txn_result)
+        if txns:
+            formatted_lines = [
+                f"Found {len(txns)} record(s) in 'bank_account_transaction_history':\n"
+            ]
+            for i, (record_id, record) in enumerate(txns, 1):
+                formatted_lines.append(f"{i}. Record ID: {record_id}")
+                for field, value in record.items():
+                    formatted_lines.append(f"   {field}: {value}")
+                formatted_lines.append("")
+            result_parts.append("\n".join(formatted_lines))
         else:
             result_parts.append("\nNo transactions found for this account.")
 

--- a/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
+++ b/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
@@ -3012,6 +3012,55 @@ class TestReadOnlyDiscoverableAgentTools:
         assert not resp.error
         assert "transactions" in resp.content.lower()
 
+    def test_get_bank_account_transactions_reverse_chronological(
+        self, environment: Environment
+    ):
+        def txn(txn_id: str, date: str) -> dict:
+            return {
+                "transaction_id": txn_id,
+                "account_id": "chk_001",
+                "date": date,
+                "description": "TEST TRANSACTION",
+                "amount": -10.0,
+                "type": "debit_card_purchase",
+                "status": "posted",
+            }
+
+        # Insert deliberately out of chronological order, with a same-date
+        # duplicate pair and a timestamped date.
+        environment.tools.db.bank_account_transaction_history.data.update(
+            {
+                "btxn_dup_first": txn("btxn_dup_first", "11/11/2025"),
+                "btxn_dup_second": txn("btxn_dup_second", "11/11/2025"),
+                "btxn_oldest": txn("btxn_oldest", "11/01/2025"),
+                "btxn_newest": txn("btxn_newest", "11/13/2025"),
+                "btxn_timestamped": txn("btxn_timestamped", "11/12/2025 14:30:00"),
+            }
+        )
+
+        resp = call_discoverable_agent(
+            environment,
+            "get_bank_account_transactions_9173",
+            {
+                "account_id": "chk_001",
+            },
+        )
+        assert not resp.error
+
+        listed_ids = [
+            line.split("Record ID:")[1].strip()
+            for line in resp.content.splitlines()
+            if "Record ID:" in line
+        ]
+        # Most recent first; same-date records keep their stored order.
+        assert listed_ids == [
+            "btxn_newest",
+            "btxn_timestamped",
+            "btxn_dup_first",
+            "btxn_dup_second",
+            "btxn_oldest",
+        ]
+
     def test_get_debit_cards_by_account(self, environment: Environment):
         resp = call_discoverable_agent(
             environment,


### PR DESCRIPTION
## Summary

Addresses part (a) of #371 (duplicate-transaction disputes in T083/T084 with "no tie-breaker").

The scenario is actually *not* under-determined on paper: `doc_bank_accounts_(general)_018` — required reading for T083, T084, and T085 — states that `get_bank_account_transactions_9173` returns transactions in **reverse chronological order (most recent first)**, and `doc_031` says to dispute the **earliest** duplicate. Together these uniquely identify which duplicate to dispute.

The real bug is that the tool did not honor the documented contract: it returned raw DB insertion order (oldest first). An agent reading the actual output sees dates ascending, concludes the *first*-listed duplicate is the earliest, and disputes the non-gold transaction. The gold ids for T083/T084 are only reachable by trusting doc_018 over the visibly ascending output.

## Changes

- **`tools.py`**: `get_bank_account_transactions_9173` now sorts by date descending with a **stable** sort. Same-date records keep their stored order, so under the most-recent-first contract the later-listed of two identical same-date duplicates is the earlier one — which matches the existing gold `transaction_id` for T083 (`btxn_d937eaa1d21d`) and T084 (`btxn_e8c3b09d2c45`). Handles both `MM/DD/YYYY` and `MM/DD/YYYY HH:MM:SS` date formats (both occur in the data). Tool docstring now states the ordering.
- **`task_085.json` / `tasks.json`**: T085 also has an identical same-date duplicate pair (CityFit Gym), but its gold id implied the *opposite* tie-break from T083/T084. Swapped the stored order of the two rows so all three tasks follow the same convention. **No gold actions were changed.**
- **Tests**: new test asserting reverse chronological output, same-date stability, and timestamped-date handling.

## Blast radius checked

- T083/T084/T085 are the only tasks with byte-identical same-date duplicates; verified the tool output for all three now resolves "the earliest duplicate" to the existing gold id (ran the real environment per task).
- No other task golds or scripted user instructions depend on transaction list position; base-db duplicate pairs (NON-RHO ATM FEE) are not dispute targets in any task.
- No code consumes this tool's output programmatically; the only existing test on it asserts content, not order.
- `tasks_voice.json` holds voice configs only (no gold actions); `web/leaderboard/public/task-data` is a symlink to the source data.
- Full `test_tools_knowledge.py` suite passes (205 tests).

Note: existing leaderboard results for T083/T084 were produced under the contradictory ordering, so per-task scores there may shift on re-runs.

Fixes part (a) of #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)