### PR TITLE
Blog: add Victor Barres and Honghua Dong to the Stanford AIMS talk card

### DIFF
--- a/web/leaderboard/src/data/blogData.js
+++ b/web/leaderboard/src/data/blogData.js
@@ -110,7 +110,7 @@ export const BLOG_POSTS = [
     description:
       'Slides from a guest lecture at the Stanford AIMS Seminar tracing the τ-bench family — from the original tool-agent-user substrate through dual control and knowledge to full-duplex voice — including how pausing time makes a realistic, controllable voice benchmark possible.',
     href: 'talks/stanford-aims-tau.html',
-    authorSlugs: ['soham-ray'],
+    authorSlugs: ['soham-ray', 'victor-barres', 'honghua-dong'],
   },
   {
     slug: 'tau-voice-sierra',


### PR DESCRIPTION
Adds Victor Barres and Honghua Dong alongside Soham Ray as authors on the Stanford AIMS talk blog card. Both already have author profiles and photos; verified locally that the byline and all three avatars render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)