### PR TITLE
feat: expose qwen as --audio-native-provider CLI choice

### DIFF
--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -239,7 +239,7 @@ def add_run_args(parser):
     parser.add_argument(
         "--audio-native-provider",
         type=str,
-        choices=["openai", "gemini", "xai", "livekit"],
+        choices=["openai", "gemini", "xai", "qwen", "livekit"],
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
         help=f"Audio native API provider. Default is '{DEFAULT_AUDIO_NATIVE_PROVIDER}'.",
     )


### PR DESCRIPTION
## Summary
- Follow-up to #449: the qwen provider was fully wired up (config, adapter factory, registry) but not exposed in the CLI's `--audio-native-provider` choices, so `tau2 run --audio-native-provider qwen` failed with an argparse error.

## Test plan
- [x] E2E: `tau2 run --domain retail --audio-native --audio-native-provider qwen --num-tasks 2 --speech-complexity control --max-steps-seconds 300` completed both tasks cleanly (no disconnects/retries on the final run). Both conversations show multiple tool calls with results consumed by the agent (`find_user_id_by_name_zip`, `get_order_details`, `get_product_details`, `get_user_details`) and are viewable via `tau2 view` (run: `qwen_retail_e2e`).

## Notes from E2E
- Rewards were 0.0 on both tasks: the model is verbose and didn't complete the multi-step retail exchanges within the 300s budget — a model-capability observation, not an integration issue.
- An earlier run saw intermittent server-side WebSocket closes mid-response (~90–175s in, no close code, no error event) that exhausted retries; the rerun was fully clean. Looks like alpha-grade instability on the qwen3.5 realtime backend, worth watching in longer eval runs.

Made with [Cursor](https://cursor.com)