### PR TITLE
fix(data): validate reward criteria gates

### DIFF
--- a/data/tau2/domains/airline/tasks.json
+++ b/data/tau2/domains/airline/tasks.json
@@ -25,7 +25,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -73,7 +73,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -132,7 +132,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -264,7 +264,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -305,7 +305,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -345,7 +345,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -533,8 +533,7 @@
                 "Agent uses single certificate for payment."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -579,7 +578,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -610,7 +609,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -746,7 +745,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -787,7 +786,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -951,8 +950,7 @@
                 "Agent uses the payment id: gift_card_8887175"
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1004,8 +1002,7 @@
                 "Agent uses payment id gift_card_8887175."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1084,8 +1081,7 @@
                 "Number of bags for reservation FQ8APE is updated to 3."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1271,8 +1267,7 @@
                 "Agent cancels reservation Z7GOZK"
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1346,8 +1341,7 @@
                 "Agent charges $250 on payment method certificate_7504069 and $5 on credit_card_4421486."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1419,8 +1413,7 @@
                 "Agent updates reservation OBUT9V to 2 free baggages."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1499,8 +1492,7 @@
                 "Agent updates reservation FQ8APE baggages to 3 free baggages."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1772,8 +1764,7 @@
                 "Agent charges $67 to gift_card_7773485 and $39 to gift_card_7359776."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1847,8 +1838,7 @@
                 "Agent charges $128 to gift_card_8516878 and $247 to credit_card_3563913."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -1879,7 +1869,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -1921,7 +1911,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -1953,7 +1943,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -2041,7 +2031,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -2111,8 +2101,7 @@
                 "Agent does not make modifications to checked bags since policy doesn't allow to remove bags."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -2143,7 +2132,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -2237,8 +2226,7 @@
                 "Agent updates reservation OWZ4XL to flight HAT041."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -2330,8 +2318,7 @@
                 "Agent add 2 free baggages to reservation HXDUBJ."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -2362,7 +2349,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -2433,8 +2420,7 @@
                 "Agent charges $290 to credit card credit_card_907483"
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -2474,7 +2460,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -2555,8 +2541,7 @@
                 "Agent upgrades M20IZO to business class."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -2607,7 +2592,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -2729,8 +2714,7 @@
                 "Agent does not cancel  any other reservation."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -2789,8 +2773,7 @@
                 "Agent updates reservation 3RK2T9 to passenger Mei Garcia."
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -2887,7 +2870,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -2999,8 +2982,7 @@
                 "Agent cancels reservation HSR97W"
             ],
             "reward_basis": [
-                "DB",
-                "COMMUNICATE"
+                "DB"
             ]
         },
         "annotations": null
@@ -3081,7 +3063,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -3321,7 +3303,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -3362,7 +3344,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -3393,7 +3375,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -3433,7 +3415,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -3473,7 +3455,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null
@@ -3513,7 +3495,7 @@
             ],
             "reward_basis": [
                 "DB",
-                "COMMUNICATE"
+                "NL_ASSERTION"
             ]
         },
         "annotations": null

--- a/data/tau2/domains/retail/tasks.json
+++ b/data/tau2/domains/retail/tasks.json
@@ -74,8 +74,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -152,8 +151,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -282,7 +280,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -420,7 +419,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -573,7 +573,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         },
         "issues": [
@@ -657,8 +658,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         },
         "issues": [
@@ -754,8 +754,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -840,8 +839,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         },
         "issues": [
@@ -936,8 +934,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -1022,8 +1019,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -1093,7 +1089,7 @@
             "nl_assertions": null,
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "ACTION"
             ]
         }
     },
@@ -1180,8 +1176,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -1251,7 +1246,7 @@
             "nl_assertions": null,
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "ACTION"
             ]
         }
     },
@@ -1325,8 +1320,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -1410,8 +1404,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -1504,8 +1497,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -1618,7 +1610,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -1702,8 +1695,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -1780,8 +1772,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -1878,7 +1869,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -2001,8 +1993,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -2142,7 +2133,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -2246,8 +2238,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -2394,8 +2385,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -2428,7 +2418,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -2506,8 +2497,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -2607,8 +2597,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -2693,8 +2682,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -2831,7 +2819,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -2930,7 +2919,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -3076,7 +3066,7 @@
             "nl_assertions": null,
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "COMMUNICATE"
             ]
         }
     },
@@ -3210,7 +3200,7 @@
             "nl_assertions": null,
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "COMMUNICATE"
             ]
         }
     },
@@ -3353,7 +3343,7 @@
             "nl_assertions": null,
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "COMMUNICATE"
             ]
         }
     },
@@ -3616,8 +3606,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -3671,7 +3660,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -3751,7 +3741,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -3821,7 +3812,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -3904,7 +3896,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -3972,7 +3965,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -4107,8 +4101,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -4243,8 +4236,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -4333,7 +4325,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -4415,7 +4408,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -4497,7 +4491,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -4595,7 +4590,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -4693,7 +4689,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -4775,8 +4772,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -4893,8 +4889,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -4932,7 +4927,7 @@
             "nl_assertions": null,
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "ACTION"
             ]
         }
     },
@@ -5014,8 +5009,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -5092,8 +5086,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -5175,8 +5168,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -5314,7 +5306,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -5459,8 +5452,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -5553,8 +5545,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -5581,8 +5572,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -5669,8 +5659,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -5754,7 +5743,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -5828,7 +5818,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -5905,8 +5896,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -5983,7 +5973,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -6085,7 +6076,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -6193,8 +6185,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6248,8 +6239,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6320,8 +6310,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6400,7 +6389,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -6469,7 +6459,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -6532,8 +6523,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6581,7 +6571,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -6638,8 +6629,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6696,8 +6686,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6740,8 +6729,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6793,8 +6781,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6837,8 +6824,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6889,7 +6875,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -6932,8 +6919,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -6999,8 +6985,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7043,8 +7028,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7087,8 +7071,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7134,8 +7117,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7178,8 +7160,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7219,8 +7200,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7260,8 +7240,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7304,8 +7283,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7362,8 +7340,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7447,8 +7424,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7485,8 +7461,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7537,7 +7512,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -7574,8 +7550,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7632,8 +7607,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7687,8 +7661,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7731,8 +7704,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7775,8 +7747,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7843,7 +7814,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -7900,8 +7872,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -7958,8 +7929,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -8028,8 +7998,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -8089,8 +8058,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -8147,8 +8115,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -8220,8 +8187,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -8293,8 +8259,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },
@@ -8381,7 +8346,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -8480,7 +8446,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -8682,7 +8649,8 @@
             ],
             "reward_basis": [
                 "DB",
-                "NL_ASSERTION"
+                "NL_ASSERTION",
+                "COMMUNICATE"
             ]
         }
     },
@@ -8980,8 +8948,7 @@
             "communicate_info": [],
             "nl_assertions": null,
             "reward_basis": [
-                "DB",
-                "NL_ASSERTION"
+                "DB"
             ]
         }
     },

--- a/src/tau2/scripts/check_data.py
+++ b/src/tau2/scripts/check_data.py
@@ -3,26 +3,84 @@
 Script to check if the tau2 data directory is properly configured.
 """
 
+import json
 import sys
+from pathlib import Path
 
 from tau2.utils.utils import DATA_DIR
 
 
+def find_reward_basis_issues(tasks: list[dict]) -> tuple[list[str], list[str]]:
+    """Find reward criteria that cannot evaluate what their basis declares."""
+    errors = []
+    warnings = []
+    for task in tasks:
+        task_id = task.get("id", "<unknown>")
+        criteria = task.get("evaluation_criteria") or {}
+        basis = set(
+            criteria["reward_basis"]
+            if "reward_basis" in criteria
+            else ("DB", "COMMUNICATE")
+        )
+        communicate_info = criteria.get("communicate_info")
+        nl_assertions = criteria.get("nl_assertions")
+
+        if "COMMUNICATE" in basis and not communicate_info:
+            errors.append(
+                f"task {task_id}: COMMUNICATE is in reward_basis but "
+                "communicate_info is empty"
+            )
+        if "NL_ASSERTION" in basis and not nl_assertions:
+            errors.append(
+                f"task {task_id}: NL_ASSERTION is in reward_basis but "
+                "nl_assertions is empty"
+            )
+        if communicate_info and "COMMUNICATE" not in basis:
+            warnings.append(
+                f"task {task_id}: communicate_info is populated but "
+                "COMMUNICATE is not in reward_basis"
+            )
+    return errors, warnings
+
+
+def check_task_files(data_dir: Path) -> tuple[list[str], list[str]]:
+    """Validate reward criteria in every domain task file."""
+    errors = []
+    warnings = []
+    domains_dir = data_dir / "tau2" / "domains"
+    for task_file in sorted(domains_dir.glob("*/tasks.json")):
+        if task_file.parent.name == "mock":
+            # Mock tasks intentionally exercise omitted/default criteria fields.
+            continue
+        tasks = json.loads(task_file.read_text(encoding="utf-8"))
+        domain_errors, domain_warnings = find_reward_basis_issues(tasks)
+        errors.extend(f"{task_file}: {message}" for message in domain_errors)
+        warnings.extend(f"{task_file}: {message}" for message in domain_warnings)
+    return errors, warnings
+
+
 def main():
-    """Main function to check data directory."""
+    """Main function to check data directory and task criteria."""
     print("tau2 Data Directory Checker")
     print("=" * 40)
-
     print(f"Data directory: {DATA_DIR}")
 
     if DATA_DIR.exists():
-        print("✅ Data directory exists")
+        print("Data directory exists")
+        errors, warnings = check_task_files(DATA_DIR)
+        for warning in warnings:
+            print(f"WARNING: {warning}")
+        for error in errors:
+            print(f"ERROR: {error}")
+        if errors:
+            print(f"Found {len(errors)} invalid reward criteria.")
+            sys.exit(1)
         print("You can now run tau2 commands.")
     else:
-        print("❌ Data directory does not exist!")
+        print("Data directory does not exist!")
         print("\nTo fix this, you can:")
         print("1. Set the TAU2_DATA_DIR environment variable:")
-        print("   export TAU2_DATA_DIR=/path/to/your/tau2-bench/data")
+        print("   export TAU2_DATA_DIR=/path/to/your/data")
         print("2. Or ensure the data directory exists in the expected location")
         sys.exit(1)
 

--- a/tests/test_check_data.py
+++ b/tests/test_check_data.py
@@ -1,0 +1,61 @@
+from tau2.scripts.check_data import find_reward_basis_issues
+
+
+def test_reward_basis_reports_empty_gates():
+    errors, warnings = find_reward_basis_issues(
+        [
+            {
+                "id": "empty-criteria",
+                "evaluation_criteria": {
+                    "communicate_info": [],
+                    "nl_assertions": None,
+                    "reward_basis": ["DB", "COMMUNICATE", "NL_ASSERTION"],
+                },
+            }
+        ]
+    )
+
+    assert errors == [
+        "task empty-criteria: COMMUNICATE is in reward_basis but "
+        "communicate_info is empty",
+        "task empty-criteria: NL_ASSERTION is in reward_basis but "
+        "nl_assertions is empty",
+    ]
+    assert warnings == []
+
+
+def test_reward_basis_reports_populated_criteria_that_are_not_gates():
+    errors, warnings = find_reward_basis_issues(
+        [
+            {
+                "id": "missing-gates",
+                "evaluation_criteria": {
+                    "communicate_info": ["tracking number"],
+                    "nl_assertions": ["The agent follows policy."],
+                    "reward_basis": ["DB"],
+                },
+            }
+        ]
+    )
+
+    assert errors == []
+    assert warnings == [
+        "task missing-gates: communicate_info is populated but "
+        "COMMUNICATE is not in reward_basis",
+    ]
+
+
+def test_reward_basis_uses_default_basis_when_omitted():
+    errors, warnings = find_reward_basis_issues(
+        [
+            {
+                "id": "default-basis",
+                "evaluation_criteria": {
+                    "communicate_info": ["status updated"],
+                },
+            }
+        ]
+    )
+
+    assert errors == []
+    assert warnings == []


### PR DESCRIPTION
## Summary

- Validate that active reward-basis components have criteria to evaluate.
- Correct empty `COMMUNICATE` and `NL_ASSERTION` gates in airline and retail task data.
- Add explicit gates for populated communication criteria and identified airline policy assertions.
- Keep `tau2 check-data` safe on Windows consoles.

## Testing

- `uv run pytest tests/test_check_data.py tests/test_tasks.py tests/test_domains/test_airline tests/test_domains/test_retail -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run tau2 check-data`

The full suite was not runnable locally because optional dependencies for voice, gym, retrieval, and Agentify tests are not installed.

This addresses the invalid empty reward gates in #384. It does not invent expected answers for the remaining semantic task-data gaps such as retail tasks 25, 57, and 65.

Related to #384.