### PR TITLE
Website: split leaderboard into τ²-bench / τ-knowledge / τ-voice tracks

### DIFF
--- a/web/leaderboard/src/App.jsx
+++ b/web/leaderboard/src/App.jsx
@@ -162,7 +162,7 @@ function App() {
           <span className="notification-text">
             τ³-bench is here: <a href={`${import.meta.env.BASE_URL}blog/tau-knowledge.html`} className="notification-link"><strong>τ-knowledge</strong></a> evaluates
             agents on knowledge-intensive tasks, and{' '}
-            <a href={`${import.meta.env.BASE_URL}blog/tau-voice-examples.html`} className="notification-link"><strong>τ-voice</strong></a> benchmarks
+            <a href="https://sierra.ai/blog/tau-voice-benchmarking-real-time-voice-agents-on-real-world-tasks" className="notification-link"><strong>τ-voice</strong></a> benchmarks
             real-time voice agents.
           </span>
         </div>

--- a/web/leaderboard/src/components/EvolutionTimeline.jsx
+++ b/web/leaderboard/src/components/EvolutionTimeline.jsx
@@ -1,7 +1,8 @@
 import './EvolutionTimeline.css'
 
-// One entry per release, chronological. All content is static and visible
-// without interaction; the only links are the paper/blog references.
+// One entry per release, chronological (oldest first); rendered newest-first.
+// All content is static and visible without interaction; the only links are
+// the paper/blog references.
 const MILESTONES = [
   {
     name: 'τ-bench',
@@ -96,7 +97,7 @@ function EvolutionTimeline() {
     <section className="evolution-section">
       <h2 className="evolution-title">How τ-bench has evolved</h2>
       <div className="evolution-timeline">
-        {MILESTONES.map((m) => (
+        {[...MILESTONES].reverse().map((m) => (
           <div className="evolution-entry" key={`${m.name}-${m.date}`}>
             <div className="evolution-marker">
               <span className="evolution-dot" />

--- a/web/leaderboard/src/components/Leaderboard.css
+++ b/web/leaderboard/src/components/Leaderboard.css
@@ -216,10 +216,17 @@
     justify-content: center;
   }
 
+  /* Three bucket options need to fit side by side on narrow screens */
   .benchmark-toggle-option {
-    padding: 8px 20px;
-    font-size: 14px;
-    min-width: 110px;
+    padding: 8px 12px;
+    font-size: 13px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .benchmark-toggle-container {
+    width: 100%;
+    max-width: 360px;
   }
 }
 

--- a/web/leaderboard/src/components/Leaderboard.css
+++ b/web/leaderboard/src/components/Leaderboard.css
@@ -29,7 +29,7 @@
   justify-content: center;
   gap: 24px;
   flex-wrap: wrap;
-  margin-bottom: 32px;
+  margin-bottom: 12px;
 }
 
 .leaderboard-title-row .leaderboard-title {
@@ -105,7 +105,8 @@
   font-size: 1.125rem;
   color: #718096;
   text-align: center;
-  margin-bottom: 32px;
+  margin: 0 auto 32px;
+  max-width: 640px;
   font-weight: 400;
 }
 

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -45,16 +45,8 @@ const VOICE_DOMAINS = [
   { key: 'telecom', label: '📱 Telecom' },
 ]
 
+// Key order determines toggle order: newest tracks first.
 const BENCHMARK_CONFIG = {
-  core: {
-    label: 'τ²-bench',
-    icon: '📝',
-    title: 'τ²-bench Leaderboard',
-    modality: 'text',
-    domains: CORE_DOMAINS,
-    defaultDomain: 'overall',
-    breakdownDomains: ['retail', 'airline', 'telecom'],
-  },
   knowledge: {
     label: 'τ-knowledge',
     icon: '🏦',
@@ -70,6 +62,15 @@ const BENCHMARK_CONFIG = {
     title: 'τ-voice Leaderboard',
     modality: 'voice',
     domains: VOICE_DOMAINS,
+    defaultDomain: 'overall',
+    breakdownDomains: ['retail', 'airline', 'telecom'],
+  },
+  core: {
+    label: 'τ²-bench',
+    icon: '📝',
+    title: 'τ²-bench Leaderboard',
+    modality: 'text',
+    domains: CORE_DOMAINS,
     defaultDomain: 'overall',
     breakdownDomains: ['retail', 'airline', 'telecom'],
   },
@@ -228,13 +229,14 @@ const Leaderboard = () => {
     if (fromHash) return fromHash
 
     const fromStorage = normalizeBenchmark(localStorage.getItem('benchmark'))
-    return BENCHMARK_VALUES.has(fromStorage) ? fromStorage : 'core'
+    // Default to the first toggle position (newest track)
+    return BENCHMARK_VALUES.has(fromStorage) ? fromStorage : 'knowledge'
   })
   // Add unified domain selection state with localStorage persistence
   const [domain, setDomain] = useState(() => {
     const storedBenchmark = normalizeBenchmark(localStorage.getItem('benchmark'))
     const storedDomain = localStorage.getItem('domain')
-    const config = BENCHMARK_CONFIG[storedBenchmark] || BENCHMARK_CONFIG.core
+    const config = BENCHMARK_CONFIG[storedBenchmark] || BENCHMARK_CONFIG.knowledge
     return config.domains.some(({ key }) => key === storedDomain)
       ? storedDomain
       : config.defaultDomain

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -47,7 +47,7 @@ const VOICE_DOMAINS = [
 
 const BENCHMARK_CONFIG = {
   core: {
-    label: 'Core',
+    label: 'τ²-bench',
     icon: '📝',
     title: 'τ²-bench Leaderboard',
     modality: 'text',
@@ -56,7 +56,7 @@ const BENCHMARK_CONFIG = {
     breakdownDomains: ['retail', 'airline', 'telecom'],
   },
   knowledge: {
-    label: 'Knowledge',
+    label: 'τ-knowledge',
     icon: '🏦',
     title: 'τ-knowledge Leaderboard',
     modality: 'text',
@@ -65,7 +65,7 @@ const BENCHMARK_CONFIG = {
     breakdownDomains: ['banking_knowledge'],
   },
   voice: {
-    label: 'Voice',
+    label: 'τ-voice',
     icon: '🎙️',
     title: 'τ-voice Leaderboard',
     modality: 'voice',

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -2,7 +2,13 @@ import React, { useState, useEffect } from 'react'
 import './Leaderboard.css'
 import ProgressView from './ProgressView'
 
-const BENCHMARK_VALUES = new Set(['text', 'voice'])
+// The leaderboard is split into three buckets, one per benchmark track:
+// Core (τ²-bench: retail/airline/telecom in text), Knowledge (τ-knowledge:
+// banking), and Voice (τ-voice: retail/airline/telecom in real-time voice).
+const BENCHMARK_VALUES = new Set(['core', 'knowledge', 'voice'])
+
+// Pre-bucket URLs and localStorage used benchmark=text for what is now 'core'.
+const normalizeBenchmark = (value) => (value === 'text' ? 'core' : value)
 
 const getBenchmarkFromHash = () => {
   const hash = window.location.hash.slice(1)
@@ -11,7 +17,7 @@ const getBenchmarkFromHash = () => {
   // benchmark on the same view, so accept either route.
   if (route !== 'leaderboard' && route !== 'progress') return null
 
-  const value = new URLSearchParams(queryString).get('benchmark')
+  const value = normalizeBenchmark(new URLSearchParams(queryString).get('benchmark'))
   return BENCHMARK_VALUES.has(value) ? value : null
 }
 
@@ -19,12 +25,18 @@ const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
   || `${import.meta.env.BASE_URL}submissions`
 
 const NO_CACHE = { cache: 'no-cache' }
-const TEXT_DEFAULT_DOMAIN = 'banking_knowledge'
-const TEXT_DOMAINS = [
-  { key: 'banking_knowledge', label: '🏦 Banking' },
+const CORE_DOMAINS = [
+  { key: 'overall', label: '📊 Overall' },
   { key: 'retail', label: '🛍️ Retail' },
   { key: 'airline', label: '✈️ Airline' },
   { key: 'telecom', label: '📱 Telecom' },
+]
+// TODO(voice-banking): when banking is supported in voice mode, add a
+// Text | Voice modality toggle inside the Knowledge bucket rather than a
+// banking domain tab under Voice. That keeps the Voice bucket's Overall
+// (core 3 domains) stable and keeps all knowledge scores in one place.
+const KNOWLEDGE_DOMAINS = [
+  { key: 'banking_knowledge', label: '🏦 Banking' },
 ]
 const VOICE_DOMAINS = [
   { key: 'overall', label: '📊 Overall' },
@@ -32,6 +44,43 @@ const VOICE_DOMAINS = [
   { key: 'airline', label: '✈️ Airline' },
   { key: 'telecom', label: '📱 Telecom' },
 ]
+
+const BENCHMARK_CONFIG = {
+  core: {
+    label: 'Core',
+    icon: '📝',
+    title: 'τ²-bench Leaderboard',
+    modality: 'text',
+    domains: CORE_DOMAINS,
+    defaultDomain: 'overall',
+    breakdownDomains: ['retail', 'airline', 'telecom'],
+  },
+  knowledge: {
+    label: 'Knowledge',
+    icon: '🏦',
+    title: 'τ-knowledge Leaderboard',
+    modality: 'text',
+    domains: KNOWLEDGE_DOMAINS,
+    defaultDomain: 'banking_knowledge',
+    breakdownDomains: ['banking_knowledge'],
+  },
+  voice: {
+    label: 'Voice',
+    icon: '🎙️',
+    title: 'τ-voice Leaderboard',
+    modality: 'voice',
+    domains: VOICE_DOMAINS,
+    defaultDomain: 'overall',
+    breakdownDomains: ['retail', 'airline', 'telecom'],
+  },
+}
+
+const DOMAIN_CARDS = {
+  retail: { key: 'retail', label: 'Retail', icon: '🛍️', desc: 'Order cancellations, returns, exchanges, address changes, and product inquiries.' },
+  airline: { key: 'airline', label: 'Airline', icon: '✈️', desc: 'Flight bookings, modifications, cancellations, refunds, baggage, and compensation.' },
+  telecom: { key: 'telecom', label: 'Telecom', icon: '📱', desc: 'Technical support for connectivity issues, bill payments, and plan management.' },
+  banking_knowledge: { key: 'banking_knowledge', label: 'Banking', icon: '🏦', desc: 'Banking customer service with knowledge retrieval over policy documents.' },
+}
 
 const formatVoicePipeline = (pipeline) => {
   if (!pipeline) return ''
@@ -172,22 +221,23 @@ const formatInteractionValue = (value, unit) => {
 }
 
 const Leaderboard = () => {
-  // Benchmark selector: 'text' (τ-bench) or 'voice' (τ-voice)
+  // Benchmark selector: 'core' (τ²-bench), 'knowledge' (τ-knowledge), or
+  // 'voice' (τ-voice)
   const [benchmark, setBenchmark] = useState(() => {
     const fromHash = getBenchmarkFromHash()
     if (fromHash) return fromHash
 
-    const fromStorage = localStorage.getItem('benchmark')
-    return BENCHMARK_VALUES.has(fromStorage) ? fromStorage : 'text'
+    const fromStorage = normalizeBenchmark(localStorage.getItem('benchmark'))
+    return BENCHMARK_VALUES.has(fromStorage) ? fromStorage : 'core'
   })
   // Add unified domain selection state with localStorage persistence
   const [domain, setDomain] = useState(() => {
-    const storedBenchmark = localStorage.getItem('benchmark')
+    const storedBenchmark = normalizeBenchmark(localStorage.getItem('benchmark'))
     const storedDomain = localStorage.getItem('domain')
-    const validDomains = storedBenchmark === 'voice' ? VOICE_DOMAINS : TEXT_DOMAINS
-    return validDomains.some(({ key }) => key === storedDomain)
+    const config = BENCHMARK_CONFIG[storedBenchmark] || BENCHMARK_CONFIG.core
+    return config.domains.some(({ key }) => key === storedDomain)
       ? storedDomain
-      : (storedBenchmark === 'voice' ? 'overall' : TEXT_DEFAULT_DOMAIN)
+      : config.defaultDomain
   })
   // Selected pass^k metric (1-4) with localStorage persistence
   const [selectedPassK, setSelectedPassK] = useState(() => {
@@ -315,18 +365,19 @@ const Leaderboard = () => {
             submission.results.banking_knowledge?.pass_4 || null
           ]
           
-          // Calculate overall averages (only if all 4 domains have data)
+          // Overall = average of the three core domains (retail, airline,
+          // telecom), only when all three have data. Banking is scored
+          // separately in the Knowledge bucket.
           const hasRetailData = submission.results.retail?.pass_1 !== null && submission.results.retail?.pass_1 !== undefined
           const hasAirlineData = submission.results.airline?.pass_1 !== null && submission.results.airline?.pass_1 !== undefined
           const hasTelecomData = submission.results.telecom?.pass_1 !== null && submission.results.telecom?.pass_1 !== undefined
-          const hasBankingData = submission.results.banking_knowledge?.pass_1 !== null && submission.results.banking_knowledge?.pass_1 !== undefined
           
-          const overallData = (hasRetailData && hasAirlineData && hasTelecomData && hasBankingData) 
+          const overallData = (hasRetailData && hasAirlineData && hasTelecomData) 
             ? [0, 1, 2, 3].map(passIndex => {
-                const values = [retailData[passIndex], airlineData[passIndex], telecomData[passIndex], bankingData[passIndex]].filter(val => val !== null)
+                const values = [retailData[passIndex], airlineData[passIndex], telecomData[passIndex]].filter(val => val !== null)
                 return values.length > 0 ? values.reduce((sum, val) => sum + val, 0) / values.length : null
               })
-            : [null, null, null, null] // No overall score if missing any domain
+            : [null, null, null, null] // No overall score if missing any core domain
           
           const modelData = {
             modelName: submission.model_name,
@@ -451,9 +502,9 @@ const Leaderboard = () => {
   }, [domain])
 
   useEffect(() => {
-    const domainsForBenchmark = benchmark === 'voice' ? VOICE_DOMAINS : TEXT_DOMAINS
-    if (!domainsForBenchmark.some(({ key }) => key === domain)) {
-      setDomain(benchmark === 'voice' ? 'overall' : TEXT_DEFAULT_DOMAIN)
+    const config = BENCHMARK_CONFIG[benchmark]
+    if (!config.domains.some(({ key }) => key === domain)) {
+      setDomain(config.defaultDomain)
     }
   }, [benchmark, domain])
 
@@ -492,16 +543,13 @@ const Leaderboard = () => {
   const handleBenchmarkChange = (newBenchmark) => {
     setBenchmark(newBenchmark)
     setExpandedRows(new Set())
+    const config = BENCHMARK_CONFIG[newBenchmark]
+    if (!config.domains.some(({ key }) => key === domain)) {
+      setDomain(config.defaultDomain)
+    }
     if (newBenchmark === 'voice') {
-      // Voice doesn't have banking_knowledge or a meaningful overall (no banking)
-      // Reset to 'overall' which will show avg of available domains
-      if (domain === 'banking_knowledge') {
-        setDomain('overall')
-      }
       // Voice only has pass^1
       setSelectedPassK(1)
-    } else if (domain === 'overall') {
-      setDomain(TEXT_DEFAULT_DOMAIN)
     }
   }
 
@@ -567,9 +615,11 @@ const Leaderboard = () => {
     )
   }
 
+  const benchConfig = BENCHMARK_CONFIG[benchmark]
+
   const hasUnverifiedSubmission = Object.values(passKData).some(data => {
     // Filter by benchmark modality
-    if (data.modality !== benchmark) return false
+    if (data.modality !== benchConfig.modality) return false
     if (data.isLegacy && !showLegacy) return false
     const isStandard = data.submissionType === 'standard' || !data.submissionType
     const isCustom = data.submissionType === 'custom'
@@ -584,7 +634,8 @@ const Leaderboard = () => {
 
   // Determine domains available for current benchmark
   const isVoice = benchmark === 'voice'
-  const availableDomains = isVoice ? VOICE_DOMAINS : TEXT_DOMAINS
+  const availableDomains = benchConfig.domains
+  const benchmarkKeys = Object.keys(BENCHMARK_CONFIG)
 
   // For voice overall, only average the 3 non-banking domains
   const voiceDomains = ['retail', 'airline', 'telecom']
@@ -594,35 +645,34 @@ const Leaderboard = () => {
     <div className="leaderboard-container">
       {/* Benchmark Selector */}
       <div className="benchmark-selector">
-        <div className="benchmark-toggle-container">
-          <button
-            className={`benchmark-toggle-option ${benchmark === 'text' ? 'active' : ''}`}
-            onClick={() => handleBenchmarkChange('text')}
-          >
-            <span className="benchmark-icon">📝</span> τ-bench
-          </button>
-          <button
-            className={`benchmark-toggle-option ${benchmark === 'voice' ? 'active' : ''}`}
-            onClick={() => handleBenchmarkChange('voice')}
-          >
-            <span className="benchmark-icon">🎙️</span> τ-voice
-          </button>
+        <div className="benchmark-toggle-container" style={{ '--benchmark-count': benchmarkKeys.length }}>
+          {benchmarkKeys.map((key) => (
+            <button
+              key={key}
+              className={`benchmark-toggle-option ${benchmark === key ? 'active' : ''}`}
+              onClick={() => handleBenchmarkChange(key)}
+            >
+              <span className="benchmark-icon">{BENCHMARK_CONFIG[key].icon}</span> {BENCHMARK_CONFIG[key].label}
+            </button>
+          ))}
           <div
             className="benchmark-toggle-slider"
             style={{
-              transform: benchmark === 'text' ? 'translateX(0%)' : 'translateX(100%)'
+              width: `calc((100% - 8px) / ${benchmarkKeys.length})`,
+              transform: `translateX(${benchmarkKeys.indexOf(benchmark) * 100}%)`
             }}
           />
         </div>
       </div>
 
       <div className="leaderboard-title-row">
-        <h2 className="leaderboard-title">{isVoice ? 'τ-voice Leaderboard' : 'τ-bench Leaderboard'}</h2>
+        <h2 className="leaderboard-title">{benchConfig.title}</h2>
       </div>
 
       {/* Combined Controls Row — applies to both ranking and progress views */}
       <div className="leaderboard-controls">
-        {/* Domain Toggle Switch */}
+        {/* Domain Toggle Switch (hidden when the bucket has a single domain) */}
+        {availableDomains.length > 1 && (
         <div className="domain-toggle-switch">
           <div className="toggle-container domain-toggle-container" style={{ '--domain-count': availableDomains.length }}>
             {availableDomains.map(d => (
@@ -643,6 +693,7 @@ const Leaderboard = () => {
             />
           </div>
         </div>
+        )}
 
         {/* Submission Type Filter */}
         <div className="submission-type-filter">
@@ -664,7 +715,7 @@ const Leaderboard = () => {
             <span className="checkbox-checkmark"></span>
             <span className="checkbox-label">Custom</span>
           </label>
-          {!isVoice && (
+          {benchmark === 'core' && (
             <label className="checkbox-container">
               <input 
                 type="checkbox" 
@@ -708,7 +759,7 @@ const Leaderboard = () => {
       </div>
 
       {/* Table View */}
-      {(!showStandard && !showCustom && (isVoice || !showLegacy)) ? (
+      {(!showStandard && !showCustom && (benchmark !== 'core' || !showLegacy)) ? (
           <div className="filter-empty-state">
             <div className="empty-icon">🔍</div>
             <h3>No Results</h3>
@@ -831,7 +882,7 @@ const Leaderboard = () => {
                 const modelStats = Object.entries(passKData)
                   .filter(([, data]) => {
                     // Filter by benchmark modality
-                    if (data.modality !== benchmark) {
+                    if (data.modality !== benchConfig.modality) {
                       return false
                     }
                     // Filter out legacy submissions unless toggled on
@@ -851,7 +902,7 @@ const Leaderboard = () => {
                       return voiceDomains.some(d => data[d]?.some(val => val !== null))
                     }
                     
-                    // For overall domain, only include models that have data for all 4 domains
+                    // For overall domain, only include models that have data for all core domains
                     if (domain === 'overall') {
                       return data.overall.some(val => val !== null)
                     }
@@ -1153,19 +1204,7 @@ const Leaderboard = () => {
                     <tr className="domain-detail-row">
                       <td colSpan={isVoice ? 12 : 8} className="domain-detail-cell">
                         <div className="domain-breakdown">
-                          {(isVoice
-                            ? [
-                                { key: 'retail', label: 'Retail', icon: '🛍️', desc: 'Order cancellations, returns, exchanges, address changes, and product inquiries.' },
-                                { key: 'airline', label: 'Airline', icon: '✈️', desc: 'Flight bookings, modifications, cancellations, refunds, baggage, and compensation.' },
-                                { key: 'telecom', label: 'Telecom', icon: '📱', desc: 'Technical support for connectivity issues, bill payments, and plan management.' },
-                              ]
-                            : [
-                                { key: 'retail', label: 'Retail', icon: '🛍️', desc: 'Order cancellations, returns, exchanges, address changes, and product inquiries.' },
-                                { key: 'airline', label: 'Airline', icon: '✈️', desc: 'Flight bookings, modifications, cancellations, refunds, baggage, and compensation.' },
-                                { key: 'telecom', label: 'Telecom', icon: '📱', desc: 'Technical support for connectivity issues, bill payments, and plan management.' },
-                                { key: 'banking_knowledge', label: 'Banking', icon: '🏦', desc: 'Banking customer service with knowledge retrieval over policy documents.' },
-                              ]
-                          ).map(({ key, label, icon, desc }) => {
+                          {benchConfig.breakdownDomains.map((k) => DOMAIN_CARDS[k]).map(({ key, label, icon, desc }) => {
                             const value = model.data[key]?.[selectedPassK - 1]
                             const submissionInfo = fullSubmissionData[model.key]
                             const hasTraj = submissionInfo?.trajectories_available && submissionInfo?.trajectory_files?.[key]

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -51,6 +51,7 @@ const BENCHMARK_CONFIG = {
     label: 'τ-knowledge',
     icon: '🏦',
     title: 'τ-knowledge Leaderboard',
+    description: 'Text agents resolving banking customer-service tasks by retrieving and reasoning over a ~700-document knowledge base.',
     modality: 'text',
     domains: KNOWLEDGE_DOMAINS,
     defaultDomain: 'banking_knowledge',
@@ -60,6 +61,7 @@ const BENCHMARK_CONFIG = {
     label: 'τ-voice',
     icon: '🎙️',
     title: 'τ-voice Leaderboard',
+    description: 'Real-time, full-duplex voice agents on retail, airline, and telecom customer-service tasks.',
     modality: 'voice',
     domains: VOICE_DOMAINS,
     defaultDomain: 'overall',
@@ -69,6 +71,7 @@ const BENCHMARK_CONFIG = {
     label: 'τ²-bench',
     icon: '📝',
     title: 'τ²-bench Leaderboard',
+    description: 'Text agents on retail, airline, and telecom customer-service tasks, where the agent and the user both act on the world.',
     modality: 'text',
     domains: CORE_DOMAINS,
     defaultDomain: 'overall',
@@ -670,6 +673,7 @@ const Leaderboard = () => {
       <div className="leaderboard-title-row">
         <h2 className="leaderboard-title">{benchConfig.title}</h2>
       </div>
+      <p className="leaderboard-subtitle">{benchConfig.description}</p>
 
       {/* Combined Controls Row — applies to both ranking and progress views */}
       <div className="leaderboard-controls">

--- a/web/leaderboard/src/components/LeaderboardPreview.css
+++ b/web/leaderboard/src/components/LeaderboardPreview.css
@@ -30,16 +30,17 @@
 }
 
 .preview-table-title {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   color: #4a5568;
-  padding: 14px 16px;
+  padding: 14px 12px;
   margin: 0;
   border-bottom: 1px solid #e2e8f0;
   display: flex;
   align-items: center;
   gap: 8px;
   text-align: left;
+  white-space: nowrap;
 }
 
 .preview-mode-badge {
@@ -48,8 +49,9 @@
   border-radius: 4px;
   font-size: 11px;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  /* No uppercase: the badges are τ-track names and τ must stay lowercase */
+  letter-spacing: 0.3px;
+  white-space: nowrap;
 }
 
 .preview-mode-badge.core {

--- a/web/leaderboard/src/components/LeaderboardPreview.css
+++ b/web/leaderboard/src/components/LeaderboardPreview.css
@@ -43,6 +43,13 @@
   white-space: nowrap;
 }
 
+.preview-table-subtitle {
+  font-size: 11px;
+  font-weight: 500;
+  color: #a0aec0;
+  letter-spacing: 0.2px;
+}
+
 .preview-mode-badge {
   display: inline-block;
   padding: 2px 8px;

--- a/web/leaderboard/src/components/LeaderboardPreview.css
+++ b/web/leaderboard/src/components/LeaderboardPreview.css
@@ -1,6 +1,6 @@
 .leaderboard-preview {
   width: 100%;
-  max-width: 800px;
+  max-width: 900px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -52,9 +52,14 @@
   letter-spacing: 0.5px;
 }
 
-.preview-mode-badge.text {
+.preview-mode-badge.core {
   background: #ebf8ff;
   color: #2b6cb0;
+}
+
+.preview-mode-badge.knowledge {
+  background: #fffbeb;
+  color: #b45309;
 }
 
 .preview-mode-badge.voice {
@@ -73,18 +78,18 @@
   color: #a0aec0;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  padding: 8px 16px;
+  padding: 8px 12px;
   text-align: left;
   border-bottom: 1px solid #f1f5f9;
 }
 
 .preview-rank-col {
-  width: 40px;
+  width: 36px;
   text-align: center !important;
 }
 
 .preview-score-col {
-  width: 80px;
+  width: 64px;
   text-align: right !important;
 }
 
@@ -102,12 +107,12 @@
 
 .preview-rank {
   text-align: center;
-  padding: 10px 16px;
+  padding: 10px 8px;
   font-size: 16px;
 }
 
 .preview-model {
-  padding: 10px 16px;
+  padding: 10px 12px;
   display: flex;
   flex-direction: column;
   gap: 1px;
@@ -120,7 +125,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 180px;
+  max-width: 130px;
 }
 
 .preview-model-org {
@@ -130,7 +135,7 @@
 }
 
 .preview-score {
-  padding: 10px 16px;
+  padding: 10px 12px;
   text-align: right;
   font-size: 15px;
   font-weight: 700;
@@ -167,7 +172,8 @@
   box-shadow: 0 4px 12px rgba(6, 95, 70, 0.25);
 }
 
-@media (max-width: 768px) {
+/* Three cards need more room than two did; stack a little earlier. */
+@media (max-width: 900px) {
   .preview-tables {
     flex-direction: column;
     gap: 16px;

--- a/web/leaderboard/src/components/LeaderboardPreview.css
+++ b/web/leaderboard/src/components/LeaderboardPreview.css
@@ -44,10 +44,29 @@
 }
 
 .preview-table-subtitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: 11px;
   font-weight: 500;
   color: #a0aec0;
   letter-spacing: 0.2px;
+}
+
+/* The mode reads differently from the domain list: darker, heavier, and
+   separated by a vertical divider instead of the interpunct. */
+.preview-mode {
+  color: #718096;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+}
+
+.preview-subtitle-divider {
+  width: 1px;
+  height: 10px;
+  background: #cbd5e0;
 }
 
 .preview-mode-badge {

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -119,9 +119,9 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
   }
 
   const cards = [
-    { badge: 'Core', badgeClass: 'core', title: 'Retail · Airline · Telecom', models: coreTop3 },
-    { badge: 'Knowledge', badgeClass: 'knowledge', title: 'Banking', models: knowledgeTop3 },
-    { badge: 'Voice', badgeClass: 'voice', title: 'Retail · Airline · Telecom', models: voiceTop3 },
+    { badge: 'τ²-bench', badgeClass: 'core', title: 'Retail · Airline · Telecom', models: coreTop3 },
+    { badge: 'τ-knowledge', badgeClass: 'knowledge', title: 'Banking', models: knowledgeTop3 },
+    { badge: 'τ-voice', badgeClass: 'voice', title: 'Retail · Airline · Telecom', models: voiceTop3 },
   ]
 
   return (

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -120,9 +120,9 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
 
   // Newest tracks first, matching the leaderboard toggle order.
   const cards = [
-    { badge: 'τ-knowledge', badgeClass: 'knowledge', title: 'Banking', models: knowledgeTop3 },
-    { badge: 'τ-voice', badgeClass: 'voice', title: 'Retail · Airline · Telecom', models: voiceTop3 },
-    { badge: 'τ²-bench', badgeClass: 'core', title: 'Retail · Airline · Telecom', models: coreTop3 },
+    { badge: 'τ-knowledge', badgeClass: 'knowledge', subtitle: 'Text · Banking', models: knowledgeTop3 },
+    { badge: 'τ-voice', badgeClass: 'voice', subtitle: 'Voice · Retail · Airline · Telecom', models: voiceTop3 },
+    { badge: 'τ²-bench', badgeClass: 'core', subtitle: 'Text · Retail · Airline · Telecom', models: coreTop3 },
   ]
 
   return (
@@ -132,7 +132,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
           <div className="preview-table-wrapper" key={card.badge}>
             <h3 className="preview-table-title">
               <span className={`preview-mode-badge ${card.badgeClass}`}>{card.badge}</span>
-              {card.title}
+              <span className="preview-table-subtitle">{card.subtitle}</span>
             </h3>
             <table className="preview-table">
               <thead>

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -120,9 +120,9 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
 
   // Newest tracks first, matching the leaderboard toggle order.
   const cards = [
-    { badge: 'τ-knowledge', badgeClass: 'knowledge', subtitle: 'Text · Banking', models: knowledgeTop3 },
-    { badge: 'τ-voice', badgeClass: 'voice', subtitle: 'Voice · Retail · Airline · Telecom', models: voiceTop3 },
-    { badge: 'τ²-bench', badgeClass: 'core', subtitle: 'Text · Retail · Airline · Telecom', models: coreTop3 },
+    { badge: 'τ-knowledge', badgeClass: 'knowledge', mode: 'Text', domains: 'Banking', models: knowledgeTop3 },
+    { badge: 'τ-voice', badgeClass: 'voice', mode: 'Voice', domains: 'Retail · Airline · Telecom', models: voiceTop3 },
+    { badge: 'τ²-bench', badgeClass: 'core', mode: 'Text', domains: 'Retail · Airline · Telecom', models: coreTop3 },
   ]
 
   return (
@@ -132,7 +132,11 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
           <div className="preview-table-wrapper" key={card.badge}>
             <h3 className="preview-table-title">
               <span className={`preview-mode-badge ${card.badgeClass}`}>{card.badge}</span>
-              <span className="preview-table-subtitle">{card.subtitle}</span>
+              <span className="preview-table-subtitle">
+                <span className="preview-mode">{card.mode}</span>
+                <span className="preview-subtitle-divider" aria-hidden="true" />
+                {card.domains}
+              </span>
             </h3>
             <table className="preview-table">
               <thead>

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -118,10 +118,11 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
     )
   }
 
+  // Newest tracks first, matching the leaderboard toggle order.
   const cards = [
-    { badge: 'τ²-bench', badgeClass: 'core', title: 'Retail · Airline · Telecom', models: coreTop3 },
     { badge: 'τ-knowledge', badgeClass: 'knowledge', title: 'Banking', models: knowledgeTop3 },
     { badge: 'τ-voice', badgeClass: 'voice', title: 'Retail · Airline · Telecom', models: voiceTop3 },
+    { badge: 'τ²-bench', badgeClass: 'core', title: 'Retail · Airline · Telecom', models: coreTop3 },
   ]
 
   return (

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -8,8 +8,22 @@ const SUBMISSIONS_BASE = import.meta.env.VITE_SUBMISSIONS_BASE_URL
 
 const NO_CACHE = { cache: 'no-cache' }
 
+const CORE_DOMAINS = ['retail', 'airline', 'telecom']
+
+// Average pass^1 across the three core domains; null unless all three exist.
+const corePass1 = (results) => {
+  const values = CORE_DOMAINS.map((d) => results[d]?.pass_1)
+  if (values.some((v) => v == null)) return null
+  return values.reduce((s, v) => s + v, 0) / values.length
+}
+
+// One preview card per leaderboard bucket: Core (τ²-bench), Knowledge
+// (τ-knowledge), and Voice (τ-voice), each showing its Overall top 3.
+// TODO(voice-banking): when banking is supported in voice mode, its scores
+// belong in the Knowledge bucket (as a text/voice split), not in Voice.
 function LeaderboardPreview({ onViewFullLeaderboard }) {
-  const [bankingTop3, setBankingTop3] = useState([])
+  const [coreTop3, setCoreTop3] = useState([])
+  const [knowledgeTop3, setKnowledgeTop3] = useState([])
   const [voiceTop3, setVoiceTop3] = useState([])
   const [isLoading, setIsLoading] = useState(true)
 
@@ -26,8 +40,9 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
       const textDirs = [...(manifest.submissions || []), ...(manifest.legacy_submissions || [])]
       const voiceDirs = manifest.voice_submissions || []
 
-      // Load text submissions and rank by banking pass^1.
-      const textModels = []
+      // Load text submissions once; they feed both the Core and Knowledge cards.
+      const coreModels = []
+      const knowledgeModels = []
       for (const dir of textDirs) {
         try {
           const res = await fetch(`${SUBMISSIONS_BASE}/${dir}/submission.json`, NO_CACHE)
@@ -37,11 +52,18 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
           // Only include standard submissions
           if (sub.submission_type && sub.submission_type !== 'standard') continue
 
-          const r = sub.results
-          const banking = r.banking_knowledge?.pass_1
+          const core = corePass1(sub.results)
+          if (core != null) {
+            coreModels.push({
+              name: sub.model_name,
+              org: sub.model_organization,
+              score: core,
+            })
+          }
 
+          const banking = sub.results.banking_knowledge?.pass_1
           if (banking != null) {
-            textModels.push({
+            knowledgeModels.push({
               name: sub.model_name,
               org: sub.model_organization,
               score: banking,
@@ -50,12 +72,13 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
         } catch { /* skip */ }
       }
 
-      textModels.sort((a, b) => b.score - a.score)
-      setBankingTop3(textModels.slice(0, 3))
+      coreModels.sort((a, b) => b.score - a.score)
+      setCoreTop3(coreModels.slice(0, 3))
+      knowledgeModels.sort((a, b) => b.score - a.score)
+      setKnowledgeTop3(knowledgeModels.slice(0, 3))
 
       // Load voice submissions and compute overall pass^1.
       const voiceModels = []
-      const voiceDomains = ['airline', 'retail', 'telecom']
       for (const dir of voiceDirs) {
         try {
           const res = await fetch(`${SUBMISSIONS_BASE}/${dir}/submission.json`, NO_CACHE)
@@ -64,9 +87,8 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
 
           if (sub.submission_type && sub.submission_type !== 'standard') continue
 
-          const r = sub.results
-          const values = voiceDomains
-            .map(d => r[d]?.pass_1)
+          const values = CORE_DOMAINS
+            .map(d => sub.results[d]?.pass_1)
             .filter(v => v != null)
 
           if (values.length > 0) {
@@ -96,65 +118,45 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
     )
   }
 
+  const cards = [
+    { badge: 'Core', badgeClass: 'core', title: 'Overall', models: coreTop3 },
+    { badge: 'Knowledge', badgeClass: 'knowledge', title: 'Banking', models: knowledgeTop3 },
+    { badge: 'Voice', badgeClass: 'voice', title: 'Overall', models: voiceTop3 },
+  ]
+
   return (
     <div className="leaderboard-preview">
       <div className="preview-tables">
-        <div className="preview-table-wrapper">
-          <h3 className="preview-table-title">
-            <span className="preview-mode-badge text">Text</span>
-            Banking
-          </h3>
-          <table className="preview-table">
-            <thead>
-              <tr>
-                <th className="preview-rank-col">#</th>
-                <th className="preview-model-col">Model</th>
-                <th className="preview-score-col">Pass^1</th>
-              </tr>
-            </thead>
-            <tbody>
-              {bankingTop3.map((model, i) => (
-                <tr key={i} className="preview-row">
-                  <td className="preview-rank">{MEDAL_EMOJI[i]}</td>
-                  <td className="preview-model">
-                    <span className="preview-model-name">{model.name}</span>
-                    <span className="preview-model-org">{model.org}</span>
-                  </td>
-                  <td className="preview-score">{model.score.toFixed(1)}%</td>
+        {cards.map((card) => (
+          <div className="preview-table-wrapper" key={card.badge}>
+            <h3 className="preview-table-title">
+              <span className={`preview-mode-badge ${card.badgeClass}`}>{card.badge}</span>
+              {card.title}
+            </h3>
+            <table className="preview-table">
+              <thead>
+                <tr>
+                  <th className="preview-rank-col">#</th>
+                  <th className="preview-model-col">Model</th>
+                  <th className="preview-score-col">Pass^1</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-          <div className="preview-more">⋯</div>
-        </div>
-        <div className="preview-table-wrapper">
-          <h3 className="preview-table-title">
-            <span className="preview-mode-badge voice">Voice</span>
-            Overall
-          </h3>
-          <table className="preview-table">
-            <thead>
-              <tr>
-                <th className="preview-rank-col">#</th>
-                <th className="preview-model-col">Model</th>
-                <th className="preview-score-col">Pass^1</th>
-              </tr>
-            </thead>
-            <tbody>
-              {voiceTop3.map((model, i) => (
-                <tr key={i} className="preview-row">
-                  <td className="preview-rank">{MEDAL_EMOJI[i]}</td>
-                  <td className="preview-model">
-                    <span className="preview-model-name">{model.name}</span>
-                    <span className="preview-model-org">{model.org}</span>
-                  </td>
-                  <td className="preview-score">{model.score.toFixed(1)}%</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          <div className="preview-more">⋯</div>
-        </div>
+              </thead>
+              <tbody>
+                {card.models.map((model, i) => (
+                  <tr key={i} className="preview-row">
+                    <td className="preview-rank">{MEDAL_EMOJI[i]}</td>
+                    <td className="preview-model">
+                      <span className="preview-model-name">{model.name}</span>
+                      <span className="preview-model-org">{model.org}</span>
+                    </td>
+                    <td className="preview-score">{model.score.toFixed(1)}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className="preview-more">⋯</div>
+          </div>
+        ))}
       </div>
       <button className="preview-cta" onClick={onViewFullLeaderboard}>
         View Full Leaderboard →

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -119,9 +119,9 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
   }
 
   const cards = [
-    { badge: 'Core', badgeClass: 'core', title: 'Overall', models: coreTop3 },
+    { badge: 'Core', badgeClass: 'core', title: 'Retail · Airline · Telecom', models: coreTop3 },
     { badge: 'Knowledge', badgeClass: 'knowledge', title: 'Banking', models: knowledgeTop3 },
-    { badge: 'Voice', badgeClass: 'voice', title: 'Overall', models: voiceTop3 },
+    { badge: 'Voice', badgeClass: 'voice', title: 'Retail · Airline · Telecom', models: voiceTop3 },
   ]
 
   return (

--- a/web/leaderboard/src/components/ProgressView.jsx
+++ b/web/leaderboard/src/components/ProgressView.jsx
@@ -36,17 +36,30 @@ const ORG_EMOJI = {
 const formatMonth = (d) => d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
 const formatDate = (d) => d.toISOString().slice(0, 10)
 
+// benchmark is one of 'core' (τ²-bench), 'knowledge' (τ-knowledge), or
+// 'voice' (τ-voice). Core and voice share the same three domains but differ
+// in modality; knowledge is banking-only in text.
+const BENCHMARK_MODALITY = {
+  core: 'text',
+  knowledge: 'text',
+  voice: 'voice',
+}
+
+const BENCHMARK_LABEL = {
+  core: 'τ²-bench',
+  knowledge: 'τ-knowledge',
+  voice: 'τ-voice',
+}
+
 /**
  * Compute the score the chart should plot for a given model+domain pair.
  * For 'overall', match the leaderboard table semantics: average pass_1 across
- * all available core domains for the benchmark, but only when every core
- * domain has data. For a specific domain, just use that domain's pass_1.
+ * the three core domains, but only when every one has data. For a specific
+ * domain, just use that domain's pass_1.
  */
-const computeScore = (model, domain, benchmark) => {
+const computeScore = (model, domain) => {
   if (domain === 'overall') {
-    const overallDomains = benchmark === 'voice'
-      ? ['retail', 'airline', 'telecom']
-      : ['retail', 'airline', 'telecom', 'banking_knowledge']
+    const overallDomains = ['retail', 'airline', 'telecom']
     const vals = overallDomains
       .map((d) => model[d]?.[0])
       .filter((v) => v !== null && v !== undefined)
@@ -75,7 +88,7 @@ const extractEntries = (
   { showStandard, showCustom, showLegacy }
 ) => {
   const passesFilters = (model) => {
-    if (model.modality !== benchmark) return false
+    if (model.modality !== BENCHMARK_MODALITY[benchmark]) return false
     if (model.isLegacy && !showLegacy) return false
     const isStandard = model.submissionType === 'standard' || !model.submissionType
     const isCustom = model.submissionType === 'custom'
@@ -87,7 +100,7 @@ const extractEntries = (
   const bestByModel = new Map()
   for (const [key, model] of Object.entries(passKData)) {
     if (!passesFilters(model)) continue
-    const score = computeScore(model, domain, benchmark)
+    const score = computeScore(model, domain)
     if (score === null) continue
     const sub = fullSubmissionData[key] || {}
     const modelName = sub.model_name || model.modelName
@@ -100,7 +113,7 @@ const extractEntries = (
   const entries = []
   for (const [key, model] of Object.entries(passKData)) {
     if (!passesFilters(model)) continue
-    const score = computeScore(model, domain, benchmark)
+    const score = computeScore(model, domain)
     if (score === null) continue
     const sub = fullSubmissionData[key] || {}
     const modelName = sub.model_name || model.modelName
@@ -169,7 +182,7 @@ const ProgressView = ({
   )
   const frontierKeys = useMemo(() => computeFrontier(entries), [entries])
 
-  const benchmarkLabel = benchmark === 'voice' ? 'τ-voice' : 'τ-bench'
+  const benchmarkLabel = BENCHMARK_LABEL[benchmark] || 'τ-bench'
   const domainLabel = DOMAIN_LABEL[domain] || domain
 
   if (entries.length === 0) {


### PR DESCRIPTION
## Summary

Splits the leaderboard into three tracks, since knowledge (retrieval over unstructured documents) measures a genuinely different skill than the core dual-control domains:

- **τ²-bench**: retail / airline / telecom in text. Overall = 3-domain average (previously Overall required banking too, which silently excluded strong models that lack banking runs — e.g. Gemini 3.0 Pro at 85.4 core-3)
- **τ-knowledge**: banking only. Domain tab row is hidden (single domain) and the Retrieval column is always shown. Legacy (v1) filter only appears under τ²-bench, where legacy submissions exist
- **τ-voice**: retail / airline / telecom in real-time voice (behavior unchanged, now a sibling track)

Each track defaults to its own Overall, resolving the previously inconsistent defaults (text card ranked by Banking, voice card by Overall; leaderboard defaulted to the Banking tab). Tracks are ordered newest-first (τ-knowledge · τ-voice · τ²-bench) in the toggle, homepage preview, and evolution timeline.

Also:

- Homepage preview shows one card per track: an emphasized track badge, then a de-emphasized subtitle with the mode (small caps, divider) and the domain list — e.g. **τ-knowledge** | TEXT | Banking
- Each full leaderboard page gets a one-sentence description under the title of what that track measures
- Old `benchmark=text` deep links and localStorage values map to `core`
- Progress-over-time chart understands the new track values and titles
- Banner τ-voice link now points to the τ-voice announcement post instead of the examples page
- `TODO(voice-banking)` comments document the plan for banking-in-voice: a Text | Voice modality toggle inside the τ-knowledge track, keeping τ-voice Overall stable

## Before / After

### Homepage

| Before | After |
|---|---|
| ![before home](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/before-home.png) | ![after home](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/after-home.png) |

Two cards with inconsistent defaults (Text ranked by Banking, Voice by Overall) become three cards, one per track, each ranked by its own Overall.

### Leaderboard

| Before (default) | Before (voice) |
|---|---|
| ![before leaderboard](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/before-leaderboard.png) | ![before voice](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/before-leaderboard-voice.png) |

| After (τ-knowledge, default) | After (τ-voice) | After (τ²-bench) |
|---|---|---|
| ![after knowledge](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/after-leaderboard-knowledge.png) | ![after voice](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/after-leaderboard-voice.png) | ![after core](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/after-leaderboard-core.png) |

The two-way τ-bench / τ-voice toggle (with τ-bench defaulting to the Banking tab) becomes a three-way track toggle, each with a one-sentence description and its own Overall default.

*(Screenshots hosted on the throwaway `pr426-assets` branch; delete it after merge.)*

## Test plan

- [x] Verified all three tracks at 1920×1080 (toggle, titles, descriptions, tabs, retrieval column, filters)
- [x] Verified homepage three-card preview at desktop and that cards stack at mobile width
- [x] Verified old `#leaderboard?benchmark=text` URL resolves to the τ²-bench track
- [x] Spot-check deployed preview

Made with [Cursor](https://cursor.com)