### PR TITLE
Voice leaderboard: one-line Banking note, Banking in the timeline, standard-only default

### DIFF
--- a/web/leaderboard/src/components/EvolutionTimeline.jsx
+++ b/web/leaderboard/src/components/EvolutionTimeline.jsx
@@ -90,7 +90,7 @@ const MILESTONES = [
       </>
     ),
     domainsLabel: 'Voice mode',
-    domains: ['🛍️ Retail', '✈️ Airline', '📱 Telecom'],
+    domains: ['🛍️ Retail', '✈️ Airline', '📱 Telecom', '🏦 Banking'],
   },
 ]
 

--- a/web/leaderboard/src/components/Leaderboard.css
+++ b/web/leaderboard/src/components/Leaderboard.css
@@ -242,7 +242,7 @@
   align-items: flex-start;
   justify-content: center;
   gap: 10px;
-  max-width: 760px;
+  max-width: 840px;
   margin: -40px auto 48px;
   padding: 12px 20px;
   background: #ecfdf5;
@@ -280,6 +280,16 @@
   .domain-scope-note {
     margin: -24px 16px 40px;
     font-size: 13px;
+  }
+}
+
+/* The note reads as one sentence, so keep it on one line once there's room for
+   it (~792px incl. padding). Below this it wraps instead of overflowing. */
+@media (min-width: 900px) {
+  .domain-scope-note {
+    width: fit-content;
+    white-space: nowrap;
+    align-items: center;
   }
 }
 

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -276,10 +276,9 @@ const Leaderboard = () => {
   })
   const [showCustom, setShowCustom] = useState(() => {
     const stored = localStorage.getItem('showCustom')
-    if (stored !== null) return stored === 'true'
-    // Voice defaults to showing custom submissions alongside standard ones
-    const initialBenchmark = getBenchmarkFromUrl() || localStorage.getItem('benchmark')
-    return initialBenchmark === 'voice'
+    // Every track defaults to standard-only: custom rows aren't comparable to
+    // the rest of the board, so they're opt-in rather than mixed in by default.
+    return stored === null ? false : stored === 'true'
   })
   // Legacy submissions toggle
   const [showLegacy, setShowLegacy] = useState(() => {


### PR DESCRIPTION
Three small, independent website tweaks to the voice track. No submission data or scoring logic touched.

### 1. The voice Overall scope note fits on one line

It wrapped to two lines, orphaning "Banking." by itself. The note needs **~792px** including padding but `.domain-scope-note` was capped at **760px** — it missed by ~32px.

- Raise `max-width` to `840px`.
- Add `white-space: nowrap` + `width: fit-content` above `900px`, so it's *guaranteed* one line rather than one-line-by-luck across platforms and font stacks.
- Below 900px it wraps exactly as before. Verified no horizontal overflow at 850px or mobile.

### 2. 🏦 Banking added to τ-voice in "How τ-bench has evolved"

The τ-voice milestone still listed only Retail / Airline / Telecom under **Voice mode**. Voice covers Banking now, so the list was stale.

### 3. Submission-type filter defaults to standard-only everywhere

Voice special-cased `showCustom` to default **on**, so the first view mixed custom rows in with standard ones. Custom rows aren't comparable to the rest of the board, so they should be opt-in — same as every other track.

This only changes the *default*. A visitor who has previously toggled custom keeps their stored choice, since the `localStorage` value still wins.

### Verification

- `npm run build` + `npm run prerender` clean.
- 15/15 routing e2e pass.
- `npm run lint` byte-identical to baseline (2 pre-existing errors in `TrajectoryVisualizer.jsx` / `voiceViewerRenderer.js`, neither in these files).
- Browser-verified at 1440 / 1280 / 850 / mobile: note is a single line box (68px tall → 47px), timeline shows the Banking chip, and Standard is checked with Custom unchecked on a cleared `localStorage`.

Screenshots in a comment below.