### PR TITLE
Deck: move overview to front, standalone takeaways slide with hiring link

### DIFF
--- a/web/leaderboard/public/talks/stanford-aims-tau.html
+++ b/web/leaderboard/public/talks/stanford-aims-tau.html
@@ -662,6 +662,29 @@
     </div>
   </section>
 
+  <!-- ================= 1b · OVERVIEW & CONTENTS ================= -->
+  <section class="slide">
+    <div class="inner">
+      <div class="kicker">This talk, in one slide</div>
+      <h2>Overview &amp; contents</h2>
+      <p class="lede" style="max-width:74ch; margin-bottom:18px;">One benchmark family for customer-service agents, built on one idea: <strong>grounded tasks whose reward is a verifiable database diff</strong>. The talk traces how realism was added one axis at a time — <strong>dual control</strong>, <strong>knowledge</strong>, then <strong>full-duplex voice</strong> — and what each axis revealed that the previous one couldn&rsquo;t see.</p>
+      <div class="cols" style="grid-template-columns:1fr 1fr; gap:12px 22px;">
+        <div class="cardlist" style="gap:10px;">
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">01 &middot; Context</span>Sierra, and why customer service is where agents meet reality.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">02 &middot; <span class="tau">τ</span>-bench &middot; 2024</span>Tool &middot; agent &middot; user — grounded tasks, verifiable rewards, pass^k.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">03 &middot; <span class="tau">τ²</span>-bench &middot; 2025</span>Dual control: give the user a world — adoption, then saturation.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">04 &middot; <span class="tau">τ</span>-knowledge &middot; 2026</span>Find the policy before acting on it.</div>
+        </div>
+        <div class="cardlist" style="gap:10px;">
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">05 &middot; <span class="tau">τ</span>-voice &middot; 2026</span>Pause time: ticks, personas, the audio pipeline.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">06 &middot; Results &amp; analysis</span>The voice&ndash;text gap, interactivity metrics, failure attribution.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">07 &middot; What&rsquo;s next</span>Multilingual <span class="tau">τ</span>-voice, and thoughts on benchmarking.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">08 &middot; Appendix</span>User-realism study, significance tests, error analysis, limitations.</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- ================= 2 · SIERRA ================= -->
   <section class="slide">
     <div class="inner">
@@ -1936,40 +1959,27 @@
     </div>
   </section>
 
-  <!-- ================= 22b · OVERVIEW & CONTENTS ================= -->
+  <!-- ================= 22c · TAKEAWAYS ================= -->
   <section class="slide">
     <div class="inner">
-      <div class="kicker">This talk, in one slide</div>
-      <h2>Overview &amp; contents</h2>
-      <p class="lede" style="max-width:74ch; margin-bottom:18px;">One benchmark family for customer-service agents, built on one idea: <strong>grounded tasks whose reward is a verifiable database diff</strong>. The talk traces how realism was added one axis at a time — <strong>dual control</strong>, <strong>knowledge</strong>, then <strong>full-duplex voice</strong> — and what each axis revealed that the previous one couldn&rsquo;t see.</p>
-      <div class="cols" style="grid-template-columns:1fr 1fr; gap:12px 22px;">
-        <div class="cardlist" style="gap:10px;">
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">01 &middot; Context</span>Sierra, and why customer service is where agents meet reality.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">02 &middot; <span class="tau">τ</span>-bench &middot; 2024</span>Tool &middot; agent &middot; user — grounded tasks, verifiable rewards, pass^k.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">03 &middot; <span class="tau">τ²</span>-bench &middot; 2025</span>Dual control: give the user a world — adoption, then saturation.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">04 &middot; <span class="tau">τ</span>-knowledge &middot; 2026</span>Find the policy before acting on it.</div>
-        </div>
-        <div class="cardlist" style="gap:10px;">
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">05 &middot; <span class="tau">τ</span>-voice &middot; 2026</span>Pause time: ticks, personas, the audio pipeline.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">06 &middot; Results &amp; analysis</span>The voice&ndash;text gap, interactivity metrics, failure attribution.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">07 &middot; What&rsquo;s next</span>Multilingual <span class="tau">τ</span>-voice, and thoughts on benchmarking.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">08 &middot; Appendix</span>User-realism study, significance tests, error analysis, limitations.</div>
-        </div>
+      <div class="kicker">Takeaways</div>
+      <h2>If you remember four things</h2>
+      <div class="cols" style="grid-template-columns:1fr 1fr; gap:14px; margin-top:6px;">
+        <div class="card" style="font-size:15.5px;"><span class="tag">Ground the reward</span>The reward should be as grounded as possible — <b>deterministic is best</b>; it carried <span class="tau">τ</span> across four benchmarks. But <b>LLM judges are maturing</b>, and that opens the door to many new possibilities.</div>
+        <div class="card" style="font-size:15.5px;"><span class="tag">Choosing the problem is as important as choosing the solution</span>We&rsquo;ve found <b>production issues</b> to be a good source to draw from.</div>
+        <div class="card" style="font-size:15.5px;"><span class="tag">Quality &amp; verifiability are paramount</span>That&rsquo;s what drove <span class="tau">τ²</span>&rsquo;s adoption. You only trust the metrics <b>as much as you trust the system</b>.</div>
+        <div class="card" style="font-size:15.5px;"><span class="tag">Voice is not text + TTS</span>Full-duplex timing, accents, and noise cost frontier agents a <b>large share of their text performance</b>.</div>
       </div>
+      <div class="card chip" style="margin-top:16px;"><span class="tag">We&rsquo;re hiring — <a href="https://sierra.ai/careers" style="color:var(--accent-mid); text-decoration:none;">sierra.ai/careers</a></span></div>
     </div>
   </section>
 
-  <!-- ================= 23 · CLOSE (takeaways + thank you) ================= -->
+  <!-- ================= 23 · CLOSE ================= -->
   <section class="slide divider">
     <div class="inner">
       <div class="kicker">Takeaways</div>
-      <div class="giant" style="font-size:64px;">τ → τ² → τ³ → …</div>
-      <div class="cols" style="grid-template-columns:1fr 1fr; gap:12px; margin-top:20px;">
-        <div class="card" style="font-size:14px; padding:11px 16px;"><span class="tag">Ground the reward</span>The reward should be as grounded as possible — <b>deterministic is best</b>; it carried <span class="tau">τ</span> across four benchmarks. But <b>LLM judges are maturing</b>, and that opens the door to many new possibilities.</div>
-        <div class="card" style="font-size:14px; padding:11px 16px;"><span class="tag">Choosing the problem is as important as choosing the solution</span>We&rsquo;ve found <b>production issues</b> to be a good source to draw from.</div>
-        <div class="card" style="font-size:14px; padding:11px 16px;"><span class="tag">Quality &amp; verifiability are paramount</span>That&rsquo;s what drove <span class="tau">τ²</span>&rsquo;s adoption. You only trust the metrics <b>as much as you trust the system</b>.</div>
-        <div class="card" style="font-size:14px; padding:11px 16px;"><span class="tag">Voice is not text + TTS</span>Full-duplex timing, accents, and noise cost frontier agents a <b>large share of their text performance</b>.</div>
-      </div>
+      <div class="giant" style="font-size:96px;">τ → τ² → τ³ → …</div>
+      <p class="lede" style="margin-top:22px; max-width:70ch;">One grounded, deterministic task substrate — with realism added one axis at a time: <strong>dual control</strong>, then <strong>knowledge</strong>, then <strong>full-duplex voice</strong>, next <strong>language</strong>. Each axis found a capability cliff the previous one couldn’t see.</p>
       <div class="stats">
         <div class="stat"><div class="num" style="font-size:18px; padding-top:4px;">taubench.com</div><div class="lbl">leaderboards, trajectories, audio</div></div>
         <div class="stat"><div class="num" style="font-size:18px; padding-top:4px;">github.com/sierra-research/tau2-bench</div><div class="lbl">open source</div></div>


### PR DESCRIPTION
Fixes the previous round's slide placement:

- **Overview & contents** now sits right after the title slide (2/50), not at the end.
- **Takeaways** is its own slide again (39/50), right before the close, with the four reworded cards plus a "We're hiring — sierra.ai/careers" chip.
- The closing thank-you slide is restored exactly to its pre-#419 form (96px giant, lede, link cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)