### PR TITLE
docs: mention ClawBench as a related web-agent benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Each domain specifies:
 | **Text (half-duplex)** | Turn-based chat with tool use |
 | **Voice (full-duplex)** | End-to-end audio via realtime providers (OpenAI, Gemini, xAI) |
 
+### Related external benchmarks
+
+[ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) is a complementary benchmark for AI web agents performing real-world tasks across live websites. It is independent of τ-bench and is not integrated or supported by this repository; the link is provided for readers comparing interactive-agent evaluation environments.
+
 ## Quick Start
 
 ### 1. Install


### PR DESCRIPTION
This documentation-only change adds ClawBench as a clearly labeled complementary benchmark for real-world web-agent evaluation.

It does not claim τ-bench integration, support, or endorsement. The official ClawBench repository is linked for readers comparing interactive-agent benchmarks.

Submitted by reacher-z (mtrxcop@gmail.com), with OpenAI Codex assistance.