### PR TITLE
Website: rewrite banner/hero copy, simplify CTAs, add evolution timeline

### DIFF
--- a/web/leaderboard/scripts/screenshot.mjs
+++ b/web/leaderboard/scripts/screenshot.mjs
@@ -1,0 +1,12 @@
+// Quick screenshot helper for local dev review.
+// Usage: node scripts/screenshot.mjs <url> <outfile> [fullpage]
+import { chromium } from 'playwright'
+
+const [url, outfile, fullpage] = process.argv.slice(2)
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1920, height: 1080 } })
+await page.goto(url, { waitUntil: 'networkidle' })
+await page.waitForTimeout(1000)
+await page.screenshot({ path: outfile, fullPage: fullpage === 'fullpage' })
+await browser.close()
+console.log(`saved ${outfile}`)

--- a/web/leaderboard/scripts/screenshot.mjs
+++ b/web/leaderboard/scripts/screenshot.mjs
@@ -1,4 +1,8 @@
 // Quick screenshot helper for local dev review.
+//
+// playwright is intentionally not a devDependency (only needed for this
+// helper). Before first use, run: npm install --no-save playwright
+//
 // Usage: node scripts/screenshot.mjs <url> <outfile> [fullpage]
 import { chromium } from 'playwright'
 

--- a/web/leaderboard/src/App.css
+++ b/web/leaderboard/src/App.css
@@ -173,11 +173,6 @@ body {
   pointer-events: none;
 }
 
-.dropdown-arrow {
-  font-size: 10px;
-  transition: transform 0.2s ease;
-}
-
 .nav-cta {
   background: #065f46;
   color: white;
@@ -400,154 +395,6 @@ body {
   border-color: #065f46;
   color: #065f46;
   transform: translateY(-1px);
-}
-
-/* Hero Papers Dropdown */
-.hero-dropdown {
-  position: relative;
-  display: inline-block;
-}
-
-.hero-dropdown .btn-secondary {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.hero-dropdown-menu {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%) translateY(-8px);
-  margin-top: 8px;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  min-width: 180px;
-  opacity: 0;
-  visibility: hidden;
-  transition: all 0.2s ease;
-  z-index: 1000;
-}
-
-.hero-dropdown-menu.open {
-  opacity: 1;
-  visibility: visible;
-  transform: translateX(-50%) translateY(0);
-}
-
-.hero-dropdown-menu > a {
-  display: block;
-  padding: 12px 16px;
-  color: #4a5568;
-  text-decoration: none;
-  font-size: 14px;
-  font-weight: 500;
-  transition: all 0.15s ease;
-  border-bottom: 1px solid #f1f5f9;
-}
-
-.hero-dropdown-menu > a:last-child {
-  border-bottom: none;
-}
-
-.hero-dropdown-menu > a:hover {
-  background: #f8fafc;
-  color: #065f46;
-}
-
-.hero-dropdown-menu > a:first-child,
-.hero-dropdown-menu > .hero-submenu-item:first-child .hero-submenu-label {
-  border-radius: 8px 8px 0 0;
-}
-
-.hero-dropdown-menu > a:last-child,
-.hero-dropdown-menu > .hero-submenu-item:last-child .hero-submenu-label {
-  border-radius: 0 0 8px 8px;
-}
-
-/* Submenu (nested dropdown) */
-.hero-submenu-item {
-  position: relative;
-}
-
-.hero-submenu-label {
-  display: block;
-  padding: 12px 16px;
-  color: #4a5568;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: default;
-  transition: all 0.15s ease;
-  border-bottom: 1px solid #f1f5f9;
-  text-align: center;
-}
-
-.hero-submenu-item:hover .hero-submenu-label {
-  background: #f8fafc;
-  color: #065f46;
-}
-
-.submenu-arrow {
-  font-size: 12px;
-  color: #a0aec0;
-  transition: color 0.15s ease;
-}
-
-.hero-submenu-item:hover .submenu-arrow {
-  color: #065f46;
-}
-
-.hero-submenu {
-  position: absolute;
-  left: 100%;
-  top: 0;
-  margin-left: 4px;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  min-width: 160px;
-  opacity: 0;
-  visibility: hidden;
-  transform: translateX(-8px);
-  transition: all 0.2s ease;
-  z-index: 1001;
-}
-
-.hero-submenu-item:hover .hero-submenu {
-  opacity: 1;
-  visibility: visible;
-  transform: translateX(0);
-}
-
-.hero-submenu a {
-  display: block;
-  padding: 12px 16px;
-  color: #4a5568;
-  text-decoration: none;
-  font-size: 14px;
-  font-weight: 500;
-  transition: all 0.15s ease;
-  border-bottom: 1px solid #f1f5f9;
-}
-
-.hero-submenu a:last-child {
-  border-bottom: none;
-}
-
-.hero-submenu a:hover {
-  background: #f8fafc;
-  color: #065f46;
-}
-
-.hero-submenu a:first-child {
-  border-radius: 8px 8px 0 0;
-}
-
-.hero-submenu a:last-child {
-  border-radius: 0 0 8px 8px;
 }
 
 .hero-visual {
@@ -1197,41 +1044,6 @@ body {
     max-width: 280px;
   }
 
-  .hero-dropdown {
-    width: 100%;
-    max-width: 280px;
-  }
-
-  .hero-dropdown .btn-secondary {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .hero-dropdown-menu {
-    left: 50%;
-    transform: translateX(-50%) translateY(-8px);
-  }
-
-  .hero-dropdown-menu.open {
-    transform: translateX(-50%) translateY(0);
-  }
-
-  .hero-submenu {
-    position: static;
-    margin-left: 0;
-    border: none;
-    box-shadow: none;
-    border-radius: 0;
-    opacity: 1;
-    visibility: visible;
-    transform: none;
-    background: #f8fafc;
-  }
-
-  .hero-submenu a {
-    padding-left: 32px;
-  }
-  
   .nav-links {
     display: flex;
     flex-direction: column;

--- a/web/leaderboard/src/App.css
+++ b/web/leaderboard/src/App.css
@@ -349,54 +349,6 @@ body {
   font-weight: 400;
 }
 
-.hero-actions {
-  display: flex;
-  flex-direction: row;
-  gap: 16px;
-  justify-content: center;
-}
-
-.button-row {
-  display: flex;
-  gap: 16px;
-  justify-content: flex-start;
-}
-
-.btn-primary {
-  background: #065f46;
-  color: white;
-  border: none;
-  padding: 16px 32px;
-  border-radius: 8px;
-  font-size: 16px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.btn-primary:hover {
-  background: #047857;
-  transform: translateY(-1px);
-}
-
-.btn-secondary {
-  background: white;
-  color: #718096;
-  border: 2px solid #e2e8f0;
-  padding: 14px 32px;
-  border-radius: 8px;
-  font-size: 16px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.btn-secondary:hover {
-  border-color: #065f46;
-  color: #065f46;
-  transform: translateY(-1px);
-}
-
 .hero-visual {
   flex: 1;
   display: flex;
@@ -835,26 +787,6 @@ body {
   justify-content: center;
 }
 
-.cta .btn-primary {
-  background: white;
-  color: #065f46;
-}
-
-.cta .btn-primary:hover {
-  background: #f7fafc;
-}
-
-.cta .btn-secondary {
-  background: transparent;
-  color: white;
-  border-color: rgba(255, 255, 255, 0.3);
-}
-
-.cta .btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: white;
-}
-
 /* Footer */
 .footer {
   background: #1a202c;
@@ -1027,23 +959,6 @@ body {
     font-size: 2.5rem;
   }
   
-  .hero-actions {
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .button-row {
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-  }
-  
-  .btn-primary,
-  .btn-secondary {
-    width: 100%;
-    max-width: 280px;
-  }
-
   .nav-links {
     display: flex;
     flex-direction: column;

--- a/web/leaderboard/src/App.jsx
+++ b/web/leaderboard/src/App.jsx
@@ -3,6 +3,7 @@ import './App.css'
 import TrajectoryVisualizer from './components/TrajectoryVisualizer'
 import Leaderboard from './components/Leaderboard'
 import LeaderboardPreview from './components/LeaderboardPreview'
+import EvolutionTimeline from './components/EvolutionTimeline'
 import Blog from './components/Blog'
 
 function App() {
@@ -33,7 +34,6 @@ function App() {
   
   const [currentView, setCurrentView] = useState(getInitialView())
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [papersDropdownOpen, setPapersDropdownOpen] = useState(false)
 
   // Handle navigation with URL updates
   const navigateTo = (view) => {
@@ -150,6 +150,7 @@ function App() {
             <button onClick={() => navigateTo('trajectory-visualizer')} className={`nav-link ${currentView === 'trajectory-visualizer' ? 'active' : ''}`}>Visualizer</button>
             <button onClick={() => navigateTo('blog')} className={`nav-link ${currentView === 'blog' ? 'active' : ''}`}>Blog</button>
             <a href="https://github.com/sierra-research/tau2-bench" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)}>GitHub</a>
+            <a href="https://github.com/sierra-research/tau2-bench/blob/main/docs/leaderboard-submission.md" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)}>Submit Results</a>
           </div>
         </div>
       </nav>
@@ -159,9 +160,10 @@ function App() {
         <div className="notification-container">
           <span className="notification-badge">NEW</span>
           <span className="notification-text">
-            τ-bench now supports the <strong>banking domain</strong> and a <strong>voice mode</strong>, introduced by the{' '}
-            <a href={`${import.meta.env.BASE_URL}blog/tau-knowledge.html`} className="notification-link">τ-knowledge</a> and{' '}
-            <a href={`${import.meta.env.BASE_URL}blog/tau-voice-examples.html`} className="notification-link">τ-voice examples</a>.
+            τ³-bench is here: <a href={`${import.meta.env.BASE_URL}blog/tau-knowledge.html`} className="notification-link"><strong>τ-knowledge</strong></a> evaluates
+            agents on knowledge-intensive tasks, and{' '}
+            <a href={`${import.meta.env.BASE_URL}blog/tau-voice-examples.html`} className="notification-link"><strong>τ-voice</strong></a> benchmarks
+            real-time voice agents.
           </span>
         </div>
       </div>
@@ -181,47 +183,17 @@ function App() {
                 </div>
 
                 <p className="hero-description">
-                  Benchmarking AI agents in collaborative real-world scenarios. 
-                  τ-bench challenges agents to coordinate, guide, and assist users 
-                  in achieving shared objectives across complex enterprise domains.
+                  Can AI agents reliably complete real-world tasks? 
+                  τ-bench measures how well agents converse with users, call tools, 
+                  retrieve knowledge, and follow policy across enterprise domains — in text and voice.
                 </p>
-
-                <div className="hero-actions">
-                  <div className="button-row">
-                    <a href="https://github.com/sierra-research/tau2-bench" target="_blank" rel="noopener noreferrer">
-                      <button className="btn-primary">View on GitHub</button>
-                    </a>
-                    <a href="https://github.com/sierra-research/tau2-bench/blob/main/docs/leaderboard-submission.md" target="_blank" rel="noopener noreferrer">
-                      <button className="btn-secondary">Submit Results</button>
-                    </a>
-                  </div>
-                  <div className="button-row">
-                    <div className="hero-dropdown" onMouseEnter={() => setPapersDropdownOpen(true)} onMouseLeave={() => setPapersDropdownOpen(false)}>
-                      <button className="btn-secondary">
-                        Read Papers <span className="dropdown-arrow">▾</span>
-                      </button>
-                      <div className={`hero-dropdown-menu ${papersDropdownOpen ? 'open' : ''}`}>
-                        <div className="hero-submenu-item">
-                          <span className="hero-submenu-label">τ³-bench <span className="submenu-arrow">›</span></span>
-                          <div className="hero-submenu">
-                            <a href="https://arxiv.org/abs/2603.04370" target="_blank" rel="noopener noreferrer">τ-Knowledge</a>
-                            <a href="https://arxiv.org/abs/2603.13686" target="_blank" rel="noopener noreferrer">τ-Voice</a>
-                          </div>
-                        </div>
-                        <a href="https://arxiv.org/abs/2506.07982" target="_blank" rel="noopener noreferrer">τ²-bench</a>
-                        <a href="https://arxiv.org/abs/2406.12045" target="_blank" rel="noopener noreferrer">τ-bench</a>
-                      </div>
-                    </div>
-                    <button className="btn-secondary" onClick={() => navigateTo('blog')}>Blog</button>
-                  </div>
-                </div>
 
                 <LeaderboardPreview onViewFullLeaderboard={() => navigateTo('leaderboard')} />
               </div>
             </div>
           </section>
 
-
+          <EvolutionTimeline />
         </>
       ) : currentView === 'leaderboard' ? (
         <Leaderboard />

--- a/web/leaderboard/src/components/EvolutionTimeline.css
+++ b/web/leaderboard/src/components/EvolutionTimeline.css
@@ -1,0 +1,152 @@
+.evolution-section {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 24px 64px;
+}
+
+.evolution-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: #2d3748;
+  text-align: center;
+  margin: 0 0 32px;
+}
+
+.evolution-timeline {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+/* Vertical rail connecting the dots */
+.evolution-timeline::before {
+  content: '';
+  position: absolute;
+  left: 7px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: #e2e8f0;
+}
+
+.evolution-entry {
+  display: flex;
+  gap: 20px;
+}
+
+.evolution-marker {
+  position: relative;
+  flex: 0 0 16px;
+}
+
+.evolution-dot {
+  display: block;
+  width: 12px;
+  height: 12px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: #065f46;
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 2px #065f46;
+}
+
+.evolution-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.evolution-header {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.evolution-name {
+  font-size: 17px;
+  font-weight: 700;
+  color: #2d3748;
+}
+
+.evolution-badge {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #6b46c1;
+  background: #faf5ff;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.evolution-date {
+  font-size: 13px;
+  font-weight: 500;
+  color: #a0aec0;
+}
+
+.evolution-links {
+  margin-left: auto;
+  display: flex;
+  gap: 14px;
+}
+
+.evolution-link {
+  font-size: 13px;
+  font-weight: 600;
+  color: #065f46;
+  text-decoration: none;
+}
+
+.evolution-link:hover {
+  color: #047857;
+  text-decoration: underline;
+}
+
+.evolution-description {
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: #4a5568;
+  margin: 6px 0 10px;
+}
+
+.evolution-domains {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.evolution-domains-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #a0aec0;
+}
+
+.evolution-domain-chip {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #4a5568;
+  background: #f7fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  padding: 3px 10px;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .evolution-section {
+    padding: 16px 16px 48px;
+  }
+
+  .evolution-entry {
+    gap: 14px;
+  }
+
+  .evolution-links {
+    margin-left: 0;
+  }
+}

--- a/web/leaderboard/src/components/EvolutionTimeline.jsx
+++ b/web/leaderboard/src/components/EvolutionTimeline.jsx
@@ -1,0 +1,138 @@
+import './EvolutionTimeline.css'
+
+// One entry per release, chronological. All content is static and visible
+// without interaction; the only links are the paper/blog references.
+const MILESTONES = [
+  {
+    name: 'τ-bench',
+    date: 'June 2024',
+    links: [
+      { label: 'Paper', href: 'https://arxiv.org/abs/2406.12045' },
+      { label: 'Blog', href: 'https://sierra.ai/blog/benchmarking-ai-agents' },
+    ],
+    description: (
+      <>
+        The original benchmark for tool-agent-user interaction. Agents converse
+        with a simulated user and call tools, scored against verifiable database
+        outcomes with the pass<sup>k</sup> reliability metric.
+      </>
+    ),
+    domainsLabel: 'Domains',
+    domains: ['🛍️ Retail', '✈️ Airline'],
+  },
+  {
+    name: 'τ²-bench',
+    date: 'June 2025',
+    links: [
+      { label: 'Paper', href: 'https://arxiv.org/abs/2506.07982' },
+      { label: 'Blog', href: 'https://sierra.ai/blog/benchmarking-agents-in-collaborative-real-world-scenarios' },
+    ],
+    description: (
+      <>
+        Dual control: the user can now act on the world too. Agents must guide
+        users through steps only the user can perform, not just act on their
+        behalf.
+      </>
+    ),
+    domainsLabel: 'Adds domain',
+    domains: ['📱 Telecom'],
+  },
+  {
+    name: 'Task audit & fixes',
+    date: 'February 2026',
+    badge: 'τ³-bench',
+    links: [
+      { label: 'Blog', href: `${import.meta.env.BASE_URL}blog/tau3-task-fixes.html` },
+    ],
+    description: (
+      <>
+        Audited and fixed 50+ tasks across the airline and retail domains —
+        correcting expected actions, ambiguous instructions, and impossible
+        constraints.
+      </>
+    ),
+    domainsLabel: 'Updates',
+    domains: ['🛍️ Retail', '✈️ Airline'],
+  },
+  {
+    name: 'τ-knowledge',
+    date: 'March 2026',
+    badge: 'τ³-bench',
+    links: [
+      { label: 'Paper', href: 'https://arxiv.org/abs/2603.04370' },
+      { label: 'Blog', href: `${import.meta.env.BASE_URL}blog/tau-knowledge.html` },
+    ],
+    description: (
+      <>
+        Knowledge-intensive tasks: agents retrieve and reason over a realistic
+        knowledge base of ~700 documents, combining retrieval with policy
+        application.
+      </>
+    ),
+    domainsLabel: 'Adds domain',
+    domains: ['🏦 Banking'],
+  },
+  {
+    name: 'τ-voice',
+    date: 'March 2026',
+    badge: 'τ³-bench',
+    links: [
+      { label: 'Paper', href: 'https://arxiv.org/abs/2603.13686' },
+      { label: 'Blog', href: 'https://sierra.ai/blog/tau-voice-benchmarking-real-time-voice-agents-on-real-world-tasks' },
+    ],
+    description: (
+      <>
+        Real-time voice: full-duplex conversations with interruptions, accents,
+        and background noise — the same task rigor, now in speech.
+      </>
+    ),
+    domainsLabel: 'Voice mode',
+    domains: ['🛍️ Retail', '✈️ Airline', '📱 Telecom'],
+  },
+]
+
+function EvolutionTimeline() {
+  return (
+    <section className="evolution-section">
+      <h2 className="evolution-title">How τ-bench has evolved</h2>
+      <div className="evolution-timeline">
+        {MILESTONES.map((m) => (
+          <div className="evolution-entry" key={`${m.name}-${m.date}`}>
+            <div className="evolution-marker">
+              <span className="evolution-dot" />
+            </div>
+            <div className="evolution-content">
+              <div className="evolution-header">
+                <span className="evolution-name">{m.name}</span>
+                {m.badge && <span className="evolution-badge">{m.badge}</span>}
+                <span className="evolution-date">{m.date}</span>
+                <span className="evolution-links">
+                  {m.links.map((l) => (
+                    <a
+                      className="evolution-link"
+                      key={l.label}
+                      href={l.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {l.label} →
+                    </a>
+                  ))}
+                </span>
+              </div>
+              <p className="evolution-description">{m.description}</p>
+              <div className="evolution-domains">
+                <span className="evolution-domains-label">{m.domainsLabel}:</span>
+                {m.domains.map((d) => (
+                  <span className="evolution-domain-chip" key={d}>{d}</span>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default EvolutionTimeline

--- a/web/leaderboard/src/components/LeaderboardPreview.css
+++ b/web/leaderboard/src/components/LeaderboardPreview.css
@@ -149,22 +149,22 @@
 }
 
 .preview-cta {
-  background: none;
-  border: 2px solid #e2e8f0;
-  color: #065f46;
-  font-size: 14px;
+  background: #065f46;
+  border: 2px solid #065f46;
+  color: white;
+  font-size: 15px;
   font-weight: 600;
   cursor: pointer;
-  padding: 10px 24px;
+  padding: 12px 28px;
   border-radius: 8px;
   transition: all 0.15s ease;
 }
 
 .preview-cta:hover {
-  background: #f0fdf4;
-  border-color: #065f46;
-  color: #047857;
+  background: #047857;
+  border-color: #047857;
   transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(6, 95, 70, 0.25);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

Homepage improvements focused on first-time visitors:

- **Banner**: now announces τ³-bench with links to τ-knowledge and τ-voice (previous text incorrectly said the tracks were "introduced by the τ-voice examples")
- **Hero copy**: leads with "Can AI agents reliably complete real-world tasks?" and describes what τ-bench actually measures (conversing with users, calling tools, retrieving knowledge, following policy) instead of the vague "collaborative scenarios" copy
- **CTA cleanup**: five hero buttons across two rows reduced to a single primary "View Full Leaderboard" CTA below the preview cards. "Submit Results" moved to the nav next to GitHub; "Blog"/"View on GitHub" buttons dropped (duplicated nav links); "Read Papers" dropdown removed (papers now linked from the timeline) along with its ~180 lines of dead CSS
- **New "How τ-bench has evolved" timeline**: five entries (τ-bench, τ²-bench, task audit & fixes, τ-knowledge, τ-voice) with dates, capability summaries, domain chips, and paper/blog links — so newcomers can understand the benchmark's history and how the domains fit together at a glance, without any interaction
- Adds `scripts/screenshot.mjs`, a small Playwright helper used for local visual review

## Test plan

- [x] Verified desktop rendering at 1920×1080 (hero, banner, timeline, preview cards)
- [x] Verified banner wraps and timeline stacks correctly at mobile width (390px)
- [ ] Spot-check deployed preview on mobile device

Made with [Cursor](https://cursor.com)