### PR TITLE
Website: path routing, prerendered pages, and routing e2e tests

### DIFF
--- a/.github/workflows/deploy-leaderboard.yml
+++ b/.github/workflows/deploy-leaderboard.yml
@@ -45,6 +45,13 @@ jobs:
           VITE_SUBMISSIONS_BASE_URL: https://sierra-tau-bench-public.s3.us-west-2.amazonaws.com/submissions
         run: npm run build
 
+      # Snapshot each route to its own static HTML file (content + per-page
+      # meta baked in). Fails the deploy if any page renders empty/broken,
+      # so a data-fetch flake can't silently ship blank pages.
+      - name: Prerender routes
+        working-directory: web/leaderboard
+        run: npm run prerender
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/test-leaderboard.yml
+++ b/.github/workflows/test-leaderboard.yml
@@ -1,0 +1,44 @@
+name: Leaderboard E2E
+
+# Routing/prerender regression tests for the website. Builds and prerenders
+# dist/ exactly like the deploy workflow (but against the git-tracked
+# submissions data, so no network dependency), then runs Playwright against
+# it with GitHub Pages serving semantics.
+on:
+  pull_request:
+    paths:
+      - 'web/leaderboard/**'
+      - '.github/workflows/test-leaderboard.yml'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/leaderboard/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web/leaderboard
+        run: npm ci
+
+      - name: Build
+        working-directory: web/leaderboard
+        env:
+          NODE_ENV: production
+        run: npm run build
+
+      - name: Prerender routes
+        working-directory: web/leaderboard
+        run: npm run prerender
+
+      - name: Run e2e tests
+        working-directory: web/leaderboard
+        run: npm run test:e2e

--- a/web/leaderboard/.gitignore
+++ b/web/leaderboard/.gitignore
@@ -1,0 +1,4 @@
+# Playwright artifacts
+test-results/
+playwright-report/
+.playwright/

--- a/web/leaderboard/README.md
+++ b/web/leaderboard/README.md
@@ -44,6 +44,33 @@ See the **[Leaderboard Submission Guide](../../docs/leaderboard-submission.md)**
 
 ## 🔧 Development
 
+### Routing, Prerendering & SEO
+
+The site uses **path-based routing** (`/leaderboard`, `/blog`, …) driven by
+`src/routes.js` — the single source of truth for routes and per-page meta tags.
+Legacy hash URLs (`/#leaderboard?benchmark=voice`) are rewritten to paths by a
+shim in `index.html`, so old shared links keep working.
+
+At deploy time, `scripts/prerender.mjs` snapshots each route into its own
+static HTML file (real content + per-page `<title>`/OG tags for crawlers and
+link unfurls). Content guards fail the deploy if any page renders empty.
+**Adding a new page?** Register it in `src/routes.js` (route, view, meta) and
+add a guard in `scripts/prerender.mjs`.
+
+Nothing here requires manual steps: pushes to `main` touching `web/leaderboard/`
+trigger `.github/workflows/deploy-leaderboard.yml` (build → prerender → deploy),
+and PRs run the Playwright routing tests in `e2e/` via
+`.github/workflows/test-leaderboard.yml`.
+
+To reproduce locally:
+
+```bash
+npm run build          # build dist/
+npm run prerender      # prerender routes into dist/ (needs Chrome)
+npm run serve:dist     # serve dist/ with GitHub Pages semantics on :4173
+npm run test:e2e       # run the Playwright suite against it
+```
+
 ### Project Structure
 ```
 src/

--- a/web/leaderboard/e2e/routing.spec.js
+++ b/web/leaderboard/e2e/routing.spec.js
@@ -104,6 +104,17 @@ test('preview card navigates client-side; back returns home', async ({ page }) =
   await expect(page.getByText('How τ-bench has evolved')).toBeVisible()
 })
 
+test('nav from /progress back to /leaderboard scrolls to top and keeps params', async ({ page }) => {
+  await page.goto('/progress?benchmark=voice')
+  // Wait for the auto-scroll down to the progress section to happen.
+  await page.waitForFunction(() => window.scrollY > 0)
+
+  await page.getByRole('button', { name: 'Leaderboard' }).click()
+  await expect(page).toHaveURL(/\/leaderboard\?benchmark=voice/)
+  await page.waitForFunction(() => window.scrollY === 0)
+  await expect(page.getByRole('heading', { name: 'τ³-Voice Leaderboard' })).toBeVisible()
+})
+
 test('nav links update path and title', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: 'Leaderboard' }).click()

--- a/web/leaderboard/e2e/routing.spec.js
+++ b/web/leaderboard/e2e/routing.spec.js
@@ -1,0 +1,126 @@
+// Routing + prerendering behavior tests. Run against the prerendered dist/
+// served with GitHub Pages semantics (see playwright.config.js).
+import { expect, test } from '@playwright/test'
+
+// ---------------------------------------------------------------------------
+// Direct loads: every route serves a real page with its own title and content.
+// ---------------------------------------------------------------------------
+
+test('direct load: homepage', async ({ page }) => {
+  await page.goto('/')
+  await expect(page).toHaveTitle(/τ-bench — Benchmarking AI Agents/)
+  await expect(page.locator('.preview-table-wrapper')).toHaveCount(3)
+  await expect(page.getByText('How τ-bench has evolved')).toBeVisible()
+})
+
+test('direct load: leaderboard defaults to τ³-Banking', async ({ page }) => {
+  await page.goto('/leaderboard')
+  await expect(page).toHaveTitle(/Leaderboard — τ-bench/)
+  await expect(page.getByRole('heading', { name: 'τ³-Banking Leaderboard' })).toBeVisible()
+})
+
+test('direct load: leaderboard respects benchmark param', async ({ page }) => {
+  await page.goto('/leaderboard?benchmark=voice')
+  await expect(page.getByRole('heading', { name: 'τ³-Voice Leaderboard' })).toBeVisible()
+})
+
+test('direct load: /progress shows leaderboard with progress section', async ({ page }) => {
+  await page.goto('/progress')
+  await expect(page.locator('#progress')).toBeAttached()
+})
+
+test('direct load: blog and visualizer', async ({ page }) => {
+  await page.goto('/blog')
+  await expect(page).toHaveTitle(/Blog — τ-bench/)
+
+  await page.goto('/trajectory-visualizer')
+  await expect(page).toHaveTitle(/Visualizer — τ-bench/)
+})
+
+// ---------------------------------------------------------------------------
+// Prerendered HTML: content and per-route meta exist without JavaScript.
+// ---------------------------------------------------------------------------
+
+test('prerendered leaderboard HTML contains content and meta', async ({ request }) => {
+  const res = await request.get('/leaderboard')
+  expect(res.status()).toBe(200)
+  const html = await res.text()
+  expect(html).toContain('<title>Leaderboard — τ-bench</title>')
+  expect(html).toContain('τ³-Banking Leaderboard')
+  expect(html).toContain('property="og:title"')
+  expect(html).toContain('https://taubench.com/leaderboard')
+})
+
+test('prerendered homepage HTML contains preview cards', async ({ request }) => {
+  const html = await (await request.get('/')).text()
+  expect(html).toContain('preview-table-wrapper')
+  expect(html).not.toContain('Loading leaderboard')
+})
+
+// ---------------------------------------------------------------------------
+// Legacy hash links: every pre-path-routing URL shape redirects correctly.
+// ---------------------------------------------------------------------------
+
+test('legacy #leaderboard redirects with params intact', async ({ page }) => {
+  await page.goto('/#leaderboard?benchmark=voice')
+  await expect(page.getByRole('heading', { name: 'τ³-Voice Leaderboard' })).toBeVisible()
+  await expect(page).toHaveURL(/\/leaderboard\?benchmark=voice/)
+})
+
+test('legacy benchmark=text maps to core', async ({ page }) => {
+  await page.goto('/#leaderboard?benchmark=text')
+  await expect(page.getByRole('heading', { name: 'τ²-bench Leaderboard' })).toBeVisible()
+  await expect(page).toHaveURL(/benchmark=core/)
+})
+
+test('legacy #progress and deprecated #docs redirect', async ({ page }) => {
+  await page.goto('/#progress')
+  await expect(page).toHaveURL(/\/progress/)
+  await expect(page.locator('#progress')).toBeAttached()
+
+  await page.goto('/#docs')
+  await expect(page).toHaveURL(/\/(\?.*)?$/)
+  await expect(page.locator('.preview-table-wrapper')).toHaveCount(3)
+})
+
+test('legacy visualizer deep link preserves query', async ({ page }) => {
+  await page.goto('/#trajectory-visualizer?view=tasks')
+  await expect(page).toHaveURL(/\/trajectory-visualizer\?.*view=tasks/)
+  await expect(page).toHaveTitle(/Visualizer — τ-bench/)
+})
+
+// ---------------------------------------------------------------------------
+// Client-side navigation and history.
+// ---------------------------------------------------------------------------
+
+test('preview card navigates client-side; back returns home', async ({ page }) => {
+  await page.goto('/')
+  await page.locator('.preview-table-wrapper').first().click()
+  await expect(page).toHaveURL(/\/leaderboard\?benchmark=knowledge/)
+  await expect(page.getByRole('heading', { name: 'τ³-Banking Leaderboard' })).toBeVisible()
+
+  await page.goBack()
+  await expect(page).toHaveURL(/\/(\?.*)?$/)
+  await expect(page.getByText('How τ-bench has evolved')).toBeVisible()
+})
+
+test('nav links update path and title', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Leaderboard' }).click()
+  await expect(page).toHaveURL(/\/leaderboard/)
+  await expect(page).toHaveTitle(/Leaderboard — τ-bench/)
+
+  await page.getByRole('button', { name: 'Overview' }).click()
+  await expect(page).toHaveURL(/\/(\?.*)?$/)
+  await expect(page).toHaveTitle(/τ-bench — Benchmarking AI Agents/)
+})
+
+// ---------------------------------------------------------------------------
+// Unknown paths: GitHub Pages serves 404.html, which boots the SPA.
+// ---------------------------------------------------------------------------
+
+test('unknown path returns 404 status but renders the app', async ({ page }) => {
+  const response = await page.goto('/definitely-not-a-page')
+  expect(response.status()).toBe(404)
+  await expect(page.locator('.preview-table-wrapper')).toHaveCount(3)
+})

--- a/web/leaderboard/eslint.config.js
+++ b/web/leaderboard/eslint.config.js
@@ -26,4 +26,11 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  // Node contexts: build/test config and scripts (process, __dirname, …).
+  {
+    files: ['*.config.js', 'scripts/**/*.mjs', 'e2e/**/*.js'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 ])

--- a/web/leaderboard/index.html
+++ b/web/leaderboard/index.html
@@ -33,6 +33,19 @@
     />
     <meta name="twitter:image" content="https://taubench.com/og-image.png" />
 
+    <script>
+      // Legacy hash routes (taubench.com/#leaderboard?benchmark=voice) predate
+      // path routing. Rewrite them to path equivalents before the app boots so
+      // old shared links keep working. #home/#docs/#results map to the root.
+      ;(function () {
+        var m = window.location.hash.match(
+          /^#(home|leaderboard|progress|trajectory-visualizer|blog|docs|results)(\?[^#]*)?$/
+        )
+        if (!m) return
+        var view = m[1] === 'home' || m[1] === 'docs' || m[1] === 'results' ? '' : m[1]
+        window.history.replaceState(null, '', '/' + view + (m[2] || ''))
+      })()
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   </head>
   <body>

--- a/web/leaderboard/package-lock.json
+++ b/web/leaderboard/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@playwright/test": "^1.61.1",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1057,6 +1058,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2902,6 +2919,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/leaderboard/package.json
+++ b/web/leaderboard/package.json
@@ -7,6 +7,9 @@
     "dev": "vite",
     "generate": "node scripts/generate-author-pages.mjs",
     "build": "npm run generate && vite build",
+    "prerender": "node scripts/prerender.mjs",
+    "serve:dist": "node scripts/prerender.mjs --serve",
+    "test:e2e": "playwright test",
     "lint": "eslint .",
     "preview": "vite preview",
     "deploy": "npm run build && gh-pages -d dist"
@@ -17,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@playwright/test": "^1.61.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/web/leaderboard/playwright.config.js
+++ b/web/leaderboard/playwright.config.js
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test'
+
+// E2E tests for routing + prerendering. They run against the *built and
+// prerendered* dist/ served with GitHub Pages semantics (no SPA rewrites,
+// 404.html for unknown paths) — `npm run build && npm run prerender` first.
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30000,
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    // Use the system Chrome instead of downloading a Playwright browser;
+    // it's preinstalled on GitHub runners and dev machines alike.
+    channel: 'chrome',
+  },
+  webServer: {
+    command: 'node scripts/prerender.mjs --serve',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/web/leaderboard/public/authors/honghua-dong.html
+++ b/web/leaderboard/public/authors/honghua-dong.html
@@ -156,6 +156,17 @@
       <h2 class="section-title">Posts</h2>
       <div class="blog-grid">
       <article class="blog-card">
+        <a class="blog-card-link" href="/talks/stanford-aims-tau.html">
+          <div class="blog-card-top">
+            <span class="blog-card-label">Talk · July 2026</span>
+            
+          </div>
+          <h2 class="blog-card-title">The τ-bench Family: Guest Lecture at the Stanford AIMS Seminar</h2>
+          <p class="blog-card-description">Slides from a guest lecture at the Stanford AIMS Seminar tracing the τ-bench family — from the original tool-agent-user substrate through dual control and knowledge to full-duplex voice — including how pausing time makes a realistic, controllable voice benchmark possible.</p>
+        </a>
+        <div class="post-authors"><div class="post-author-photos"><a href="/authors/soham-ray.html" class="post-author-photo-link" title="Soham Ray"><img src="/authors/soham-ray.jpg" alt="Soham Ray" class="post-author-photo" /></a><a href="/authors/victor-barres.html" class="post-author-photo-link" title="Victor Barres"><img src="/authors/victor-barres.jpg" alt="Victor Barres" class="post-author-photo" /></a><a href="/authors/honghua-dong.html" class="post-author-photo-link" title="Honghua Dong"><img src="/authors/honghua-dong.jpg" alt="Honghua Dong" class="post-author-photo" /></a></div><span class="post-author-names"><a href="/authors/soham-ray.html" class="post-author-name">Soham Ray</a>, <a href="/authors/victor-barres.html" class="post-author-name">Victor Barres</a> &amp; <a href="/authors/honghua-dong.html" class="post-author-name">Honghua Dong</a></span></div>
+      </article>
+      <article class="blog-card">
         <a class="blog-card-link" href="https://sierra.ai/blog/benchmarking-agents-in-collaborative-real-world-scenarios" target="_blank" rel="noopener noreferrer">
           <div class="blog-card-top">
             <span class="blog-card-label">Announcement · June 2025</span>

--- a/web/leaderboard/public/authors/soham-ray.html
+++ b/web/leaderboard/public/authors/soham-ray.html
@@ -157,6 +157,17 @@
       <h2 class="section-title">Posts</h2>
       <div class="blog-grid">
       <article class="blog-card">
+        <a class="blog-card-link" href="/talks/stanford-aims-tau.html">
+          <div class="blog-card-top">
+            <span class="blog-card-label">Talk · July 2026</span>
+            
+          </div>
+          <h2 class="blog-card-title">The τ-bench Family: Guest Lecture at the Stanford AIMS Seminar</h2>
+          <p class="blog-card-description">Slides from a guest lecture at the Stanford AIMS Seminar tracing the τ-bench family — from the original tool-agent-user substrate through dual control and knowledge to full-duplex voice — including how pausing time makes a realistic, controllable voice benchmark possible.</p>
+        </a>
+        <div class="post-authors"><div class="post-author-photos"><a href="/authors/soham-ray.html" class="post-author-photo-link" title="Soham Ray"><img src="/authors/soham-ray.jpg" alt="Soham Ray" class="post-author-photo" /></a><a href="/authors/victor-barres.html" class="post-author-photo-link" title="Victor Barres"><img src="/authors/victor-barres.jpg" alt="Victor Barres" class="post-author-photo" /></a><a href="/authors/honghua-dong.html" class="post-author-photo-link" title="Honghua Dong"><img src="/authors/honghua-dong.jpg" alt="Honghua Dong" class="post-author-photo" /></a></div><span class="post-author-names"><a href="/authors/soham-ray.html" class="post-author-name">Soham Ray</a>, <a href="/authors/victor-barres.html" class="post-author-name">Victor Barres</a> &amp; <a href="/authors/honghua-dong.html" class="post-author-name">Honghua Dong</a></span></div>
+      </article>
+      <article class="blog-card">
         <a class="blog-card-link" href="https://sierra.ai/blog/tau-voice-benchmarking-real-time-voice-agents-on-real-world-tasks" target="_blank" rel="noopener noreferrer">
           <div class="blog-card-top">
             <span class="blog-card-label">Research · May 2026</span>

--- a/web/leaderboard/public/authors/victor-barres.html
+++ b/web/leaderboard/public/authors/victor-barres.html
@@ -158,6 +158,17 @@
       <h2 class="section-title">Posts</h2>
       <div class="blog-grid">
       <article class="blog-card">
+        <a class="blog-card-link" href="/talks/stanford-aims-tau.html">
+          <div class="blog-card-top">
+            <span class="blog-card-label">Talk · July 2026</span>
+            
+          </div>
+          <h2 class="blog-card-title">The τ-bench Family: Guest Lecture at the Stanford AIMS Seminar</h2>
+          <p class="blog-card-description">Slides from a guest lecture at the Stanford AIMS Seminar tracing the τ-bench family — from the original tool-agent-user substrate through dual control and knowledge to full-duplex voice — including how pausing time makes a realistic, controllable voice benchmark possible.</p>
+        </a>
+        <div class="post-authors"><div class="post-author-photos"><a href="/authors/soham-ray.html" class="post-author-photo-link" title="Soham Ray"><img src="/authors/soham-ray.jpg" alt="Soham Ray" class="post-author-photo" /></a><a href="/authors/victor-barres.html" class="post-author-photo-link" title="Victor Barres"><img src="/authors/victor-barres.jpg" alt="Victor Barres" class="post-author-photo" /></a><a href="/authors/honghua-dong.html" class="post-author-photo-link" title="Honghua Dong"><img src="/authors/honghua-dong.jpg" alt="Honghua Dong" class="post-author-photo" /></a></div><span class="post-author-names"><a href="/authors/soham-ray.html" class="post-author-name">Soham Ray</a>, <a href="/authors/victor-barres.html" class="post-author-name">Victor Barres</a> &amp; <a href="/authors/honghua-dong.html" class="post-author-name">Honghua Dong</a></span></div>
+      </article>
+      <article class="blog-card">
         <a class="blog-card-link" href="https://sierra.ai/blog/tau-voice-benchmarking-real-time-voice-agents-on-real-world-tasks" target="_blank" rel="noopener noreferrer">
           <div class="blog-card-top">
             <span class="blog-card-label">Research · May 2026</span>

--- a/web/leaderboard/public/sitemap.xml
+++ b/web/leaderboard/public/sitemap.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://taubench.com/</loc></url>
+  <url><loc>https://taubench.com/talks/stanford-aims-tau.html</loc></url>
   <url><loc>https://taubench.com/blog/tau-knowledge.html</loc></url>
   <url><loc>https://taubench.com/blog/tau-voice-examples.html</loc></url>
   <url><loc>https://taubench.com/blog/tau3-task-fixes.html</loc></url>
-  <url><loc>https://taubench.com/talks/stanford-aims-tau.html</loc></url>
   <url><loc>https://taubench.com/authors/victor-barres.html</loc></url>
   <url><loc>https://taubench.com/authors/ben-shi.html</loc></url>
   <url><loc>https://taubench.com/authors/ola-zytek.html</loc></url>

--- a/web/leaderboard/scripts/prerender.mjs
+++ b/web/leaderboard/scripts/prerender.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+// Prerender the built SPA: one static HTML file per route, with that route's
+// content and meta tags baked in, so crawlers and unfurl bots see real pages.
+//
+//   node scripts/prerender.mjs           # prerender dist/ in place
+//   node scripts/prerender.mjs --serve   # just serve dist/ with GitHub Pages
+//                                        # semantics (for e2e / manual testing)
+//
+// How it works: serve dist/ locally, load each route from src/routes.js in
+// headless Chrome (--dump-dom serializes the DOM after React renders and
+// App.jsx's applyPageMeta sets the head tags), validate the snapshot against
+// per-route content guards, and write it to dist/<route>/index.html. The
+// original index.html is copied to 404.html first, so unknown paths still
+// boot the SPA (GitHub Pages serves 404.html for paths with no file).
+//
+// The guards are load-bearing: the leaderboard fetches live submission data
+// while being snapshotted, and a network flake would otherwise deploy blank
+// pages that look like a successful build.
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+import fs from 'node:fs'
+import http from 'node:http'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { PAGE_META, ROUTES } from '../src/routes.js'
+
+const DIST = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist')
+const VIRTUAL_TIME_BUDGET_MS = 20000
+
+// Per-route sanity checks applied to each snapshot. `required` patterns must
+// all match; `forbidden` patterns must not.
+const GUARDS = {
+  '/': {
+    required: [/preview-table-wrapper/, /τ³-Banking/, /How τ-bench has evolved/],
+    forbidden: [/Loading leaderboard/],
+  },
+  '/leaderboard': {
+    required: [/τ³-Banking Leaderboard/, /(<tr[\s>].*?){5,}/s],
+    forbidden: [/Loading leaderboard/],
+  },
+  '/progress': {
+    required: [/id="progress"/],
+    forbidden: [/Loading leaderboard/],
+  },
+  '/trajectory-visualizer': {
+    required: [/τ-bench Visualizer/],
+    forbidden: [],
+    // Small by design: header + selectors, no data until a model is chosen.
+    minBytes: 6000,
+  },
+  '/blog': {
+    required: [/τ-voice/i],
+    forbidden: [],
+  },
+}
+
+const MIME = {
+  '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css',
+  '.json': 'application/json', '.png': 'image/png', '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg', '.svg': 'image/svg+xml', '.ico': 'image/x-icon',
+  '.mp3': 'audio/mpeg', '.wav': 'audio/wav', '.woff2': 'font/woff2',
+  '.txt': 'text/plain', '.xml': 'application/xml', '.webmanifest': 'application/json',
+}
+
+const resolveFile = (urlPath) => {
+  const clean = path.normalize(decodeURIComponent(urlPath)).replace(/^(\.\.[/\\])+/, '')
+  let filePath = path.join(DIST, clean)
+  if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+    filePath = path.join(filePath, 'index.html')
+  }
+  return fs.existsSync(filePath) && fs.statSync(filePath).isFile() ? filePath : null
+}
+
+// Static server. `routeFallback` controls what happens for known-route paths
+// with no file on disk yet:
+//   true  → serve index.html (needed during the prerender pass itself)
+//   false → GitHub Pages semantics: 404.html with a 404 status
+const createServer = (routeFallback) =>
+  http.createServer((req, res) => {
+    const urlPath = new URL(req.url, 'http://localhost').pathname
+    let filePath = resolveFile(urlPath)
+
+    if (!filePath && routeFallback && ROUTES[urlPath.replace(/\/$/, '') || '/']) {
+      filePath = path.join(DIST, 'index.html')
+    }
+
+    if (!filePath) {
+      const notFound = path.join(DIST, '404.html')
+      res.writeHead(404, { 'Content-Type': 'text/html' })
+      res.end(fs.existsSync(notFound) ? fs.readFileSync(notFound) : 'Not found')
+      return
+    }
+
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(filePath)] || 'application/octet-stream' })
+    res.end(fs.readFileSync(filePath))
+  })
+
+const listen = (server, port) =>
+  new Promise((resolve) => server.listen(port, '127.0.0.1', () => resolve(server.address().port)))
+
+const findChrome = () => {
+  if (process.env.CHROME_BIN) return process.env.CHROME_BIN
+  const candidates = [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/chromium',
+  ]
+  const found = candidates.find((c) => fs.existsSync(c))
+  if (!found) throw new Error('Chrome not found; set CHROME_BIN')
+  return found
+}
+
+// NOTE: must be async — the dist server runs in this same process, so a
+// synchronous exec would block the event loop and deadlock Chrome's requests.
+const dumpDom = async (chrome, url) => {
+  const { stdout } = await execFileAsync(
+    chrome,
+    [
+      '--headless=new', '--disable-gpu', '--hide-scrollbars', '--no-sandbox',
+      `--virtual-time-budget=${VIRTUAL_TIME_BUDGET_MS}`, '--dump-dom', url,
+    ],
+    { maxBuffer: 64 * 1024 * 1024, encoding: 'utf8', timeout: 120000 }
+  )
+  return stdout
+}
+
+const checkGuards = (route, html) => {
+  const failures = []
+  const guard = GUARDS[route] || { required: [], forbidden: [] }
+
+  const view = ROUTES[route]
+  const expectedTitle = PAGE_META[view]?.title
+  if (expectedTitle && !html.includes(`<title>${expectedTitle}</title>`)) {
+    failures.push(`missing <title>${expectedTitle}</title>`)
+  }
+  for (const re of guard.required) {
+    if (!re.test(html)) failures.push(`missing required pattern ${re}`)
+  }
+  for (const re of guard.forbidden) {
+    if (re.test(html)) failures.push(`contains forbidden pattern ${re}`)
+  }
+  const minBytes = guard.minBytes ?? 10000
+  if (html.length < minBytes) failures.push(`suspiciously small snapshot (${html.length} bytes)`)
+  return failures
+}
+
+const prerender = async () => {
+  if (!fs.existsSync(path.join(DIST, 'index.html'))) {
+    throw new Error(`${DIST}/index.html not found — run \`npm run build\` first`)
+  }
+
+  // The pristine SPA shell doubles as the 404 fallback: it boots the app,
+  // which renders the right view for any path (or home for unknown ones).
+  fs.copyFileSync(path.join(DIST, 'index.html'), path.join(DIST, '404.html'))
+
+  const server = createServer(true)
+  const port = await listen(server, 0)
+  const chrome = findChrome()
+
+  const errors = []
+  const snapshots = {}
+  try {
+    for (const route of Object.keys(ROUTES)) {
+      const url = `http://127.0.0.1:${port}${route}`
+      process.stdout.write(`prerendering ${route} ... `)
+      let html = await dumpDom(chrome, url)
+      if (!/^<!doctype html>/i.test(html)) html = `<!DOCTYPE html>\n${html}`
+
+      const failures = checkGuards(route, html)
+      if (failures.length > 0) {
+        console.log('FAIL')
+        errors.push(`${route}: ${failures.join('; ')}`)
+        continue
+      }
+      snapshots[route] = html
+      console.log(`ok (${(html.length / 1024).toFixed(0)} KB)`)
+    }
+  } finally {
+    server.close()
+  }
+
+  if (errors.length > 0) {
+    console.error('\nPrerender guard failures (refusing to write partial output):')
+    for (const e of errors) console.error(`  - ${e}`)
+    process.exit(1)
+  }
+
+  // All snapshots passed; write them out. '/' overwrites index.html itself.
+  for (const [route, html] of Object.entries(snapshots)) {
+    const outFile =
+      route === '/' ? path.join(DIST, 'index.html') : path.join(DIST, route.slice(1), 'index.html')
+    fs.mkdirSync(path.dirname(outFile), { recursive: true })
+    fs.writeFileSync(outFile, html)
+  }
+  console.log(`\nPrerendered ${Object.keys(snapshots).length} routes into ${DIST}`)
+}
+
+const serveOnly = async () => {
+  const port = Number(process.env.PORT || 4173)
+  await listen(createServer(false), port)
+  console.log(`Serving ${DIST} at http://127.0.0.1:${port} (GitHub Pages semantics, Ctrl-C to stop)`)
+}
+
+if (process.argv.includes('--serve')) {
+  serveOnly()
+} else {
+  prerender().catch((err) => {
+    console.error(err.message)
+    process.exit(1)
+  })
+}

--- a/web/leaderboard/src/App.jsx
+++ b/web/leaderboard/src/App.jsx
@@ -1,57 +1,58 @@
 import { useState, useEffect } from 'react'
 import './App.css'
+import { getViewFromPath, PAGE_META, SITE_ORIGIN, VIEW_PATHS } from './routes'
 import TrajectoryVisualizer from './components/TrajectoryVisualizer'
 import Leaderboard from './components/Leaderboard'
 import LeaderboardPreview from './components/LeaderboardPreview'
 import EvolutionTimeline from './components/EvolutionTimeline'
 import Blog from './components/Blog'
 
-function App() {
-  
-  // Initialize currentView based on URL hash (strip query params for view matching)
-  const getViewFromHash = (hash) => {
-    const base = hash.split('?')[0]
-    if (base === 'leaderboard') return 'leaderboard'
-    // #progress is a deep-link to the Progress-over-time panel inside the
-    // leaderboard view. The view is the leaderboard; the in-page scroll to
-    // #progress is handled by the effect below.
-    if (base === 'progress') return 'leaderboard'
-    if (base === 'trajectory-visualizer') return 'trajectory-visualizer'
-    if (base === 'blog') return 'blog'
-    if (base === 'results' || base === 'docs') return '__deprecated__'
-    return 'home'
-  }
+// Update the document head to match the current view. The prerender step
+// (scripts/prerender.mjs) snapshots the DOM after this runs, which is how
+// each prerendered page gets its own title/description/canonical tags.
+const setHeadContent = (selector, attr, value) => {
+  const el = document.head.querySelector(selector)
+  if (el) el.setAttribute(attr, value)
+}
 
-  const getInitialView = () => {
-    const hash = window.location.hash.slice(1)
-    const view = getViewFromHash(hash)
-    if (view === '__deprecated__') {
-      window.history.replaceState(null, '', '#home')
-      return 'home'
-    }
-    return view
-  }
-  
-  const [currentView, setCurrentView] = useState(getInitialView())
+const applyPageMeta = (view) => {
+  const meta = PAGE_META[view]
+  if (!meta) return
+  const url = `${SITE_ORIGIN}${VIEW_PATHS[view] || '/'}`
+  document.title = meta.title
+  setHeadContent('meta[name="description"]', 'content', meta.description)
+  setHeadContent('link[rel="canonical"]', 'href', url)
+  setHeadContent('meta[property="og:url"]', 'content', url)
+  setHeadContent('meta[property="og:title"]', 'content', meta.title)
+  setHeadContent('meta[property="og:description"]', 'content', meta.description)
+  setHeadContent('meta[name="twitter:title"]', 'content', meta.title)
+  setHeadContent('meta[name="twitter:description"]', 'content', meta.description)
+}
+
+function App() {
+
+  const [currentView, setCurrentView] = useState(() => getViewFromPath(window.location.pathname))
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   // Handle navigation with URL updates
   const navigateTo = (view) => {
     setCurrentView(view)
     setMobileMenuOpen(false) // Close mobile menu when navigating
-    if (view === 'home') {
-      window.history.pushState(null, '', '#home')
-    } else if (view === 'leaderboard') {
-      window.history.pushState(null, '', '#leaderboard')
-    } else if (view === 'blog') {
-      window.history.pushState(null, '', '#blog')
-    } else if (view === 'trajectory-visualizer') {
-      // Preserve existing query params if already on the visualizer
-      const currentHash = window.location.hash || ''
-      if (!currentHash.startsWith('#trajectory-visualizer')) {
-        window.history.pushState(null, '', '#trajectory-visualizer')
-      }
+    const path = VIEW_PATHS[view]
+    if (!path) return
+    // Preserve existing query params when already on the target path (the
+    // visualizer and leaderboard keep their state in the query string).
+    if (window.location.pathname !== path) {
+      window.history.pushState(null, '', path)
     }
+  }
+
+  // Navigate to an app-internal URL (path + query), e.g. from the homepage
+  // preview cards: '/leaderboard?benchmark=voice'.
+  const navigateToUrl = (url) => {
+    window.history.pushState(null, '', url)
+    setCurrentView(getViewFromPath(new URL(url, window.location.origin).pathname))
+    setMobileMenuOpen(false)
   }
 
   // Toggle mobile menu
@@ -61,12 +62,12 @@ function App() {
 
 
 
-  // Scroll to a specific section if the hash refers to one (e.g. #progress).
-  // Tries a few times with rAF + small timeouts so it works even if the
-  // target hasn't mounted yet (data-loading async views).
-  const scrollToSectionForHash = (hash) => {
-    const base = hash.split('?')[0]
-    const sectionId = base === 'progress' ? 'progress' : null
+  // Scroll to a specific section if the path refers to one (/progress is the
+  // leaderboard scrolled to the Progress-over-time panel). Tries a few times
+  // with rAF + small timeouts so it works even if the target hasn't mounted
+  // yet (data-loading async views).
+  const scrollToSectionForPath = (pathname) => {
+    const sectionId = pathname.replace(/\/$/, '') === '/progress' ? 'progress' : null
     if (!sectionId) return
     const tryScroll = (attemptsLeft) => {
       const el = document.getElementById(sectionId)
@@ -79,22 +80,17 @@ function App() {
     requestAnimationFrame(() => tryScroll(20))
   }
 
+  // Keep the document head (title, description, canonical, og:*) in sync
+  // with the current view.
+  useEffect(() => {
+    applyPageMeta(currentView)
+  }, [currentView])
+
   // Listen for browser back/forward button clicks and handle mobile menu
   useEffect(() => {
-    const handleHashChange = () => {
-      const hash = window.location.hash.slice(1)
-      const view = getViewFromHash(hash)
-      if (view === '__deprecated__') {
-        window.history.replaceState(null, '', '#home')
-        setCurrentView('home')
-      } else {
-        setCurrentView(view)
-        scrollToSectionForHash(hash)
-      }
-    }
-
     const handlePopState = () => {
-      handleHashChange()
+      setCurrentView(getViewFromPath(window.location.pathname))
+      scrollToSectionForPath(window.location.pathname)
     }
 
     // Close mobile menu when clicking outside
@@ -105,20 +101,13 @@ function App() {
     }
 
     // Listen to events
-    window.addEventListener('hashchange', handleHashChange)
     window.addEventListener('popstate', handlePopState)
     document.addEventListener('click', handleClickOutside)
 
-    // Set initial URL if none exists
-    if (!window.location.hash) {
-      window.history.replaceState(null, '', '#home')
-    } else {
-      // Honor an initial deep-link like #progress on first paint.
-      scrollToSectionForHash(window.location.hash.slice(1))
-    }
+    // Honor an initial deep-link like /progress on first paint.
+    scrollToSectionForPath(window.location.pathname)
 
     return () => {
-      window.removeEventListener('hashchange', handleHashChange)
       window.removeEventListener('popstate', handlePopState)
       document.removeEventListener('click', handleClickOutside)
     }
@@ -188,7 +177,10 @@ function App() {
                   retrieve knowledge, and follow policy across enterprise domains — in text and voice.
                 </p>
 
-                <LeaderboardPreview onViewFullLeaderboard={() => navigateTo('leaderboard')} />
+                <LeaderboardPreview
+                  onViewFullLeaderboard={() => navigateTo('leaderboard')}
+                  onNavigate={navigateToUrl}
+                />
               </div>
             </div>
           </section>

--- a/web/leaderboard/src/App.jsx
+++ b/web/leaderboard/src/App.jsx
@@ -43,8 +43,16 @@ function App() {
     // Preserve existing query params when already on the target path (the
     // visualizer and leaderboard keep their state in the query string).
     if (window.location.pathname !== path) {
-      window.history.pushState(null, '', path)
+      // Keep the query string when moving between two routes of the same
+      // view (e.g. /progress → /leaderboard both render the leaderboard,
+      // and ?benchmark=… should survive the switch).
+      const sameView = getViewFromPath(window.location.pathname) === view
+      window.history.pushState(null, '', sameView ? `${path}${window.location.search}` : path)
     }
+    // If the view didn't change, React won't re-render anything, so without
+    // this a nav click from e.g. /progress (scrolled to the chart) back to
+    // /leaderboard would visibly do nothing.
+    window.scrollTo(0, 0)
   }
 
   // Navigate to an app-internal URL (path + query), e.g. from the homepage
@@ -53,6 +61,7 @@ function App() {
     window.history.pushState(null, '', url)
     setCurrentView(getViewFromPath(new URL(url, window.location.origin).pathname))
     setMobileMenuOpen(false)
+    window.scrollTo(0, 0)
   }
 
   // Toggle mobile menu

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -11,14 +11,17 @@ const BENCHMARK_VALUES = new Set(['core', 'knowledge', 'voice'])
 // Pre-bucket URLs and localStorage used benchmark=text for what is now 'core'.
 const normalizeBenchmark = (value) => (value === 'text' ? 'core' : value)
 
-const getBenchmarkFromHash = () => {
-  const hash = window.location.hash.slice(1)
-  const [route, queryString = ''] = hash.split('?')
-  // Both #leaderboard?benchmark=… and #progress?benchmark=… select the
-  // benchmark on the same view, so accept either route.
-  if (route !== 'leaderboard' && route !== 'progress') return null
+// Both /leaderboard?benchmark=… and /progress?benchmark=… select the
+// benchmark on the same view, so accept either route.
+const isLeaderboardPath = (pathname) => {
+  const path = pathname.replace(/\/$/, '') || '/'
+  return path === '/leaderboard' || path === '/progress'
+}
 
-  const value = normalizeBenchmark(new URLSearchParams(queryString).get('benchmark'))
+const getBenchmarkFromUrl = () => {
+  if (!isLeaderboardPath(window.location.pathname)) return null
+
+  const value = normalizeBenchmark(new URLSearchParams(window.location.search).get('benchmark'))
   return BENCHMARK_VALUES.has(value) ? value : null
 }
 
@@ -233,8 +236,8 @@ const Leaderboard = () => {
   // Benchmark selector: 'core' (τ²-bench), 'knowledge' (τ-knowledge), or
   // 'voice' (τ-voice)
   const [benchmark, setBenchmark] = useState(() => {
-    const fromHash = getBenchmarkFromHash()
-    if (fromHash) return fromHash
+    const fromUrl = getBenchmarkFromUrl()
+    if (fromUrl) return fromUrl
 
     const fromStorage = normalizeBenchmark(localStorage.getItem('benchmark'))
     // Default to the first toggle position (newest track)
@@ -471,39 +474,32 @@ const Leaderboard = () => {
   }, [benchmark])
 
   // Keep benchmark in URL for shareable deep links, e.g.
-  // #leaderboard?benchmark=voice or #progress?benchmark=voice
+  // /leaderboard?benchmark=voice or /progress?benchmark=voice
   useEffect(() => {
-    const currentHash = window.location.hash
-    if (!currentHash.startsWith('#leaderboard') && !currentHash.startsWith('#progress')) {
-      return
-    }
+    if (!isLeaderboardPath(window.location.pathname)) return
 
-    const hash = currentHash.slice(1)
-    const [route, queryString = ''] = hash.split('?')
-    const params = new URLSearchParams(queryString)
+    const params = new URLSearchParams(window.location.search)
     params.set('benchmark', benchmark)
     params.delete('view')
 
-    const nextHash = `${route}?${params.toString()}`
-    if (hash !== nextHash) {
-      window.history.replaceState(null, '', `#${nextHash}`)
+    const next = `${window.location.pathname}?${params.toString()}`
+    if (`${window.location.pathname}${window.location.search}` !== next) {
+      window.history.replaceState(null, '', next)
     }
   }, [benchmark])
 
-  // React to manual hash edits or browser navigation events.
+  // React to browser navigation events (back/forward).
   useEffect(() => {
-    const syncFromHash = () => {
-      const benchmarkFromHash = getBenchmarkFromHash()
-      if (benchmarkFromHash) {
-        setBenchmark(prev => (prev === benchmarkFromHash ? prev : benchmarkFromHash))
+    const syncFromUrl = () => {
+      const benchmarkFromUrl = getBenchmarkFromUrl()
+      if (benchmarkFromUrl) {
+        setBenchmark(prev => (prev === benchmarkFromUrl ? prev : benchmarkFromUrl))
       }
     }
 
-    window.addEventListener('hashchange', syncFromHash)
-    window.addEventListener('popstate', syncFromHash)
+    window.addEventListener('popstate', syncFromUrl)
     return () => {
-      window.removeEventListener('hashchange', syncFromHash)
-      window.removeEventListener('popstate', syncFromHash)
+      window.removeEventListener('popstate', syncFromUrl)
     }
   }, [])
 
@@ -1277,7 +1273,7 @@ const Leaderboard = () => {
                                 {hasTraj && (
                                   <a
                                     className="view-trajectories-link"
-                                    href={`#trajectory-visualizer?model=${encodeURIComponent(submissionInfo.submissionDir)}&domain=${key}`}
+                                    href={`/trajectory-visualizer?model=${encodeURIComponent(submissionInfo.submissionDir)}&domain=${key}`}
                                   >
                                     View trajectories →
                                   </a>

--- a/web/leaderboard/src/components/LeaderboardPreview.jsx
+++ b/web/leaderboard/src/components/LeaderboardPreview.jsx
@@ -22,7 +22,7 @@ const corePass1 = (results) => {
 // each showing its Overall top 3.
 // TODO(voice-banking): when banking is supported in voice mode, its scores
 // belong in the Knowledge bucket (as a text/voice split), not in Voice.
-function LeaderboardPreview({ onViewFullLeaderboard }) {
+function LeaderboardPreview({ onViewFullLeaderboard, onNavigate }) {
   const [coreTop3, setCoreTop3] = useState([])
   const [knowledgeTop3, setKnowledgeTop3] = useState([])
   const [voiceTop3, setVoiceTop3] = useState([])
@@ -123,16 +123,28 @@ function LeaderboardPreview({ onViewFullLeaderboard }) {
   // only carries what the badge doesn't already say (e.g. no "Voice" mode
   // under the τ³-Voice badge).
   const cards = [
-    { badge: 'τ³-Banking', badgeClass: 'knowledge', mode: 'Text', domains: 'Knowledge retrieval', href: '#leaderboard?benchmark=knowledge', hoverNote: 'τ³-Banking was published as τ-knowledge', models: knowledgeTop3 },
-    { badge: 'τ³-Voice', badgeClass: 'voice', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=voice', hoverNote: 'τ³-Voice was published as τ-voice', models: voiceTop3 },
-    { badge: 'τ²-bench', badgeClass: 'core', mode: 'Text', domains: 'Retail · Airline · Telecom', href: '#leaderboard?benchmark=core', models: coreTop3 },
+    { badge: 'τ³-Banking', badgeClass: 'knowledge', mode: 'Text', domains: 'Knowledge retrieval', href: '/leaderboard?benchmark=knowledge', hoverNote: 'τ³-Banking was published as τ-knowledge', models: knowledgeTop3 },
+    { badge: 'τ³-Voice', badgeClass: 'voice', domains: 'Retail · Airline · Telecom', href: '/leaderboard?benchmark=voice', hoverNote: 'τ³-Voice was published as τ-voice', models: voiceTop3 },
+    { badge: 'τ²-bench', badgeClass: 'core', mode: 'Text', domains: 'Retail · Airline · Telecom', href: '/leaderboard?benchmark=core', models: coreTop3 },
   ]
 
   return (
     <div className="leaderboard-preview">
       <div className="preview-tables">
         {cards.map((card) => (
-          <a className="preview-table-wrapper" href={card.href} key={card.badge}>
+          <a
+            className="preview-table-wrapper"
+            href={card.href}
+            key={card.badge}
+            onClick={(e) => {
+              // Client-side navigation for plain clicks; let modified clicks
+              // (cmd/ctrl/middle) open a new tab via the real href.
+              if (onNavigate && !e.metaKey && !e.ctrlKey && !e.shiftKey && e.button === 0) {
+                e.preventDefault()
+                onNavigate(card.href)
+              }
+            }}
+          >
             <h3 className="preview-table-title">
               <span className={`preview-mode-badge ${card.badgeClass}`} title={card.hoverNote}>{card.badge}</span>
               <span className="preview-table-subtitle">

--- a/web/leaderboard/src/components/TrajectoryVisualizer.jsx
+++ b/web/leaderboard/src/components/TrajectoryVisualizer.jsx
@@ -90,10 +90,7 @@ const TrajectoryVisualizer = () => {
 
   // --- Parse URL params for deep linking ---
   const getUrlParams = () => {
-    const hash = window.location.hash || ''
-    const qIdx = hash.indexOf('?')
-    if (qIdx === -1) return {}
-    const params = new URLSearchParams(hash.slice(qIdx + 1))
+    const params = new URLSearchParams(window.location.search)
     const trialRaw = params.get('trial')
     return {
       model: params.get('model'),
@@ -109,7 +106,7 @@ const TrajectoryVisualizer = () => {
   // Suppress URL updates while we're restoring from URL
   const restoringFromUrl = useRef(false)
 
-  // --- Sync state → URL hash (replaceState to avoid history clutter) ---
+  // --- Sync state → URL query (replaceState to avoid history clutter) ---
   useEffect(() => {
     if (restoringFromUrl.current) return
     if (submissionsLoading) return
@@ -122,9 +119,9 @@ const TrajectoryVisualizer = () => {
     if (selectedTrialIdx > 0) params.set('trial', String(selectedTrialIdx))
 
     const qs = params.toString()
-    const newHash = qs ? `#trajectory-visualizer?${qs}` : '#trajectory-visualizer'
-    if (window.location.hash !== newHash) {
-      window.history.replaceState(null, '', newHash)
+    const newUrl = qs ? `/trajectory-visualizer?${qs}` : '/trajectory-visualizer'
+    if (`${window.location.pathname}${window.location.search}` !== newUrl) {
+      window.history.replaceState(null, '', newUrl)
     }
   }, [selectedModelDir, selectedDomain, selectedTaskId, selectedTrialIdx, viewMode, submissionsLoading])
 

--- a/web/leaderboard/src/routes.js
+++ b/web/leaderboard/src/routes.js
@@ -1,0 +1,57 @@
+// Single source of truth for the site's routes and per-page metadata.
+//
+// Imported by the app (App.jsx) and by scripts/prerender.mjs (plain Node),
+// so keep this file free of JSX and browser globals. Adding a page here is
+// what makes it exist: the router resolves it, the prerender step emits a
+// static HTML file for it, and the e2e suite picks it up.
+
+export const SITE_ORIGIN = 'https://taubench.com'
+
+// path → view name. Multiple paths may map to the same view ('/progress' is
+// the leaderboard scrolled to the progress-over-time section).
+export const ROUTES = {
+  '/': 'home',
+  '/leaderboard': 'leaderboard',
+  '/progress': 'leaderboard',
+  '/trajectory-visualizer': 'trajectory-visualizer',
+  '/blog': 'blog',
+}
+
+// Canonical path for each view (used for navigation and canonical/og:url).
+export const VIEW_PATHS = {
+  home: '/',
+  leaderboard: '/leaderboard',
+  'trajectory-visualizer': '/trajectory-visualizer',
+  blog: '/blog',
+}
+
+const SITE_TITLE = 'τ-bench — Benchmarking AI Agents on Real-World Tasks'
+const SITE_DESCRIPTION =
+  'Can AI agents reliably complete real-world tasks? τ-bench measures how well agents converse with users, call tools, retrieve knowledge, and follow policy across enterprise domains — in text and voice.'
+
+export const PAGE_META = {
+  home: {
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  leaderboard: {
+    title: 'Leaderboard — τ-bench',
+    description:
+      'Model rankings on τ³-Banking, τ³-Voice, and τ²-bench: pass^k reliability for AI agents on enterprise customer-service tasks.',
+  },
+  'trajectory-visualizer': {
+    title: 'Visualizer — τ-bench',
+    description:
+      'Explore τ-bench evaluation trajectories: full agent–user conversations, tool calls, and task definitions across domains.',
+  },
+  blog: {
+    title: 'Blog — τ-bench',
+    description: 'Research updates and release notes from the τ-bench team.',
+  },
+}
+
+const stripTrailingSlash = (p) => (p.length > 1 && p.endsWith('/') ? p.slice(0, -1) : p)
+
+// Resolve a pathname to a view; unknown paths render the homepage view
+// (matching the old hash router's behavior for unknown hashes).
+export const getViewFromPath = (pathname) => ROUTES[stripTrailingSlash(pathname)] || 'home'


### PR DESCRIPTION
> **Stacked on #428** (SEO meta tags). Merge #428 first; this PR will then be rebased onto `main`.

Implements the routing + prerendering plan (steps 1–3; staging deploy intentionally skipped):

## 1. Path routing
- URLs are now real paths: `/leaderboard?benchmark=voice`, `/progress`, `/trajectory-visualizer?model=…`, `/blog`
- Legacy hash links (`/#leaderboard?benchmark=voice`, `/#docs`, …) are rewritten to path equivalents by a tiny shim in `index.html` before the app boots — every old shared link keeps working
- `src/routes.js` is the single source of truth: route → view mapping + per-page `<title>`/description/canonical/OG tags, applied by `App.jsx` on view change (browser tab titles now update per page too)
- Homepage preview cards do client-side navigation on plain click, and still open in a new tab on cmd/ctrl-click

## 2. Prerendering (deploy-time)
- `scripts/prerender.mjs` serves the built `dist/`, loads each route in headless Chrome (`--dump-dom`), and writes the rendered HTML to `dist/<route>/index.html`
- Crawlers and unfurl bots now see real content + per-page meta for every route — no JS execution required
- `404.html` (pristine SPA shell) handles unknown paths: GitHub Pages serves it with a 404 status and the app renders normally
- Runs automatically in the deploy workflow between build and upload — no manual steps for anyone

## 3. Guards + e2e tests
- Per-route content guards (required/forbidden patterns, expected title, min size) make the deploy **fail loudly** instead of shipping blank pages if a data fetch flakes during prerender
- New Playwright suite (`e2e/routing.spec.js`, 14 tests) runs on PRs touching `web/leaderboard/**`: direct loads, legacy hash redirects (incl. `benchmark=text` → `core` normalization), client-side nav + back button, prerendered HTML content, 404 semantics
- Hermetic in CI: builds against the git-tracked submissions data, uses the runner's system Chrome

## Verification
- `npm run build && npm run prerender` — all 5 routes pass guards
- All 14 Playwright tests pass locally against the prerendered `dist/`
- `vite` dev server unchanged (its built-in SPA fallback serves any path)

Also snuck in: regenerated author pages + sitemap (Stanford talk card, output of `npm run generate` that hadn't been committed), and README docs for the new setup.

Made with [Cursor](https://cursor.com)

## Screenshots (local prerendered build)

**Homepage `/`**

![Homepage](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr433-assets/shots/home.png)

**`/leaderboard` (defaults to τ³-Banking)**

![Banking leaderboard](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr433-assets/shots/leaderboard-banking.png)

**Deep link `/leaderboard?benchmark=voice`**

![Voice leaderboard](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr433-assets/shots/leaderboard-voice.png)

**`/progress` (auto-scrolls to the progress chart)**

![Progress](https://raw.githubusercontent.com/sierra-research/tau2-bench/pr433-assets/shots/progress.png)

*(Images hosted on the `pr433-assets` branch — kept permanently so these screenshots don't break; do not delete.)*

