### PR TITLE
fix: drop empty/whitespace turns when flipping roles for the voice user simulator

### DIFF
--- a/src/tau2/user/user_simulator_streaming.py
+++ b/src/tau2/user/user_simulator_streaming.py
@@ -1352,19 +1352,24 @@ class VoiceStreamingUserSimulator(
         flipped = []
         for msg in messages:
             if isinstance(msg, UserMessage):
-                # User's message -> becomes assistant response
-                flipped.append(
-                    AssistantMessage(
-                        role="assistant",
-                        tool_calls=msg.tool_calls,
-                        content=msg.content,
+                # User's message -> becomes assistant response.
+                # Skip silent/whitespace-only turns (empty STT, or a proportional
+                # transcript slice landing on an inter-word space): they carry no
+                # info and would fail validate_message_history, which strips
+                # whitespace. Mirrors the agent-turn guard below.
+                if (msg.content and msg.content.strip()) or msg.is_tool_call():
+                    flipped.append(
+                        AssistantMessage(
+                            role="assistant",
+                            tool_calls=msg.tool_calls,
+                            content=msg.content,
+                        )
                     )
-                )
             elif isinstance(msg, AssistantMessage):
                 # Agent's message -> becomes user input
                 # Skip tool calls and messages without text content
                 # (audio-only messages can't be converted to text UserMessage)
-                if not msg.is_tool_call() and msg.content:
+                if not msg.is_tool_call() and msg.content and msg.content.strip():
                     flipped.append(
                         UserMessage(
                             role="user",

--- a/tests/test_streaming/test_voice_streaming_user_simulator.py
+++ b/tests/test_streaming/test_voice_streaming_user_simulator.py
@@ -13,7 +13,7 @@ This test suite verifies that the voice streaming user simulator works correctly
 import pytest
 
 from tau2.data_model.audio import AudioEncoding, AudioFormat
-from tau2.data_model.message import AssistantMessage, UserMessage
+from tau2.data_model.message import AssistantMessage, ToolCall, UserMessage
 from tau2.data_model.voice import SynthesisConfig, VoiceSettings
 from tau2.user.user_simulator_streaming import VoiceStreamingUserSimulator
 
@@ -444,6 +444,54 @@ def test_voice_streaming_user_role_flipping(
     # Test flip_roles method
     flipped = state.flip_roles()
     assert flipped is not None
+
+
+def test_flip_roles_drops_empty_and_whitespace_turns(
+    streaming_user: VoiceStreamingUserSimulator,
+):
+    """Empty/whitespace-only turns are dropped when flipping roles.
+
+    Regression: such turns used to leak through as content-less messages and
+    fail validate_message_history (which strips whitespace before asserting a
+    message has content or tool calls).
+    """
+    messages = [
+        UserMessage(role="user", content="I want to fly to Seattle"),
+        UserMessage(role="user", content="   "),  # whitespace-only -> dropped
+        UserMessage(role="user", content=""),  # empty -> dropped
+        AssistantMessage(role="assistant", content="Sure, when?"),
+        AssistantMessage(role="assistant", content="  "),  # whitespace -> dropped
+    ]
+
+    flipped = streaming_user._flip_roles_for_llm(messages)
+
+    # Only the two non-empty turns survive, with roles flipped.
+    assert len(flipped) == 2
+    assert isinstance(flipped[0], AssistantMessage)
+    assert flipped[0].content == "I want to fly to Seattle"
+    assert isinstance(flipped[1], UserMessage)
+    assert flipped[1].content == "Sure, when?"
+
+
+def test_flip_roles_keeps_empty_content_tool_call(
+    streaming_user: VoiceStreamingUserSimulator,
+):
+    """A user tool call with empty content is retained (is_tool_call() is true)."""
+    tool_call = ToolCall(
+        id="call_1",
+        name="book_flight",
+        arguments={"destination": "Seattle"},
+        requestor="user",
+    )
+    messages = [
+        UserMessage(role="user", content="", tool_calls=[tool_call]),
+    ]
+
+    flipped = streaming_user._flip_roles_for_llm(messages)
+
+    assert len(flipped) == 1
+    assert isinstance(flipped[0], AssistantMessage)
+    assert flipped[0].tool_calls == [tool_call]
 
 
 # --- Tool Call Tests ---


### PR DESCRIPTION
## Summary
`VoiceStreamingUserSimulator._flip_roles_for_llm` could emit a whitespace-only
message (empty STT, or a proportional transcript slice landing on an inter-word
space). `generate()` runs `validate_message_history` as its very first step, and
`validate_message` strips whitespace before asserting a message has content or
tool calls — so the whitespace-only turn raises before the LLM is called, aborting
the user-sim turn and the whole task (retried 3x). This is on the audio-native
voice path (`--audio-native` runs use `VoiceStreamingUserSimulator`).

## Changes Made
- `src/tau2/user/user_simulator_streaming.py`: in `_flip_roles_for_llm`, skip
  whitespace-only turns in both flip directions (user→assistant and agent→user);
  keep messages that carry tool calls. Mirrors the existing agent-turn guard.
- `tests/test_streaming/test_voice_streaming_user_simulator.py`: regression tests
  for the drop behavior and for tool-call retention.
- No new dependencies. No breaking changes.

## Testing
- `uv run pytest tests/test_streaming/test_voice_streaming_user_simulator.py -q` — 25 passed
- `make test` (core) — 197 passed; 2 pre-existing failures in `tests/test_run.py`
  (`test_run_tasks_nl_assertions`, `test_run_tasks_env_assertions`) that are
  LLM-nondeterministic and fail/pass identically on clean `main` (unrelated to this change).
- `uv run ruff check` / `uv run ruff format --check` on the changed files — passed.
- Note: `make test-voice` currently fails to *collect*
  `tests/test_streaming/test_discrete_time_audio_native_agent.py` (imports
  `tau2.voice.audio_native.openai.tick_runner`, a module absent on `main`);
  pre-existing and unrelated. The rest of the voice/streaming suite passes.

## Documentation
- None needed (internal bug fix; no user-facing surface changes).

## Checklist
- [x] Tests pass (`make test`; voice/streaming file run directly — see Testing for the two pre-existing, unrelated `test_run.py` flakes)
- [x] Code follows style guidelines (`ruff check` / `ruff format --check` clean on changed files)
- [x] Documentation updated (N/A)
- [x] Breaking changes noted (none)