### PR TITLE
Add gemini-3.5-flash-live voice leaderboard submissions (flash low, flash-lite high)

### DIFF
--- a/web/leaderboard/public/submissions/gemini-3-5-flash-lite-live-preview-thinking-high_google_2026-08-03/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-5-flash-lite-live-preview-thinking-high_google_2026-08-03/submission.json
@@ -1,0 +1,138 @@
+{
+  "model_name": "gemini-3.5-flash-lite-live-preview-thinking-high",
+  "model_organization": "Google",
+  "submitting_organization": "Google",
+  "submission_date": "2026-08-03",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "ruixifan@google.com",
+    "name": "Ruixi Fan"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 57.01754385964912
+    },
+    "airline": {
+      "pass_1": 60.0
+    },
+    "telecom": {
+      "pass_1": 18.421052631578945
+    }
+  },
+  "is_new": true,
+  "trajectories_available": false,
+  "trajectory_files": {
+    "airline": "20260729_045730_voice_airline_gemini_3_5_flash_lite_live_preview__high_us_default",
+    "retail": "20260729_045730_voice_retail_gemini_3_5_flash_lite_live_preview__high_us_default",
+    "telecom": "20260729_045730_voice_telecom_gemini_3_5_flash_lite_live_preview__high_us_default"
+  },
+  "methodology": {
+    "evaluation_date": "2026-07-29",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "v1.0",
+    "notes": "Audio-native full-duplex evaluation of gemini-3.5-flash-lite-live-preview with reasoning_effort=high, regular speech complexity, 1 trial per task. User simulator LLM: gpt-4.1-2025-04-14 (temperature 0.0), voice user simulator v1.0 with ElevenLabs eleven_v3 TTS. All three domains come from a single contiguous batch (20260729_045730) run back-to-back with byte-identical configuration, giving complete coverage with zero infrastructure errors: airline 50/50, retail 114/114, telecom 114/114. NOTE: run locally with self-provisioned ElevenLabs voice personas, not Sierra's official voice IDs, so absolute numbers may not be directly comparable to official leaderboard entries.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "gemini",
+    "model": "gemini-3.5-flash-lite-live-preview",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "interaction_metrics": {
+    "version": "1.0",
+    "config": {
+      "tick_duration_sec": 0.2,
+      "no_yield_window_sec": 2.0,
+      "backchannel_yield_window_sec": 1.0,
+      "vocal_tic_yield_window_sec": 1.0,
+      "non_directed_yield_window_sec": 1.0,
+      "vocal_tic_response_window_sec": 2.0,
+      "non_directed_response_window_sec": 2.0
+    },
+    "domains": {
+      "airline": {
+        "response_latency_mean": 2.1468438538205974,
+        "yield_latency_mean": 0.8205128205128204,
+        "response_rate": 0.9585987261146497,
+        "yield_rate": 0.5131578947368421,
+        "agent_interruption_rate": 0.08280254777070063,
+        "selectivity_backchannel": 0.9285714285714286,
+        "selectivity_vocal_tic": 0.4444444444444444,
+        "selectivity_non_directed": 0.52,
+        "counts": {
+          "n_simulations": 50,
+          "response_total": 314,
+          "yield_total": 152,
+          "backchannel_total": 14,
+          "vocal_tic_total": 27,
+          "non_directed_total": 25,
+          "agent_interrupts_count": 26
+        }
+      },
+      "retail": {
+        "response_latency_mean": 2.085082872928176,
+        "yield_latency_mean": 0.8526315789473685,
+        "response_rate": 0.9770580296896086,
+        "yield_rate": 0.5135135135135135,
+        "agent_interruption_rate": 0.12685560053981107,
+        "selectivity_backchannel": 0.9459459459459459,
+        "selectivity_vocal_tic": 0.375,
+        "selectivity_non_directed": 0.19672131147540983,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 741,
+          "yield_total": 407,
+          "backchannel_total": 37,
+          "vocal_tic_total": 80,
+          "non_directed_total": 61,
+          "agent_interrupts_count": 94
+        }
+      },
+      "telecom": {
+        "response_latency_mean": 1.8898218829516535,
+        "yield_latency_mean": 0.8216216216216217,
+        "response_rate": 0.9825,
+        "yield_rate": 0.46954314720812185,
+        "agent_interruption_rate": 0.155,
+        "selectivity_backchannel": 1.0,
+        "selectivity_vocal_tic": 0.42156862745098034,
+        "selectivity_non_directed": 0.26415094339622647,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 800,
+          "yield_total": 394,
+          "backchannel_total": 7,
+          "vocal_tic_total": 102,
+          "non_directed_total": 53,
+          "agent_interrupts_count": 124
+        }
+      }
+    },
+    "overall": {
+      "response_latency_mean": 2.0405828699001423,
+      "yield_latency_mean": 0.8315886736939367,
+      "response_rate": 0.9727189186014195,
+      "yield_rate": 0.49873818515282586,
+      "agent_interruption_rate": 0.12155271610350389,
+      "selectivity_backchannel": 0.9581724581724581,
+      "selectivity_vocal_tic": 0.4136710239651416,
+      "selectivity_non_directed": 0.3269574182905454,
+      "counts": {
+        "n_simulations": 278,
+        "response_total": 1855,
+        "yield_total": 953,
+        "backchannel_total": 58,
+        "vocal_tic_total": 209,
+        "non_directed_total": 139,
+        "agent_interrupts_count": 244
+      }
+    }
+  },
+  "reasoning_effort": "high"
+}

--- a/web/leaderboard/public/submissions/gemini-3-5-flash-live-preview-thinking-low_google_2026-08-03/submission.json
+++ b/web/leaderboard/public/submissions/gemini-3-5-flash-live-preview-thinking-low_google_2026-08-03/submission.json
@@ -1,0 +1,139 @@
+{
+  "model_name": "gemini-3.5-flash-live-preview-thinking-low",
+  "model_organization": "Google",
+  "submitting_organization": "Google",
+  "submission_date": "2026-08-03",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "ruixifan@google.com",
+    "name": "Ruixi Fan"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 61.40350877192983
+    },
+    "airline": {
+      "pass_1": 81.25
+    },
+    "telecom": {
+      "pass_1": 29.72972972972973
+    }
+  },
+  "is_new": true,
+  "trajectories_available": false,
+  "trajectory_files": {
+    "airline": "20260730_071051_voice_airline_gemini_3_5_flash_live_preview__low_us_default",
+    "retail": "20260730_071051_voice_retail_gemini_3_5_flash_live_preview__low_us_default",
+    "telecom": "20260801_054815_voice_telecom_gemini_3_5_flash_live_preview__low_us_default"
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-01",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "v1.0",
+    "notes": "Audio-native full-duplex evaluation of gemini-3.5-flash-live-preview with reasoning_effort=low, regular speech complexity, 1 trial per task. User simulator LLM: gpt-4.1-2025-04-14 (temperature 0.0), voice user simulator v1.0 with ElevenLabs eleven_v3 TTS. Per-domain runs were selected as the highest task-coverage run available for this configuration: airline=20260730_071051 (48/50 tasks scored), retail=20260730_071051 (114/114), telecom=20260801_054815 (111/114). Simulations that terminated with infrastructure_error are excluded from metrics by tau2 (5 total across the three domains). NOTE: run locally with self-provisioned ElevenLabs voice personas, not Sierra's official voice IDs, so absolute numbers may not be directly comparable to official leaderboard entries.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": true,
+      "details": "Simulations terminating in infrastructure_error are excluded from scoring by tau2: airline 2/50, telecom 3/114, retail 0/114. All remaining tasks in each domain were evaluated; no tasks were filtered via --task-ids/--num-tasks."
+    }
+  },
+  "voice_config": {
+    "provider": "gemini",
+    "model": "gemini-3.5-flash-live-preview",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "interaction_metrics": {
+    "version": "1.0",
+    "config": {
+      "tick_duration_sec": 0.2,
+      "no_yield_window_sec": 2.0,
+      "backchannel_yield_window_sec": 1.0,
+      "vocal_tic_yield_window_sec": 1.0,
+      "non_directed_yield_window_sec": 1.0,
+      "vocal_tic_response_window_sec": 2.0,
+      "non_directed_response_window_sec": 2.0
+    },
+    "domains": {
+      "airline": {
+        "response_latency_mean": 1.4125326370757174,
+        "yield_latency_mean": 0.7789473684210526,
+        "response_rate": 0.9896640826873385,
+        "yield_rate": 0.532,
+        "agent_interruption_rate": 0.18087855297157623,
+        "selectivity_backchannel": 0.875,
+        "selectivity_vocal_tic": 0.38636363636363635,
+        "selectivity_non_directed": 0.25,
+        "counts": {
+          "n_simulations": 48,
+          "response_total": 387,
+          "yield_total": 250,
+          "backchannel_total": 16,
+          "vocal_tic_total": 44,
+          "non_directed_total": 28,
+          "agent_interrupts_count": 70
+        }
+      },
+      "retail": {
+        "response_latency_mean": 1.4600652883569087,
+        "yield_latency_mean": 0.7681250000000001,
+        "response_rate": 0.9881720430107527,
+        "yield_rate": 0.5507745266781411,
+        "agent_interruption_rate": 0.1827956989247312,
+        "selectivity_backchannel": 0.8235294117647058,
+        "selectivity_vocal_tic": 0.31818181818181823,
+        "selectivity_non_directed": 0.18840579710144922,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 930,
+          "yield_total": 581,
+          "backchannel_total": 34,
+          "vocal_tic_total": 88,
+          "non_directed_total": 69,
+          "agent_interrupts_count": 170
+        }
+      },
+      "telecom": {
+        "response_latency_mean": 1.441084010840108,
+        "yield_latency_mean": 0.8065185185185185,
+        "response_rate": 0.9767072525145579,
+        "yield_rate": 0.5121396054628224,
+        "agent_interruption_rate": 0.12387506617257808,
+        "selectivity_backchannel": 0.8,
+        "selectivity_vocal_tic": 0.46153846153846156,
+        "selectivity_non_directed": 0.15596330275229353,
+        "counts": {
+          "n_simulations": 111,
+          "response_total": 1889,
+          "yield_total": 1318,
+          "backchannel_total": 30,
+          "vocal_tic_total": 182,
+          "non_directed_total": 109,
+          "agent_interrupts_count": 234
+        }
+      }
+    },
+    "overall": {
+      "response_latency_mean": 1.437893978757578,
+      "yield_latency_mean": 0.7845302956465238,
+      "response_rate": 0.9848477927375496,
+      "yield_rate": 0.5316380440469879,
+      "agent_interruption_rate": 0.16251643935629517,
+      "selectivity_backchannel": 0.832843137254902,
+      "selectivity_vocal_tic": 0.38869463869463877,
+      "selectivity_non_directed": 0.19812303328458092,
+      "counts": {
+        "n_simulations": 273,
+        "response_total": 3206,
+        "yield_total": 2149,
+        "backchannel_total": 80,
+        "vocal_tic_total": 314,
+        "non_directed_total": 206,
+        "agent_interrupts_count": 474
+      }
+    }
+  },
+  "reasoning_effort": "low"
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -36,7 +36,9 @@
     "grok-voice-think-fast-1-0-tool-mentor_pickle_2026-07-07",
     "gpt-realtime-2-banking_openai_2026-07-12",
     "gemini-3-1-flash-live-preview-thinking-high-banking_google_2026-07-13",
-    "xai-realtime-banking_xai_2026-07-13"
+    "xai-realtime-banking_xai_2026-07-13",
+    "gemini-3-5-flash-live-preview-thinking-low_google_2026-08-03",
+    "gemini-3-5-flash-lite-live-preview-thinking-high_google_2026-08-03"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",


### PR DESCRIPTION
Audio-native full-duplex results for two Gemini 3.5 Live configurations, evaluated on retail/airline/telecom at regular speech complexity with the gpt-4.1-2025-04-14 user simulator (voice user sim v1.0).

- gemini-3.5-flash-live-preview, reasoning_effort=low
- gemini-3.5-flash-lite-live-preview

Both were prepared with `tau2 submit prepare` on 1.0.1 so they carry the interaction_metrics panel. Trajectories are hosted externally (will share once I obtain an external storage from Google). 