### PR TITLE
Deck: 'So far' checkpoint slide, hiring link on thank-you, contents tweaks

### DIFF
--- a/web/leaderboard/public/talks/stanford-aims-tau.html
+++ b/web/leaderboard/public/talks/stanford-aims-tau.html
@@ -676,10 +676,9 @@
           <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">04 &middot; <span class="tau">τ</span>-knowledge &middot; 2026</span>Find the policy before acting on it.</div>
         </div>
         <div class="cardlist" style="gap:10px;">
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">05 &middot; <span class="tau">τ</span>-voice &middot; 2026</span>Pause time: ticks, personas, the audio pipeline.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">06 &middot; Results &amp; analysis</span>The voice&ndash;text gap, interactivity metrics, failure attribution.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">07 &middot; What&rsquo;s next</span>Multilingual <span class="tau">τ</span>-voice, and thoughts on benchmarking.</div>
-          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">08 &middot; Appendix</span>User-realism study, significance tests, error analysis, limitations.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">05 &middot; <span class="tau">τ</span>-voice &middot; 2026</span>Pause time: ticks, personas, the audio pipeline — then the voice&ndash;text gap, interactivity metrics, failure attribution.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">06 &middot; What&rsquo;s next</span>Multilingual <span class="tau">τ</span>-voice, and thoughts on benchmarking.</div>
+          <div class="card" style="font-size:14px; padding:10px 16px;"><span class="tag">07 &middot; Appendix</span>User-realism study, significance tests, error analysis, limitations.</div>
         </div>
       </div>
     </div>
@@ -1226,13 +1225,27 @@
     </div>
   </section>
 
+  <!-- ================= 9z · SO FAR ================= -->
+  <section class="slide">
+    <div class="inner">
+      <div class="kicker">Checkpoint</div>
+      <h2>So far</h2>
+      <div class="cols" style="grid-template-columns:1fr 1fr 1fr; gap:14px; margin-top:6px;">
+        <div class="card" style="font-size:14.5px;"><span class="tag"><span class="tau">τ</span>-bench &middot; 2024</span>The first <b>tool-use task-completion</b> benchmark — sets up the <b>user &middot; agent &middot; database</b> substrate.</div>
+        <div class="card" style="font-size:14.5px;"><span class="tag"><span class="tau">τ²</span>-bench &middot; 2025</span>Extends it to a world where <b>both user and agent</b> can interact — dual control.</div>
+        <div class="card" style="font-size:14.5px;"><span class="tag"><span class="tau">τ</span>-knowledge &middot; 2026</span>Adds a <b>banking domain</b> that needs <b>retrieval</b> and has a <b>harder policy</b>.</div>
+      </div>
+      <div class="card" style="margin-top:14px; background:var(--wash); font-size:15px;"><span class="tag">Going forward</span>We&rsquo;re <b>deprecating the other domains</b> — they&rsquo;re saturated and overfit. <b><span class="tau">τ</span>-banking</b> is the focus for the <b>text version of <span class="tau">τ</span>-bench</b>.</div>
+    </div>
+  </section>
+
   <!-- ================= 10 · TAU VOICE DIVIDER ================= -->
   <section class="slide divider">
     <div class="inner">
       <div class="kicker">The rest of this talk</div>
       <div class="giant">τ-voice</div>
       <h2>Grounded tasks, full-duplex, over a realistic phone line</h2>
-      <p class="lede">Voice is becoming a primary interface for agentic systems — and it is where text-benchmark performance goes to die.</p>
+      <p class="lede">Voice is becoming a primary interface for agentic systems.</p>
       <p class="footnote">Ray, Dhandhania, Barres &amp; Narasimhan — arXiv 2603.13686 · ICML 2026</p>
     </div>
   </section>
@@ -1970,7 +1983,6 @@
         <div class="card" style="font-size:15.5px;"><span class="tag">Quality &amp; verifiability are paramount</span>That&rsquo;s what drove <span class="tau">τ²</span>&rsquo;s adoption. You only trust the metrics <b>as much as you trust the system</b>.</div>
         <div class="card" style="font-size:15.5px;"><span class="tag">Voice is not text + TTS</span>Full-duplex timing, accents, and noise cost frontier agents a <b>large share of their text performance</b>.</div>
       </div>
-      <div class="card chip" style="margin-top:16px;"><span class="tag">We&rsquo;re hiring — <a href="https://sierra.ai/careers" style="color:var(--accent-mid); text-decoration:none;">sierra.ai/careers</a></span></div>
     </div>
   </section>
 
@@ -1984,6 +1996,7 @@
         <div class="stat"><div class="num" style="font-size:18px; padding-top:4px;">taubench.com</div><div class="lbl">leaderboards, trajectories, audio</div></div>
         <div class="stat"><div class="num" style="font-size:18px; padding-top:4px;">github.com/sierra-research/tau2-bench</div><div class="lbl">open source</div></div>
         <div class="stat"><div class="num" style="font-size:18px; padding-top:4px;"><a href="https://taubench.com/talks/stanford-aims-tau.html" style="color:inherit; text-decoration:none;">taubench.com/talks/stanford-aims-tau.html</a></div><div class="lbl">these slides</div></div>
+        <div class="stat"><div class="num" style="font-size:18px; padding-top:4px;"><a href="https://sierra.ai/careers" style="color:inherit; text-decoration:none;">sierra.ai/careers</a></div><div class="lbl">we&rsquo;re hiring!</div></div>
         <div class="stat"><div class="num" style="font-size:18px; padding-top:4px;">sohamray19 @ gmail</div><div class="lbl">thank you — questions?</div></div>
       </div>
     </div>


### PR DESCRIPTION
Four small deck changes:

- New **So far** checkpoint slide right before the τ-voice divider: τ-bench / τ²-bench / τ-knowledge recap cards plus a "Going forward" note that the other domains are deprecated in favor of τ-banking for text τ-bench.
- **We're hiring — sierra.ai/careers** card added to the thank-you slide's link row (and removed from the takeaways slide).
- Contents slide: **Results & analysis** folded into the τ-voice entry; items renumbered (7 total).
- τ-voice divider lede: dropped "— and it is where text-benchmark performance goes to die."

Deck is now 51 slides; all touched slides verified within the canvas via headless render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)