### PR TITLE
Truncate long tool results in tau2 view (default 500 chars)

### DIFF
--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -717,6 +717,17 @@ def main():
         action="store_true",
         help="Show expanded tick view instead of consolidated (for full-duplex simulations).",
     )
+    view_parser.add_argument(
+        "--max-tool-result-chars",
+        type=int,
+        default=500,
+        help="Truncate tool results (e.g. retrieved knowledge articles) to this many characters. Default: 500.",
+    )
+    view_parser.add_argument(
+        "--full-tool-results",
+        action="store_true",
+        help="Show full tool results without truncation.",
+    )
     view_parser.set_defaults(func=lambda args: run_view_simulations(args))
 
     # Domain command
@@ -972,12 +983,18 @@ def main():
 def run_view_simulations(args):
     from tau2.scripts.view_simulations import main as view_main
 
+    if args.full_tool_results or args.max_tool_result_chars <= 0:
+        max_tool_result_length = None
+    else:
+        max_tool_result_length = args.max_tool_result_chars
+
     view_main(
         sim_file=args.file,
         only_show_failed=args.only_show_failed,
         only_show_all_failed=args.only_show_all_failed,
         sim_dir=args.dir,
         expanded_ticks=args.expanded_ticks,
+        max_tool_result_length=max_tool_result_length,
     )
 
 

--- a/src/tau2/scripts/view_simulations.py
+++ b/src/tau2/scripts/view_simulations.py
@@ -826,7 +826,10 @@ def main(
     only_show_all_failed: bool = False,
     sim_dir: Optional[str] = None,
     expanded_ticks: bool = False,
+    max_tool_result_length: Optional[int] = 500,
 ):
+    ConsoleDisplay.max_tool_result_length = max_tool_result_length
+
     # Get available simulation files
     if sim_file is None:
         custom_sim_dir = Path(sim_dir) if sim_dir else None

--- a/src/tau2/utils/display.py
+++ b/src/tau2/utils/display.py
@@ -126,6 +126,21 @@ class ConsoleDisplay:
     console = Console()
     colors = get_color_scheme()
 
+    # Max characters of a tool-result payload to render. None means no limit.
+    # Knowledge-domain tool results (retrieved articles) can be tens of KB,
+    # which makes trajectories unreadable in the terminal viewer.
+    max_tool_result_length: Optional[int] = None
+
+    @classmethod
+    def truncate_tool_result(cls, content: Optional[str]) -> str:
+        if content is None:
+            return ""
+        limit = cls.max_tool_result_length
+        if limit is None or len(content) <= limit:
+            return content
+        omitted = len(content) - limit
+        return f"{content[:limit]} […truncated {omitted:,} chars, use --full-tool-results to show all]"
+
     @staticmethod
     def escape_markup(text: str) -> str:
         """
@@ -746,11 +761,16 @@ class ConsoleDisplay:
 
                 current_turn = None
                 for msg in simulation.messages:
-                    content = (
-                        cls.escape_markup(msg.content)
-                        if msg.content is not None
-                        else ""
-                    )
+                    if isinstance(msg, ToolMessage):
+                        content = cls.escape_markup(
+                            cls.truncate_tool_result(msg.content)
+                        )
+                    else:
+                        content = (
+                            cls.escape_markup(msg.content)
+                            if msg.content is not None
+                            else ""
+                        )
                     details = ""
 
                     # Set different colors based on message type
@@ -1791,7 +1811,10 @@ class ConsoleDisplay:
 
             agent_results = ""
             if tick.agent_tool_results:
-                agent_results = "\n".join(r.content for r in tick.agent_tool_results)
+                agent_results = "\n".join(
+                    cls.truncate_tool_result(r.content)
+                    for r in tick.agent_tool_results
+                )
 
             agent_turn_action = ""
             if (
@@ -1816,7 +1839,10 @@ class ConsoleDisplay:
 
             user_results = ""
             if tick.user_tool_results:
-                user_results = "\n".join(r.content for r in tick.user_tool_results)
+                user_results = "\n".join(
+                    cls.truncate_tool_result(r.content)
+                    for r in tick.user_tool_results
+                )
 
             user_turn_action = ""
             if (
@@ -1963,7 +1989,8 @@ class ConsoleDisplay:
                 )
             if tick.agent_tool_results:
                 info["agent_results"] = "\n".join(
-                    r.content for r in tick.agent_tool_results
+                    cls.truncate_tool_result(r.content)
+                    for r in tick.agent_tool_results
                 )
             if (
                 tick.agent_chunk
@@ -1986,7 +2013,8 @@ class ConsoleDisplay:
                 )
             if tick.user_tool_results:
                 info["user_results"] = "\n".join(
-                    r.content for r in tick.user_tool_results
+                    cls.truncate_tool_result(r.content)
+                    for r in tick.user_tool_results
                 )
             if (
                 tick.user_chunk


### PR DESCRIPTION
## Summary

Knowledge-domain tool results (retrieved KB articles) can exceed 100K characters, which made `tau2 view` unusable for banking_knowledge trajectories — a single tool tick would flood the terminal.

- Tool-result payloads are now truncated to **500 chars** by default, with a `… [truncated N chars — use --full-tool-results to see all]` marker.
- `--full-tool-results` restores the previous behavior.
- `--max-tool-result-chars N` tunes the limit.

Non-tool message content is untouched. Split out of #395 (voice-banking track) since it's standalone viewer tooling.

## Test plan

- `tau2 view` on a banking_knowledge voice trajectory: tool ticks render at readable length with the truncation marker (snapshot in comments).
- `tau2 view --full-tool-results` matches pre-change output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)