### PR TITLE
fix: retry transient transcription failures

### DIFF
--- a/src/tau2/utils/retry.py
+++ b/src/tau2/utils/retry.py
@@ -43,8 +43,28 @@ def log_retry_attempt(retry_state):
     )
 
 
+def is_retryable_api_error(error: BaseException) -> bool:
+    """Return whether an external API error is safe to retry."""
+    if isinstance(
+        error,
+        (
+            ConnectionError,
+            TimeoutError,
+            OSError,
+            httpx.TimeoutException,
+            httpx.ConnectError,
+        ),
+    ):
+        return True
+
+    status_code = getattr(error, "status_code", None)
+    if status_code is None:
+        status_code = getattr(getattr(error, "response", None), "status_code", None)
+    return status_code == 429 or (status_code is not None and status_code >= 500)
+
+
 # Standard retry decorator for external API calls
-# Retries on connection errors and timeouts with exponential backoff
+# Retries on transient connection, timeout, rate-limit, and server errors
 api_retry = retry(
     stop=stop_after_attempt(DEFAULT_RETRY_ATTEMPTS),
     wait=wait_exponential(
@@ -52,7 +72,7 @@ api_retry = retry(
         min=DEFAULT_RETRY_MIN_WAIT,
         max=DEFAULT_RETRY_MAX_WAIT,
     ),
-    retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+    retry=retry_if_exception(is_retryable_api_error),
     before_sleep=log_retry_attempt,
     reraise=True,
 )

--- a/src/tau2/voice/transcription/transcribe.py
+++ b/src/tau2/voice/transcription/transcribe.py
@@ -16,7 +16,7 @@ from tau2.config import (
 )
 from tau2.data_model.audio import AudioData, AudioEncoding, AudioFormat
 from tau2.data_model.voice import TranscriptionConfig, TranscriptionResult
-from tau2.utils.retry import api_retry
+from tau2.utils.retry import api_retry, is_retryable_api_error
 from tau2.voice.utils.audio_preprocessing import (
     convert_to_mono,
     convert_to_pcm16,
@@ -52,6 +52,8 @@ def transcribe_audio(
             )
 
     except Exception as e:
+        if is_retryable_api_error(e):
+            raise
         return TranscriptionResult(
             transcript="", error=f"Transcription failed: {str(e)}"
         )
@@ -142,6 +144,8 @@ def transcribe_deepgram(
         return TranscriptionResult(transcript=transcript, confidence=confidence)
 
     except Exception as e:
+        if is_retryable_api_error(e):
+            raise
         return TranscriptionResult(
             transcript="", error=f"Deepgram transcription failed: {str(e)}"
         )
@@ -187,6 +191,8 @@ def transcribe_whisper(
 
         response = requests.post(url, headers=headers, files=files, data=data)
 
+        if response.status_code == 429 or response.status_code >= 500:
+            response.raise_for_status()
         if response.status_code != 200:
             return TranscriptionResult(
                 transcript="",
@@ -197,6 +203,8 @@ def transcribe_whisper(
         return TranscriptionResult(transcript=result.get("text", ""))
 
     except Exception as e:
+        if is_retryable_api_error(e):
+            raise
         return TranscriptionResult(
             transcript="", error=f"OpenAI transcription failed: {str(e)}"
         )
@@ -258,7 +266,7 @@ async def transcribe_gpt4o_realtime(
                         error_msg = f"OpenAI API error: {event}"
                         break
                 except asyncio.TimeoutError:
-                    break
+                    raise
 
             if error_msg:
                 return TranscriptionResult(transcript="", error=error_msg)
@@ -266,6 +274,8 @@ async def transcribe_gpt4o_realtime(
             return TranscriptionResult(transcript=transcript)
 
     except Exception as e:
+        if is_retryable_api_error(e):
+            raise
         return TranscriptionResult(
             transcript="", error=f"OpenAI Realtime transcription failed: {str(e)}"
         )

--- a/tests/test_voice/test_transcription_retry.py
+++ b/tests/test_voice/test_transcription_retry.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock
+
+import httpx
+import pytest
+from tenacity import wait_none
+
+from tau2.data_model.audio import AudioData, AudioEncoding, AudioFormat
+from tau2.data_model.voice import TranscriptionConfig, TranscriptionResult
+from tau2.voice.transcription import transcribe
+
+
+@pytest.fixture
+def pcm_audio() -> AudioData:
+    return AudioData(
+        data=b"\x00\x00",
+        format=AudioFormat(
+            encoding=AudioEncoding.PCM_S16LE,
+            sample_rate=24000,
+            channels=1,
+        ),
+    )
+
+
+def test_transcribe_audio_retries_transient_provider_failure(
+    monkeypatch: pytest.MonkeyPatch, pcm_audio: AudioData
+) -> None:
+    provider = Mock(
+        side_effect=[
+            ConnectionError("transient"),
+            TranscriptionResult(transcript="recovered"),
+        ]
+    )
+    monkeypatch.setattr(
+        transcribe,
+        "_convert_audio_to_pcm16_mono_24000",
+        lambda _audio: (pcm_audio, None),
+    )
+    monkeypatch.setattr(transcribe, "transcribe_deepgram", provider)
+    monkeypatch.setattr(
+        getattr(transcribe.transcribe_audio, "retry"), "wait", wait_none()
+    )
+
+    result = transcribe.transcribe_audio(pcm_audio, TranscriptionConfig(model="nova-2"))
+
+    assert provider.call_count == 2
+    assert result == TranscriptionResult(transcript="recovered")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        httpx.ConnectError("disconnected"),
+        httpx.ReadTimeout("timed out"),
+    ],
+)
+def test_transcribe_deepgram_propagates_transient_transport_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    pcm_audio: AudioData,
+    error: Exception,
+) -> None:
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "test-key")
+    monkeypatch.setattr(transcribe.requests, "post", Mock(side_effect=error))
+
+    with pytest.raises(type(error), match=str(error)):
+        transcribe.transcribe_deepgram(pcm_audio, TranscriptionConfig(model="nova-2"))


### PR DESCRIPTION
## Summary
Retries now run when transcription providers hit transient connection, timeout, rate-limit, or server errors instead of those failures being converted immediately into empty transcripts. Closes #383.

## Changes Made
- Let retryable failures escape provider-level error rendering.
- Cover provider retry and transport-error propagation.

## Testing
- `pytest -q tests/test_voice/test_transcription_retry.py`
- `ruff check` and `ruff format --check` on changed files

## Documentation
N/A; no user-facing API changed.

## Checklist
- [ ] Tests pass (`make test`; also run relevant tier targets if changes touch voice/knowledge/gym)
- [x] Code follows style guidelines (`make check-all`)
- [x] Documentation updated
- [x] Breaking changes noted
