### PR TITLE
docs: add Qwen3.5-4B Retail baseline submission

### DIFF
--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -19,7 +19,8 @@
     "grok-4-fast_sierra_2026-05-05",
     "grok-4-1-fast_sierra_2026-05-05",
     "grok-4-2_sierra_2026-05-05",
-    "glm5-2_zai_2026-06-21"
+    "glm5-2_zai_2026-06-21",
+    "qwen3-5-4b_qwen_2026-07-15"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",

--- a/web/leaderboard/public/submissions/qwen3-5-4b_qwen_2026-07-15/submission.json
+++ b/web/leaderboard/public/submissions/qwen3-5-4b_qwen_2026-07-15/submission.json
@@ -1,0 +1,36 @@
+{
+  "model_name": "openai/qwen35-4b",
+  "model_organization": "Qwen",
+  "submitting_organization": "Independent Research",
+  "submission_date": "2026-07-15",
+  "submission_type": "custom",
+  "modality": "text",
+  "contact_info": {
+    "email": "xiaomingneu@gmail.com"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 81.57894736842105,
+      "pass_2": 68.12865497076022,
+      "pass_3": 58.114035087719294,
+      "pass_4": 50.877192982456144,
+      "cost": 0.0
+    }
+  },
+  "is_new": false,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "retail": "qwen35_4b_retail_base_114x4.json"
+  },
+  "methodology": {
+    "evaluation_date": "2026-07-13",
+    "tau2_bench_version": "1.0.0",
+    "user_simulator": "openai/deepseek-v4-pro",
+    "notes": "Raw Qwen3.5-4B served locally with vLLM; native qwen3_coder tool parser and qwen3 reasoning parser; agent thinking disabled; DeepSeek-V4-Pro user simulator with thinking enabled at low effort; complete Retail base split; 4 trials per task; seed 300; max_steps 100; no domain-specific training; no runtime assist. Marked custom because max_steps differs from the current official default of 200. The trajectory model identifier openai/qwen35-4b is the local OpenAI-compatible serving alias for Qwen3.5-4B.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "reasoning_effort": "none"
+}

--- a/web/leaderboard/public/submissions/qwen3-5-4b_qwen_2026-07-15/submission.json
+++ b/web/leaderboard/public/submissions/qwen3-5-4b_qwen_2026-07-15/submission.json
@@ -22,6 +22,18 @@
   "trajectory_files": {
     "retail": "qwen35_4b_retail_base_114x4.json"
   },
+  "references": [
+    {
+      "title": "Validated Retail trajectory package",
+      "url": "https://huggingface.co/datasets/xiaomingneu/tau3-qwen35-4b-retail-baseline",
+      "type": "huggingface"
+    },
+    {
+      "title": "Qwen3.5-4B model card",
+      "url": "https://huggingface.co/Qwen/Qwen3.5-4B",
+      "type": "model_card"
+    }
+  ],
   "methodology": {
     "evaluation_date": "2026-07-13",
     "tau2_bench_version": "1.0.0",


### PR DESCRIPTION
## Summary

Adds a Retail-only text leaderboard submission for raw Qwen3.5-4B.

- Complete Retail `base` split: 114 tasks x 4 trials (456 trajectories)
- Raw Qwen3.5-4B served locally with vLLM
- Native `qwen3_coder` tool parser and `qwen3` reasoning parser
- Agent thinking disabled; no domain-specific training and no runtime assist
- DeepSeek-V4-Pro user simulator with thinking enabled at low effort
- Marked `custom` because this run used `max_steps=100`, while the current default is 200

## Results

| Domain | Pass^1 | Pass^2 | Pass^3 | Pass^4 |
| --- | ---: | ---: | ---: | ---: |
| Retail | 81.58% | 68.13% | 58.11% | 50.88% |

## Trajectories

The complete validated trajectory package is publicly hosted at:

https://huggingface.co/datasets/xiaomingneu/tau3-qwen35-4b-retail-baseline

## Validation

- `tau2 submit verify-trajs`: passed format, task, and trial-count checks
- `tau2 submit validate`: passed trajectory-set and metric validation on current upstream `main`
- Submission JSON schema and manifest uniqueness check: passed
- `uv run ruff check .`: passed
- `npm run build` in `web/leaderboard`: passed

`make check-schema` reports the checked-in schema as out of date on the unmodified upstream `main`; this submission does not change the generated schema or its source models.