### PR TITLE
Reapply "fix(banking_knowledge): stop logging extra read calls to agent_discoverable_tools" (#329)

### DIFF
--- a/src/tau2/domains/banking_knowledge/environment.py
+++ b/src/tau2/domains/banking_knowledge/environment.py
@@ -39,6 +39,7 @@ def get_environment(
     retrieval_kwargs: Optional[dict] = None,
     task: Optional[Task] = None,
     solo_mode: bool = False,
+    read_log_allowlist: Optional[set] = None,
 ) -> Environment:
     """Get the banking_knowledge domain environment.
 
@@ -55,6 +56,11 @@ def get_environment(
         task: Optional task — needed by ``golden_retrieval`` to inline
             task-specific documents in the prompt.
         solo_mode: Not supported for banking_knowledge.
+        read_log_allowlist: Names of read-only discoverable tools whose calls
+            should be logged to ``agent_discoverable_tools`` for eval. Typically
+            derived from the task's golden trajectory so that required-read
+            assertions still discriminate, while extra validation reads don't
+            pollute the DB hash comparison.
 
     Returns:
         Fully configured Environment for the banking_knowledge domain.
@@ -71,7 +77,9 @@ def get_environment(
     kwargs = retrieval_kwargs or {}
     variant = resolve_variant(variant_name, **kwargs)
 
-    tools = build_tools(variant, db, knowledge_base)
+    tools = build_tools(
+        variant, db, knowledge_base, read_log_allowlist=read_log_allowlist
+    )
     user_tools = KnowledgeUserTools(db)
     policy = build_policy(variant, knowledge_base, task)
 

--- a/src/tau2/domains/banking_knowledge/retrieval.py
+++ b/src/tau2/domains/banking_knowledge/retrieval.py
@@ -741,12 +741,18 @@ def build_tools(
     variant: RetrievalVariant,
     db: TransactionalDB,
     knowledge_base: KnowledgeBase,
+    read_log_allowlist: Optional[set] = None,
 ) -> KnowledgeTools:
     """Build the composed toolkit for a retrieval variant.
 
     Selects the right concrete toolkit class based on which retrieval
     capabilities the variant requires, creates the backing pipelines /
     sandboxes, and returns a fully initialized toolkit.
+
+    Args:
+        read_log_allowlist: Names of read-only discoverable tools whose
+            calls should still be logged to ``agent_discoverable_tools``
+            for eval (typically the set required by the golden trajectory).
     """
     has_all_tools = (
         variant.kb_search_bm25 is not None
@@ -757,31 +763,31 @@ def build_tools(
         bm25_pipeline = _create_kb_pipeline(variant.kb_search_bm25, knowledge_base)
         dense_pipeline = _create_kb_pipeline(variant.kb_search_dense, knowledge_base)
         sandbox = _create_sandbox(knowledge_base, variant.shell)
-        return KnowledgeToolsAllTools(db, bm25_pipeline, dense_pipeline, sandbox)
+        tools = KnowledgeToolsAllTools(db, bm25_pipeline, dense_pipeline, sandbox)
+    else:
+        has_kb = variant.kb_search is not None
+        has_grep = variant.grep is not None
+        has_shell = variant.shell is not None
 
-    has_kb = variant.kb_search is not None
-    has_grep = variant.grep is not None
-    has_shell = variant.shell is not None
+        if has_shell:
+            sandbox = _create_sandbox(knowledge_base, variant.shell)
+            tools = KnowledgeToolsWithShell(db, sandbox)
+        elif has_kb and has_grep:
+            kb_pipeline = _create_kb_pipeline(variant.kb_search, knowledge_base)
+            grep_pipeline = _create_grep_pipeline(variant.grep, knowledge_base)
+            tools = KnowledgeToolsWithKBSearchAndGrep(db, kb_pipeline, grep_pipeline)
+        elif has_kb:
+            kb_pipeline = _create_kb_pipeline(variant.kb_search, knowledge_base)
+            tools = KnowledgeToolsWithKBSearch(db, kb_pipeline)
+        elif has_grep:
+            grep_pipeline = _create_grep_pipeline(variant.grep, knowledge_base)
+            tools = KnowledgeToolsWithGrep(db, grep_pipeline)
+        else:
+            # No retrieval tools (no_knowledge, full_kb, golden_retrieval)
+            tools = KnowledgeToolsPlain(db)
 
-    if has_shell:
-        sandbox = _create_sandbox(knowledge_base, variant.shell)
-        return KnowledgeToolsWithShell(db, sandbox)
-
-    if has_kb and has_grep:
-        kb_pipeline = _create_kb_pipeline(variant.kb_search, knowledge_base)
-        grep_pipeline = _create_grep_pipeline(variant.grep, knowledge_base)
-        return KnowledgeToolsWithKBSearchAndGrep(db, kb_pipeline, grep_pipeline)
-
-    if has_kb:
-        kb_pipeline = _create_kb_pipeline(variant.kb_search, knowledge_base)
-        return KnowledgeToolsWithKBSearch(db, kb_pipeline)
-
-    if has_grep:
-        grep_pipeline = _create_grep_pipeline(variant.grep, knowledge_base)
-        return KnowledgeToolsWithGrep(db, grep_pipeline)
-
-    # No retrieval tools (no_knowledge, full_kb, golden_retrieval)
-    return KnowledgeToolsPlain(db)
+    tools.set_read_log_allowlist(read_log_allowlist)
+    return tools
 
 
 # ---------------------------------------------------------------------------

--- a/src/tau2/domains/banking_knowledge/tools.py
+++ b/src/tau2/domains/banking_knowledge/tools.py
@@ -33,6 +33,7 @@ from tau2.domains.banking_knowledge.utils import (
 )
 from tau2.environment.toolkit import (
     DISCOVERABLE_ATTR,
+    MUTATES_STATE_ATTR,
     ToolKitBase,
     ToolType,
     is_discoverable_tool,
@@ -342,6 +343,16 @@ class KnowledgeTools(ToolKitBase):
         super().__init__(db)
         self._user_discoverable_tools_state: Dict[str, Dict[str, Any]] = {}
         self._agent_discoverable_tools_state: Dict[str, Dict[str, Any]] = {}
+        # Names of read-only discoverable tools whose calls should be logged to
+        # the agent_discoverable_tools table during eval. Populated at task
+        # setup from the golden trajectory so that required-read assertions
+        # still discriminate, while extra validation reads don't pollute the
+        # DB hash. See get_environment(read_log_allowlist=...).
+        self._read_log_allowlist: set[str] = set()
+
+    def set_read_log_allowlist(self, allowlist: Optional[set]) -> None:
+        """Replace the read-call DB-logging allowlist."""
+        self._read_log_allowlist = set(allowlist or [])
 
     def get_user_discoverable_tools_state(self) -> Dict[str, Dict[str, Any]]:
         """Get the current state of user discoverable tools (for sharing with user tools)."""
@@ -671,10 +682,19 @@ class KnowledgeTools(ToolKitBase):
         except TypeError as e:
             return f"Error: Invalid arguments: {e}"
 
-        # Record the call in the database for evaluation (only unique tool names)
-        agent_tool_record = {"tool_name": agent_tool_name, "status": "CALLED"}
-        record_id = generate_agent_discoverable_tool_id(agent_tool_name)
-        add_to_db("agent_discoverable_tools", record_id, agent_tool_record, db=self.db)
+        # Record the call in the database for evaluation. Only state-mutating
+        # underlying tools, plus read tools explicitly required by the task's
+        # golden trajectory (the allowlist), are logged. Extra read-only
+        # validation calls (e.g. precondition checks the agent did out of
+        # caution) are intentionally skipped so they don't break the DB-hash
+        # comparison in EnvironmentEvaluator.
+        underlying_mutates = getattr(method, MUTATES_STATE_ATTR, False)
+        if underlying_mutates or agent_tool_name in self._read_log_allowlist:
+            agent_tool_record = {"tool_name": agent_tool_name, "status": "CALLED"}
+            record_id = generate_agent_discoverable_tool_id(agent_tool_name)
+            add_to_db(
+                "agent_discoverable_tools", record_id, agent_tool_record, db=self.db
+            )
 
         return result
 

--- a/src/tau2/runner/build.py
+++ b/src/tau2/runner/build.py
@@ -307,6 +307,33 @@ def build_voice_user(
 # =============================================================================
 
 
+def _derive_read_log_allowlist(task: Task) -> set:
+    """Set of discoverable-tool names required by the task's golden trajectory.
+
+    The banking_knowledge ``call_discoverable_agent_tool`` wrapper logs every
+    call to the ``agent_discoverable_tools`` DB table, which is then hashed
+    for the env-eval reward. For READ-only discoverable tools this means any
+    extra validation call (e.g. an agent reading a balance "just in case")
+    diverges the hash and zeros the reward — even though the KB explicitly
+    encourages such reads.
+
+    To keep the "agent must call this read to verify" assertion (tasks 046,
+    085, etc.) while not punishing extra reads, we extract the set of tool
+    names appearing in golden ``call_discoverable_agent_tool`` actions and
+    pass it as an allowlist to the toolkit. Calls to writes are always
+    logged; calls to reads are only logged when in this set.
+    """
+    allowlist: set = set()
+    if task.evaluation_criteria is None:
+        return allowlist
+    for action in task.evaluation_criteria.actions or []:
+        if action.name == "call_discoverable_agent_tool":
+            name = (action.arguments or {}).get("agent_tool_name")
+            if name:
+                allowlist.add(name)
+    return allowlist
+
+
 def _build_env_kwargs(config: RunConfig, task: Task) -> dict:
     """Build env_kwargs from a RunConfig for the environment constructor.
 
@@ -321,6 +348,8 @@ def _build_env_kwargs(config: RunConfig, task: Task) -> dict:
         rk = dict(getattr(config, "retrieval_config_kwargs", None) or {})
         if rk:
             env_kwargs["retrieval_kwargs"] = rk
+    if getattr(config, "domain", None) == "banking_knowledge":
+        env_kwargs["read_log_allowlist"] = _derive_read_log_allowlist(task)
     return env_kwargs
 
 


### PR DESCRIPTION
Re-applies #329, which was reverted in #405 pending a full assessment of its impact on results.

Based on the `revert-pr-329` branch so the diff shows only the re-applied fix; GitHub will retarget this to `main` automatically once #405 merges. Keep as draft until the impact testing is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)