### PR TITLE
Website: preview card links, toggle alignment, and τ³ track naming

### DIFF
--- a/web/leaderboard/src/components/EvolutionTimeline.jsx
+++ b/web/leaderboard/src/components/EvolutionTimeline.jsx
@@ -57,7 +57,7 @@ const MILESTONES = [
   },
   {
     name: 'τ-knowledge',
-    hoverNote: 'τ-knowledge is often referred to as “τ³ banking”',
+    hoverNote: 'Appears on the leaderboard as τ³ Banking',
     date: 'March 2026',
     badge: 'τ³-bench',
     links: [
@@ -76,6 +76,7 @@ const MILESTONES = [
   },
   {
     name: 'τ-voice',
+    hoverNote: 'Appears on the leaderboard as τ³ Voice',
     date: 'March 2026',
     badge: 'τ³-bench',
     links: [

--- a/web/leaderboard/src/components/EvolutionTimeline.jsx
+++ b/web/leaderboard/src/components/EvolutionTimeline.jsx
@@ -57,6 +57,7 @@ const MILESTONES = [
   },
   {
     name: 'τ-knowledge',
+    hoverNote: 'τ-knowledge is often referred to as “τ³ banking”',
     date: 'March 2026',
     badge: 'τ³-bench',
     links: [
@@ -104,7 +105,7 @@ function EvolutionTimeline() {
             </div>
             <div className="evolution-content">
               <div className="evolution-header">
-                <span className="evolution-name">{m.name}</span>
+                <span className="evolution-name" title={m.hoverNote}>{m.name}</span>
                 {m.badge && <span className="evolution-badge">{m.badge}</span>}
                 <span className="evolution-date">{m.date}</span>
                 <span className="evolution-links">

--- a/web/leaderboard/src/components/EvolutionTimeline.jsx
+++ b/web/leaderboard/src/components/EvolutionTimeline.jsx
@@ -57,7 +57,7 @@ const MILESTONES = [
   },
   {
     name: 'τ-knowledge',
-    hoverNote: 'Appears on the leaderboard as τ³ Banking',
+    hoverNote: 'Appears on the leaderboard as τ³-Banking',
     date: 'March 2026',
     badge: 'τ³-bench',
     links: [
@@ -76,7 +76,7 @@ const MILESTONES = [
   },
   {
     name: 'τ-voice',
-    hoverNote: 'Appears on the leaderboard as τ³ Voice',
+    hoverNote: 'Appears on the leaderboard as τ³-Voice',
     date: 'March 2026',
     badge: 'τ³-bench',
     links: [

--- a/web/leaderboard/src/components/Leaderboard.css
+++ b/web/leaderboard/src/components/Leaderboard.css
@@ -137,6 +137,11 @@
 .benchmark-toggle-option {
   position: relative;
   z-index: 2;
+  /* Equal widths: the sliding pill is positioned at fixed 1/N offsets, so
+     unequal (content-sized) buttons would misalign text inside the pill.
+     nowrap makes the widest label set the shared width. */
+  flex: 1 1 0;
+  white-space: nowrap;
   padding: 10px 28px;
   border: none;
   background: transparent;
@@ -249,6 +254,9 @@
 .domain-toggle-option {
   position: relative;
   z-index: 2;
+  /* Equal widths so the 1/N-wide sliding pill lines up with the buttons */
+  flex: 1 1 0;
+  white-space: nowrap;
   padding: 10px 16px;
   border: none;
   background: transparent;

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -52,7 +52,7 @@ const BENCHMARK_CONFIG = {
     label: 'τ³-Banking',
     icon: '🏦',
     title: 'τ³-Banking Leaderboard',
-    description: 'Text agents resolving banking customer-service tasks by retrieving and reasoning over a ~700-document knowledge base. Published as τ-knowledge.',
+    description: 'Text agents resolving banking customer-service tasks over a ~700-document knowledge base. Published as τ-knowledge.',
     // Shown on hover wherever the track name appears without room for the
     // full description; maps the display name back to the paper name.
     hoverNote: 'τ³-Banking was published as τ-knowledge',

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -3,8 +3,9 @@ import './Leaderboard.css'
 import ProgressView from './ProgressView'
 
 // The leaderboard is split into three buckets, one per benchmark track:
-// Core (τ²-bench: retail/airline/telecom in text), Knowledge (τ-knowledge:
-// banking), and Voice (τ-voice: retail/airline/telecom in real-time voice).
+// τ³ Banking (published as τ-knowledge), τ³ Voice (published as τ-voice:
+// retail/airline/telecom in real-time voice), and τ²-bench (core:
+// retail/airline/telecom in text, near saturation).
 const BENCHMARK_VALUES = new Set(['core', 'knowledge', 'voice'])
 
 // Pre-bucket URLs and localStorage used benchmark=text for what is now 'core'.
@@ -48,23 +49,24 @@ const VOICE_DOMAINS = [
 // Key order determines toggle order: newest tracks first.
 const BENCHMARK_CONFIG = {
   knowledge: {
-    label: 'τ-knowledge',
+    label: 'τ³ Banking',
     icon: '🏦',
-    title: 'τ-knowledge Leaderboard',
-    description: 'Text agents resolving banking customer-service tasks by retrieving and reasoning over a ~700-document knowledge base. Often referred to as “τ³\u00A0banking”.',
+    title: 'τ³ Banking Leaderboard',
+    description: 'Text agents resolving banking customer-service tasks by retrieving and reasoning over a ~700-document knowledge base. Published as τ-knowledge.',
     // Shown on hover wherever the track name appears without room for the
-    // full description; keeps "τ³ banking" searchers oriented.
-    hoverNote: 'τ-knowledge is often referred to as “τ³ banking”',
+    // full description; maps the display name back to the paper name.
+    hoverNote: 'τ³ Banking was published as τ-knowledge',
     modality: 'text',
     domains: KNOWLEDGE_DOMAINS,
     defaultDomain: 'banking_knowledge',
     breakdownDomains: ['banking_knowledge'],
   },
   voice: {
-    label: 'τ-voice',
+    label: 'τ³ Voice',
     icon: '🎙️',
-    title: 'τ-voice Leaderboard',
-    description: 'Real-time, full-duplex voice agents on retail, airline, and telecom customer-service tasks.',
+    title: 'τ³ Voice Leaderboard',
+    description: 'Real-time, full-duplex voice agents on retail, airline, and telecom customer-service tasks. Published as τ-voice.',
+    hoverNote: 'τ³ Voice was published as τ-voice',
     modality: 'voice',
     domains: VOICE_DOMAINS,
     defaultDomain: 'overall',

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -3,7 +3,7 @@ import './Leaderboard.css'
 import ProgressView from './ProgressView'
 
 // The leaderboard is split into three buckets, one per benchmark track:
-// τ³ Banking (published as τ-knowledge), τ³ Voice (published as τ-voice:
+// τ³-Banking (published as τ-knowledge), τ³-Voice (published as τ-voice:
 // retail/airline/telecom in real-time voice), and τ²-bench (core:
 // retail/airline/telecom in text, near saturation).
 const BENCHMARK_VALUES = new Set(['core', 'knowledge', 'voice'])
@@ -49,24 +49,24 @@ const VOICE_DOMAINS = [
 // Key order determines toggle order: newest tracks first.
 const BENCHMARK_CONFIG = {
   knowledge: {
-    label: 'τ³ Banking',
+    label: 'τ³-Banking',
     icon: '🏦',
-    title: 'τ³ Banking Leaderboard',
+    title: 'τ³-Banking Leaderboard',
     description: 'Text agents resolving banking customer-service tasks by retrieving and reasoning over a ~700-document knowledge base. Published as τ-knowledge.',
     // Shown on hover wherever the track name appears without room for the
     // full description; maps the display name back to the paper name.
-    hoverNote: 'τ³ Banking was published as τ-knowledge',
+    hoverNote: 'τ³-Banking was published as τ-knowledge',
     modality: 'text',
     domains: KNOWLEDGE_DOMAINS,
     defaultDomain: 'banking_knowledge',
     breakdownDomains: ['banking_knowledge'],
   },
   voice: {
-    label: 'τ³ Voice',
+    label: 'τ³-Voice',
     icon: '🎙️',
-    title: 'τ³ Voice Leaderboard',
+    title: 'τ³-Voice Leaderboard',
     description: 'Real-time, full-duplex voice agents on retail, airline, and telecom customer-service tasks. Published as τ-voice.',
-    hoverNote: 'τ³ Voice was published as τ-voice',
+    hoverNote: 'τ³-Voice was published as τ-voice',
     modality: 'voice',
     domains: VOICE_DOMAINS,
     defaultDomain: 'overall',

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -51,7 +51,10 @@ const BENCHMARK_CONFIG = {
     label: 'τ-knowledge',
     icon: '🏦',
     title: 'τ-knowledge Leaderboard',
-    description: 'Text agents resolving banking customer-service tasks by retrieving and reasoning over a ~700-document knowledge base.',
+    description: 'Text agents resolving banking customer-service tasks by retrieving and reasoning over a ~700-document knowledge base. Often referred to as “τ³\u00A0banking”.',
+    // Shown on hover wherever the track name appears without room for the
+    // full description; keeps "τ³ banking" searchers oriented.
+    hoverNote: 'τ-knowledge is often referred to as “τ³ banking”',
     modality: 'text',
     domains: KNOWLEDGE_DOMAINS,
     defaultDomain: 'banking_knowledge',
@@ -656,6 +659,7 @@ const Leaderboard = () => {
               key={key}
               className={`benchmark-toggle-option ${benchmark === key ? 'active' : ''}`}
               onClick={() => handleBenchmarkChange(key)}
+              title={BENCHMARK_CONFIG[key].hoverNote}
             >
               <span className="benchmark-icon">{BENCHMARK_CONFIG[key].icon}</span> {BENCHMARK_CONFIG[key].label}
             </button>

--- a/web/leaderboard/src/components/LeaderboardPreview.css
+++ b/web/leaderboard/src/components/LeaderboardPreview.css
@@ -27,6 +27,18 @@
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  /* Each card is a link to its track's full leaderboard */
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.preview-table-wrapper:hover {
+  border-color: #a7d7c5;
+  box-shadow: 0 4px 14px rgba(6, 95, 70, 0.12);
+  transform: translateY(-2px);
 }
 
 .preview-table-title {

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -120,16 +120,16 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
 
   // Newest tracks first, matching the leaderboard toggle order.
   const cards = [
-    { badge: 'τ-knowledge', badgeClass: 'knowledge', mode: 'Text', domains: 'Banking', models: knowledgeTop3 },
-    { badge: 'τ-voice', badgeClass: 'voice', mode: 'Voice', domains: 'Retail · Airline · Telecom', models: voiceTop3 },
-    { badge: 'τ²-bench', badgeClass: 'core', mode: 'Text', domains: 'Retail · Airline · Telecom', models: coreTop3 },
+    { badge: 'τ-knowledge', badgeClass: 'knowledge', mode: 'Text', domains: 'Banking', href: '#leaderboard?benchmark=knowledge', models: knowledgeTop3 },
+    { badge: 'τ-voice', badgeClass: 'voice', mode: 'Voice', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=voice', models: voiceTop3 },
+    { badge: 'τ²-bench', badgeClass: 'core', mode: 'Text', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=core', models: coreTop3 },
   ]
 
   return (
     <div className="leaderboard-preview">
       <div className="preview-tables">
         {cards.map((card) => (
-          <div className="preview-table-wrapper" key={card.badge}>
+          <a className="preview-table-wrapper" href={card.href} key={card.badge}>
             <h3 className="preview-table-title">
               <span className={`preview-mode-badge ${card.badgeClass}`}>{card.badge}</span>
               <span className="preview-table-subtitle">
@@ -160,7 +160,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
               </tbody>
             </table>
             <div className="preview-more">⋯</div>
-          </div>
+          </a>
         ))}
       </div>
       <button className="preview-cta" onClick={onViewFullLeaderboard}>

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -120,7 +120,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
 
   // Newest tracks first, matching the leaderboard toggle order.
   const cards = [
-    { badge: 'τ-knowledge', badgeClass: 'knowledge', mode: 'Text', domains: 'Banking', href: '#leaderboard?benchmark=knowledge', models: knowledgeTop3 },
+    { badge: 'τ-knowledge', badgeClass: 'knowledge', mode: 'Text', domains: 'Banking', href: '#leaderboard?benchmark=knowledge', hoverNote: 'τ-knowledge is often referred to as “τ³ banking”', models: knowledgeTop3 },
     { badge: 'τ-voice', badgeClass: 'voice', mode: 'Voice', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=voice', models: voiceTop3 },
     { badge: 'τ²-bench', badgeClass: 'core', mode: 'Text', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=core', models: coreTop3 },
   ]
@@ -131,7 +131,7 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
         {cards.map((card) => (
           <a className="preview-table-wrapper" href={card.href} key={card.badge}>
             <h3 className="preview-table-title">
-              <span className={`preview-mode-badge ${card.badgeClass}`}>{card.badge}</span>
+              <span className={`preview-mode-badge ${card.badgeClass}`} title={card.hoverNote}>{card.badge}</span>
               <span className="preview-table-subtitle">
                 <span className="preview-mode">{card.mode}</span>
                 <span className="preview-subtitle-divider" aria-hidden="true" />

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -17,8 +17,8 @@ const corePass1 = (results) => {
   return values.reduce((s, v) => s + v, 0) / values.length
 }
 
-// One preview card per leaderboard bucket: τ³ Banking (published as
-// τ-knowledge), τ³ Voice (published as τ-voice), and τ²-bench (core),
+// One preview card per leaderboard bucket: τ³-Banking (published as
+// τ-knowledge), τ³-Voice (published as τ-voice), and τ²-bench (core),
 // each showing its Overall top 3.
 // TODO(voice-banking): when banking is supported in voice mode, its scores
 // belong in the Knowledge bucket (as a text/voice split), not in Voice.
@@ -121,10 +121,10 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
 
   // Newest tracks first, matching the leaderboard toggle order. The subtitle
   // only carries what the badge doesn't already say (e.g. no "Voice" mode
-  // under the τ³ Voice badge).
+  // under the τ³-Voice badge).
   const cards = [
-    { badge: 'τ³ Banking', badgeClass: 'knowledge', mode: 'Text', domains: 'Knowledge retrieval', href: '#leaderboard?benchmark=knowledge', hoverNote: 'τ³ Banking was published as τ-knowledge', models: knowledgeTop3 },
-    { badge: 'τ³ Voice', badgeClass: 'voice', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=voice', hoverNote: 'τ³ Voice was published as τ-voice', models: voiceTop3 },
+    { badge: 'τ³-Banking', badgeClass: 'knowledge', mode: 'Text', domains: 'Knowledge retrieval', href: '#leaderboard?benchmark=knowledge', hoverNote: 'τ³-Banking was published as τ-knowledge', models: knowledgeTop3 },
+    { badge: 'τ³-Voice', badgeClass: 'voice', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=voice', hoverNote: 'τ³-Voice was published as τ-voice', models: voiceTop3 },
     { badge: 'τ²-bench', badgeClass: 'core', mode: 'Text', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=core', models: coreTop3 },
   ]
 

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -17,8 +17,9 @@ const corePass1 = (results) => {
   return values.reduce((s, v) => s + v, 0) / values.length
 }
 
-// One preview card per leaderboard bucket: Core (τ²-bench), Knowledge
-// (τ-knowledge), and Voice (τ-voice), each showing its Overall top 3.
+// One preview card per leaderboard bucket: τ³ Banking (published as
+// τ-knowledge), τ³ Voice (published as τ-voice), and τ²-bench (core),
+// each showing its Overall top 3.
 // TODO(voice-banking): when banking is supported in voice mode, its scores
 // belong in the Knowledge bucket (as a text/voice split), not in Voice.
 function LeaderboardPreview({ onViewFullLeaderboard }) {
@@ -118,10 +119,12 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
     )
   }
 
-  // Newest tracks first, matching the leaderboard toggle order.
+  // Newest tracks first, matching the leaderboard toggle order. The subtitle
+  // only carries what the badge doesn't already say (e.g. no "Voice" mode
+  // under the τ³ Voice badge).
   const cards = [
-    { badge: 'τ-knowledge', badgeClass: 'knowledge', mode: 'Text', domains: 'Banking', href: '#leaderboard?benchmark=knowledge', hoverNote: 'τ-knowledge is often referred to as “τ³ banking”', models: knowledgeTop3 },
-    { badge: 'τ-voice', badgeClass: 'voice', mode: 'Voice', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=voice', models: voiceTop3 },
+    { badge: 'τ³ Banking', badgeClass: 'knowledge', mode: 'Text', domains: 'Knowledge retrieval', href: '#leaderboard?benchmark=knowledge', hoverNote: 'τ³ Banking was published as τ-knowledge', models: knowledgeTop3 },
+    { badge: 'τ³ Voice', badgeClass: 'voice', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=voice', hoverNote: 'τ³ Voice was published as τ-voice', models: voiceTop3 },
     { badge: 'τ²-bench', badgeClass: 'core', mode: 'Text', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=core', models: coreTop3 },
   ]
 
@@ -133,8 +136,12 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
             <h3 className="preview-table-title">
               <span className={`preview-mode-badge ${card.badgeClass}`} title={card.hoverNote}>{card.badge}</span>
               <span className="preview-table-subtitle">
-                <span className="preview-mode">{card.mode}</span>
-                <span className="preview-subtitle-divider" aria-hidden="true" />
+                {card.mode && (
+                  <>
+                    <span className="preview-mode">{card.mode}</span>
+                    <span className="preview-subtitle-divider" aria-hidden="true" />
+                  </>
+                )}
                 {card.domains}
               </span>
             </h3>

--- a/web/leaderboard/src/components/ProgressView.jsx
+++ b/web/leaderboard/src/components/ProgressView.jsx
@@ -36,8 +36,8 @@ const ORG_EMOJI = {
 const formatMonth = (d) => d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
 const formatDate = (d) => d.toISOString().slice(0, 10)
 
-// benchmark is one of 'core' (τ²-bench), 'knowledge' (τ-knowledge), or
-// 'voice' (τ-voice). Core and voice share the same three domains but differ
+// benchmark is one of 'core' (τ²-bench), 'knowledge' (τ³ Banking), or
+// 'voice' (τ³ Voice). Core and voice share the same three domains but differ
 // in modality; knowledge is banking-only in text.
 const BENCHMARK_MODALITY = {
   core: 'text',
@@ -47,8 +47,8 @@ const BENCHMARK_MODALITY = {
 
 const BENCHMARK_LABEL = {
   core: 'τ²-bench',
-  knowledge: 'τ-knowledge',
-  voice: 'τ-voice',
+  knowledge: 'τ³ Banking',
+  voice: 'τ³ Voice',
 }
 
 /**

--- a/web/leaderboard/src/components/ProgressView.jsx
+++ b/web/leaderboard/src/components/ProgressView.jsx
@@ -36,8 +36,8 @@ const ORG_EMOJI = {
 const formatMonth = (d) => d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
 const formatDate = (d) => d.toISOString().slice(0, 10)
 
-// benchmark is one of 'core' (τ²-bench), 'knowledge' (τ³ Banking), or
-// 'voice' (τ³ Voice). Core and voice share the same three domains but differ
+// benchmark is one of 'core' (τ²-bench), 'knowledge' (τ³-Banking), or
+// 'voice' (τ³-Voice). Core and voice share the same three domains but differ
 // in modality; knowledge is banking-only in text.
 const BENCHMARK_MODALITY = {
   core: 'text',
@@ -47,8 +47,8 @@ const BENCHMARK_MODALITY = {
 
 const BENCHMARK_LABEL = {
   core: 'τ²-bench',
-  knowledge: 'τ³ Banking',
-  voice: 'τ³ Voice',
+  knowledge: 'τ³-Banking',
+  voice: 'τ³-Voice',
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-ups to #426: two UI fixes plus a naming change.

- **Tracks renamed to τ³-Banking / τ³-Voice.** τ²-bench core is near saturation, so the τ³ release becomes the prominent brand, and the display names adopt what the community already calls the banking track ("τ³ banking"). The paper names are preserved as "Published as τ-knowledge / τ-voice" in each leaderboard description and as hover tooltips on the toggle, homepage card badges, and timeline entries. URL params (`benchmark=knowledge/voice/core`) and localStorage are unchanged, so no links break. Homepage card subtitles only carry what the badge doesn't already say (τ³-Banking → "Text · Knowledge retrieval"; τ³-Voice → "Retail · Airline · Telecom").
- **Homepage preview cards are now clickable.** Each card links to its own track's full leaderboard, with a subtle hover lift. Previously only the "View Full Leaderboard" button navigated, and it always landed on the default track.
- **Sliding-pill toggles misaligned with their labels.** The pill in the track and domain toggles is positioned at fixed 1/N offsets, but the buttons were content-sized, so the pill drifted off the active label. Buttons are now equal-width (`flex: 1 1 0` + `nowrap`).

## Screenshots

| Toggle before | Toggle after (alignment + τ³ naming) |
|---|---|
| ![before](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/toggle-before.png) | ![after](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/toggle-after.png) |

| Homepage | τ³-Banking leaderboard |
|---|---|
| ![home](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/after-home-tau3.png) | ![banking](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr426-assets/after-leaderboard-banking-tau3.png) |

## Test plan

- [x] Verified track toggle pill alignment on all three tracks at 1920px
- [x] Verified domain toggle (Overall / Retail / Airline / Telecom) pill alignment
- [x] Verified each homepage card navigates to its corresponding track leaderboard
- [x] Verified τ³-Banking / τ³-Voice names and "Published as" notes on leaderboard pages, homepage cards, and progress chart
- [x] Spot-check deployed preview

Made with [Cursor](https://cursor.com)
