### PR TITLE
feat: generic parallel runner — controller + worker processes (tau2 run --workers N)

### DIFF
--- a/docs/designs/parallel-runner.md
+++ b/docs/designs/parallel-runner.md
@@ -1,0 +1,374 @@
+# Parallel runner: a shared task queue for tau-bench, tau-voice, and tau-multi
+
+Status: draft design (2026-08-04)
+
+**Scope**: standard tau (text), tau-voice, and tau-multi (the multilingual
+pool/preset drivers on `soham/tau-multilingual`). Hyper-tau is explicitly
+out of current scope — the seam covers it structurally (see Coverage), and
+it joins later once its own `tau2 run` integration lands. A separate
+follow-up item, after this ships and the tau-multi drivers are ported:
+**remove the tau-multi-specific orchestration** (`pool_driver.py`'s
+subprocess-per-cell launching, host-wide process-table budget, cell flock
+locks), keeping the pool *spec* and census/reporting logic, which become
+producer-side code.
+
+## Background: what exists today, and why it caps out
+
+A `tau2 run` process executes simulations on a `ThreadPoolExecutor` bounded by
+`--max-concurrency` (`src/tau2/runner/batch.py`). The bottleneck is not the
+providers — it is Python compute in the main process. `tau2 bench-concurrency`
+(private repo, `soham/tau-multilingual`, 2026-07-28) measured this directly:
+
+- 1 process at concurrency 30: 272.7 sims/hr, ~100 ms asyncio tick overrun,
+  and it could not even fill its own pool (21.6 of 30 slots busy).
+- 6 processes at concurrency 10 each: 626.1 sims/hr at ~16 ms overrun,
+  60 simulations genuinely in flight. Zero provider errors at any level.
+
+So the ceiling is **per process**, and useful parallelism above ~10 means
+**more processes**. The private repo's `tau2 pool` verb builds on that: a
+driver loop launches one `tau2 run --auto-resume` subprocess per (language ×
+arm) cell, each at concurrency 10, bounded by a host-wide budget of 8 cells,
+with per-cell `flock` locks so two drivers never put two writers on one
+results directory.
+
+That works, but the unit of parallelism is a *cell* (a whole run config), and
+the coordination is indirect: process-table scans, lock files, censusing
+results.json between rounds. It is specific to the multilingual pool layout,
+and the same need exists in plain tau-bench runs, tau-voice runs, and
+hyper-tau. This design generalizes it.
+
+## Goal
+
+One thin, generic mechanism in the **public repo** that:
+
+1. Separates **task production** from **task consumption**: a producer expands
+   a run (or a grid of runs) into work units; worker processes pull units and
+   execute them.
+2. Workers **ask** for work (pull, not push), so the controller can enforce
+   global policies at lease time — per-provider concurrency caps, host
+   budgets, fair interleaving across runs.
+3. Work-unit granularity lands in the **10 s – 10 min** range.
+4. Stays adaptable to **multiple machines** later: one controller / task
+   creator, workers elsewhere — without redesign.
+
+Non-goals: distributed consensus, external queue infrastructure (Redis,
+Celery, SQS), multi-controller setups. One controller, N workers, stdlib +
+existing deps only.
+
+## Core abstraction: the work unit
+
+**One work unit = one simulation attempt**: `(run_id, task_id, trial, seed)`
+plus a reference to the run's config. This is naturally in the target
+granularity band — text sims run seconds to a couple of minutes, voice sims
+minutes. Nothing in tau-bench, tau-voice, or hyper-tau needs a finer or
+coarser unit; hyper-tau runs are still per-simulation `tau2 run` executions
+over different task representations.
+
+Seeds are computed by the **producer**, never the worker, using the stable
+sha256-based `derive_task_seed()` (the salted-`hash()` bug was exactly a
+cross-process determinism failure, fixed 2026-07-20). A unit is fully
+determined by its fields; any worker executing it gets the same simulation.
+
+```python
+class WorkUnit(BaseModel):
+    unit_id: str            # f"{run_id}/{task_id}/t{trial}"
+    run_id: str             # keys into the controller's RunConfig registry
+    task_id: str
+    trial: int
+    seed: int
+    provider: str           # the resource this unit consumes (see limits)
+    attempt: int = 0
+```
+
+A `WorkUnit` is **in-memory only and never persisted**. It is not a second
+source of truth beside `SimulationRun` — it is derived state: the producer
+computes the queue as (task list × trials) minus `done_runs` from the
+checkpoint, exactly the diff `try_resume` computes today. `SimulationRun`
+cannot play this role itself: it is the *result* (heavyweight — full message
+transcript, audio refs) and does not exist until a sim finishes, while the
+queue needs a small descriptor for work that has not happened yet, plus
+scheduling fields (`attempt`, `provider`, lease state) that have no business
+in the results schema. Conversely, persisting WorkUnits would create
+placeholder records in the results tree — the same pathology as
+infrastructure-error files convincing `--auto-resume` a cell was complete.
+
+## Components
+
+```
+                 ┌──────────────────────────────────────────┐
+                 │ Controller (one process)                  │
+  RunConfig(s) ─▶│  Producer: run/pool/preset → WorkUnits    │
+                 │  Queue + lease table (in memory)          │
+                 │  Limits: per-provider caps, global cap    │
+                 │  Sink: checkpoint writer (results.json)   │
+                 └────────────▲──────────────┬───────────────┘
+                              │ lease/result │ spawn (local mode)
+                     ┌────────┴────────┐ ┌───┴─────────────┐
+                     │ Worker process 1 │ │ Worker process N │  each holds up to
+                     │  slots ≤ 10      │ │  slots ≤ 10      │  `--slots` sims in
+                     └─────────────────┘ └─────────────────┘  flight (threads)
+```
+
+### Controller
+
+- **Producer**: expands one or more `RunConfig`s into work units. `tau2 run`
+  produces units for one run; a pool/preset/matrix driver produces units for
+  many runs into the *same* queue. The queue is heterogeneous by design —
+  interleaving across providers falls out of the lease policy instead of
+  being orchestrated per-cell.
+- **Queue + leases**: in-memory FIFO per provider with a lease table. A lease
+  has a TTL derived from the run's ceiling (`timeout_seconds ×
+  VOICE_TIMEOUT_SAFETY_FACTOR` for voice); an expired lease requeues the unit
+  with `attempt += 1`, up to a retry cap.
+- **Admission control**: at lease time the controller checks (a) the global
+  in-flight cap (host budget analog), (b) the unit's per-provider cap
+  (`--provider-limit openai=40,gemini=20`). This is the answer to "workers
+  ask someone for a task": the *controller* decides which unit a worker gets,
+  so policy lives in one place.
+- **Single writer**: workers return the finished `SimulationRun`; the
+  controller writes checkpoints via the existing `create_checkpoint_fns`
+  machinery. One writer per results.json eliminates the entire class of
+  problems the pool driver's flock/pid-file/process-table logic exists to
+  contain. A result with `termination == infrastructure_error` is not
+  checkpointed — it is requeued (up to the retry cap), which turns the
+  pool's census→drop→resume repair loop into a one-line policy. "Not
+  checkpointed" means no entry in results.json / no `simulations/<id>.json`
+  record; the run directory and any per-attempt artifacts the worker wrote
+  (`artifacts/task_<id>/sim_<id>/`, logs, audio) stay on disk for
+  post-mortem, marked discarded via `sim_status.json` — the same convention
+  the hallucination-retry path uses today. This mirrors current behavior:
+  `try_resume` strips infra-error sims from the checkpoint but leaves their
+  artifact directories in place.
+
+### Workers
+
+A worker is `tau2 worker --controller <addr> --slots 10`. Its loop:
+
+1. Ask the controller for a lease (blocking long-poll, one request per free slot).
+2. Build and run the simulation — the existing Layer 1/2 code
+   (`build_orchestrator`, `run_simulation`) unchanged.
+3. POST the result; repeat.
+
+`--slots` defaults to the measured per-process sweet spot (10). Workers hold
+no state worth preserving: kill one and its leases expire back into the
+queue. Workers never touch results.json.
+
+### Transport
+
+The seam is a four-call protocol, defined once:
+
+```python
+class TaskSource(Protocol):
+    def lease(self, worker_id: str) -> Optional[LeasedUnit]: ...
+    def complete(self, unit_id: str, result: SimulationRun) -> None: ...
+    def fail(self, unit_id: str, error: str) -> None: ...
+    def heartbeat(self, unit_id: str) -> None: ...   # extends the lease
+```
+
+Two implementations:
+
+- **`LocalTaskSource`** — plain in-process object. `tau2 run` without
+  `--workers` keeps today's behavior exactly (the ThreadPool calls it
+  directly); zero new moving parts for the common case.
+- **`HttpTaskSource`** — the controller serves the same four calls over HTTP
+  (FastAPI is already a dependency via the domain servers); the worker-side
+  client is ~50 lines of `httpx`. In local multi-process mode the controller
+  binds `127.0.0.1:<random port>` and spawns its own workers as subprocesses
+  with the address in an env var. **Multi-machine later is only**: bind a
+  routable address, add a bearer token, and start `tau2 worker` on other
+  hosts pointed at it. No new protocol, no new code paths.
+
+Result payloads are JSON (`SimulationRun` already serializes). Voice audio
+artifacts are the one wrinkle: locally, workers share the filesystem and
+write audio under the run dir as today; cross-machine, the worker streams the
+artifact in the `complete` call (or writes to shared storage). This is
+explicitly deferred — the protocol carries an `artifacts` field from day one
+so it needs no version bump.
+
+## CLI surface
+
+```
+tau2 run ... --workers 6                     # 6 processes × --max-concurrency = in flight
+tau2 run ... --provider-limit openai=40      # cap at lease time
+tau2 worker --controller http://host:8321 --slots 10   # remote/extra workers
+```
+
+- Per-worker slots reuse the existing `--max-concurrency` knob (default 10)
+  rather than adding a second flag: `--workers 6 --max-concurrency 10` = 60
+  in flight, and the flag keeps its exact current meaning when
+  `--workers 0`. The standalone `tau2 worker` verb takes `--slots` since it
+  has no run config of its own.
+- `--workers 0` (default): today's in-process ThreadPool, unchanged.
+- `--workers N`: controller mode; the run's own process does no simulation
+  work, matching the finding that main-process compute is the bottleneck.
+- Pool / preset / hyper-tau drivers stop launching subprocess-per-cell and
+  instead register their runs with one controller and produce units. The
+  pool's *census* logic (usable vs infrastructure_error, dedup, coverage)
+  stays — it becomes the producer's "what units do I still owe" question at
+  startup and after each round, computed from checkpoints exactly as now.
+
+## Coverage: standard tau, tau-voice, hyper-tau
+
+Standard tau (text) and tau-voice are covered **by construction**: both
+execute through `run_tasks` in `runner/batch.py`, which is exactly where the
+`TaskSource` seam goes. The hyper-tau branch's `batch.py` is unchanged from
+main (its runner diff touches only `build.py` and `simulation.py`), so the
+seam lands identically there.
+
+Tau-multi is covered at both layers: its cells are ordinary `tau2 run`
+invocations (so the seam applies), and its drivers (`run-preset`, `tau2
+pool`) become producers in the driver-port step.
+
+Hyper-tau is **out of current scope** but structurally covered, with two
+paths for later:
+
+1. **`tau2 run --domain hyper_*`** — hyper-tau's own README declares wiring
+   hyper domains through `runner.batch.run_tasks` as its follow-up (the
+   registered factory is currently a placeholder; `tau2 hyper-tau` is the
+   working CLI). Once that wiring lands, a hyper episode flows through the
+   same seam with zero parallel-runner work: one outer episode = one
+   WorkUnit.
+2. **The current `tau2 hyper-tau` orchestration** (outer_orchestrator,
+   eval_transfer) runs its own ThreadPools and would be a driver port, same
+   shape as `run_multiple.py` and the pool driver.
+
+Two hyper-specific caveats, acknowledged for that later work rather than
+solved here:
+
+- **Granularity**: an outer episode (Developer iterating a policy, running
+  inner evals) can exceed the 10-minute band. The protocol already carries
+  `heartbeat`, so long units are safe — a hyper run just sets its lease TTL
+  from its own ceiling. Splitting inner evals into sub-units is a possible
+  later refinement, not needed for correctness.
+- **Weight**: one hyper unit fans out inner tau sims inside the worker
+  (`TAU2_HYPER_INNER_MAX_WORKERS`, default 32), so it consumes far more
+  provider quota and CPU than one text sim. Leases carry an optional
+  `weight` so a hyper unit can count as more than 1 against slots and
+  provider caps; until inner evals are sub-units, that weight is an
+  estimate.
+
+## Persistence and resume
+
+Persistence is the existing checkpoint mechanism, unchanged — the queue is
+never persisted because it is recomputable from the checkpoint.
+
+- **During a run**: the controller appends each finished sim through
+  `create_checkpoint_fns` exactly as `run_tasks` does today (monolithic
+  results.json rewrite, or per-sim file + index update in dir format).
+- **On kill + restart**: the producer calls `try_resume`, which loads the
+  checkpoint, verifies config/task compatibility, strips
+  `infrastructure_error` sims, and returns `done_runs` keyed
+  `(trial, task_id, seed)`. The producer emits WorkUnits only for cells not
+  in `done_runs`. `--auto-resume` keeps its meaning (skip the prompt).
+- **Grid runs resume per run, exactly as `run_multiple.py` does today**
+  (`src/experiments/tau_voice/run_multiple.py`): each (domain × provider ×
+  complexity) combo keeps its own results dir under the base dir, and
+  re-invoking the driver re-registers every combo — `try_resume` per combo
+  skips what is done. A killed grid resumes mid-grid with nothing special.
+- **In-flight sims at kill time are lost**, same as today: a sim that never
+  reached `save_fn` was never checkpointed, and its `(trial, task_id, seed)`
+  cell is simply re-emitted on restart. Worker death is the cheaper case and
+  does *not* lose the run: the lease TTL expires and the unit requeues while
+  the controller keeps running.
+
+### Multiple top-level runs
+
+Supported, with one rule: **one controller per results directory**. The
+preferred shape for "many runs at once" (a pool, a preset matrix, unrelated
+experiments) is many runs registered in **one** controller — that is the
+whole point of the heterogeneous queue, and it is what makes provider caps
+and the host budget actually global. Two independent `tau2 run` invocations
+with different `save_to` targets also work (each is its own controller), but
+their caps are per-controller: two controllers each capped at
+`openai=40` are 80 against the provider. So: fine to do, but split the
+budgets yourself, or point both producers at one controller. Two controllers
+on the *same* results dir is refused at registration by the same flock guard
+the pool driver uses today.
+
+## What stays the same
+
+- **Storage locations: unchanged, for both levels.** The run-level
+  results.json (monolithic or dir format with `simulations/<sim_id>.json` +
+  index) stays where it is under `DATA_DIR/simulations/<save_to>`, and
+  per-sim artifacts stay under `artifacts/task_<task_id>/sim_<sim_id>/`.
+  The only delta is *which process* calls the existing save functions (the
+  controller instead of each run process). Cross-machine workers later need
+  an artifact-upload step, but the on-disk layout they land in is the same.
+- `RunConfig` / `VoiceRunConfig` / checkpoint format: unchanged.
+  `--auto-resume` still works — resume is just the producer not emitting
+  units that already have usable results.
+- `run_simulation`, orchestrator build, retries-within-a-sim: unchanged.
+- Determinism: unchanged contract, now structurally enforced (seed computed
+  once, in the unit).
+
+## Failure model
+
+| Failure | Handling |
+|---|---|
+| Worker dies mid-sim | Lease TTL expires → unit requeues (`attempt += 1`) |
+| Sim ends `infrastructure_error` | Not checkpointed; requeued up to retry cap |
+| Unit exhausts retries | Checkpointed as failed; counted in exit code |
+| Controller dies | Workers' leases go nowhere; workers exit on connection loss. Restart resumes from checkpoints (producer re-owes unfinished units) |
+| Two controllers on one results dir | Same flock guard as today's pool lock, kept as a belt-and-braces check at run registration |
+
+## Test plan
+
+### Automated
+
+- `tests/test_runner/test_work_queue.py` — WorkQueue semantics, no I/O:
+  FIFO lease/complete, per-provider caps gate leasing, global cap, lease-TTL
+  expiry requeues with `attempt + 1`, attempt cap moves a unit to dead,
+  `fail()` requeue/dead, heartbeat extends a lease, all-resolved signal,
+  stale complete (after expiry-requeue) is ignored.
+- `tests/test_runner/test_controller.py` — controller HTTP contract via
+  in-process ASGI transport (no sockets, no subprocesses): lease returns
+  unit + serialized config + task; complete writes exactly one checkpoint
+  entry (controller is the single writer); an `infrastructure_error` result
+  is requeued, then written once attempts are exhausted; `/fail` requeues
+  then produces a placeholder infra sim when dead; duplicate/stale completes
+  are ignored. Worker-loop test drives `tau2.runner.worker` against the same
+  ASGI app with `run_unit` monkeypatched to return fabricated sims: all
+  units complete, worker exits on done, results land in the checkpoint.
+- `tests/test_runner/test_local_seam.py` — `run_tasks` with `workers=0` and
+  `run_single_task` monkeypatched: N tasks × trials all execute, checkpoint
+  written, a second invocation resumes and runs nothing. Guards the
+  zero-behavior-change claim without LLM calls.
+
+### Manual
+
+1. Baseline: `tau2 run --domain mock --agent llm_agent --user user_simulator
+   --num-tasks 2 --num-trials 2 --max-concurrency 2 --save-to <dir A>`
+   (workers=0, requires LLM keys).
+2. Same command with `--workers 2 --save-to <dir B>`: completes, per-task
+   rewards comparable, results.json structure identical, worker logs appear
+   under the run dir.
+3. Kill the `--workers` run mid-flight (Ctrl+C / SIGTERM); re-run with
+   `--auto-resume`: completed sims are skipped, the rest finish, no
+   duplicate `(task_id, trial)` pairs in results.json.
+4. `run_multiple.py --workers 2` smoke over a small grid (guarded by
+   available provider keys); verify per-combo results dirs match the
+   sequential layout.
+
+## Rollout
+
+1. **Extract the seam** — introduce `TaskSource` + `LocalTaskSource`, refactor
+   `run_tasks` to consume it. Pure refactor, no behavior change (public repo).
+2. **Controller + worker** — `HttpTaskSource`, `tau2 worker`, `--workers N`
+   spawn path, lease TTL/retry, per-provider limits. Validate against
+   `bench-concurrency` numbers: 6×10 should reproduce ~626 sims/hr.
+3. **Port the drivers** — `run_multiple.py` (public, tau-voice) and
+   pool/preset (private, tau-multilingual) become producers over the shared
+   controller. `run_multiple.py` is the simplest port and the proof of the
+   "multiple top-level runs" story: today it runs its grid combos
+   *sequentially*, one `tau2 run --auto-resume` subprocess at a time; as a
+   producer it registers all combos in one controller and the grid runs
+   concurrently under the global caps.
+4. **Remove the tau-multi-specific implementation** (separate item, after 3
+   has soaked) — delete `pool_driver.py`'s subprocess-per-cell launching,
+   the host-wide process-table budget (`live_cell_targets`), and the cell
+   flock/pid machinery; keep `pools.py` (the spec is the record of what ran)
+   and the census/dedup/coverage logic as producer-side code.
+5. **(Later, out of scope) hyper-tau** — rides the seam once its
+   `tau2 run --domain hyper_*` wiring lands; the `tau2 hyper-tau`
+   orchestration port is its own item.
+6. **(Later) multi-machine** — auth token, routable bind, artifact upload.

--- a/docs/designs/parallel-runner.md
+++ b/docs/designs/parallel-runner.md
@@ -117,9 +117,10 @@ infrastructure-error files convincing `--auto-resume` a cell was complete.
   interleaving across providers falls out of the lease policy instead of
   being orchestrated per-cell.
 - **Queue + leases**: in-memory FIFO per provider with a lease table. A lease
-  has a TTL derived from the run's ceiling (`timeout_seconds ×
-  VOICE_TIMEOUT_SAFETY_FACTOR` for voice); an expired lease requeues the unit
-  with `attempt += 1`, up to a retry cap.
+  has a fixed 300s TTL kept alive by worker heartbeats (every ~30s from a
+  dedicated thread — the worker's main loop can block for minutes posting
+  multi-MB voice results, so heartbeating from it starves under load); an
+  expired lease requeues the unit with `attempt += 1`, up to a retry cap.
 - **Admission control**: at lease time the controller checks (a) the global
   in-flight cap (host budget analog), (b) the unit's per-provider cap
   (`--provider-limit openai=40,gemini=20`). This is the answer to "workers

--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -13,6 +13,13 @@ Usage:
     python -m experiments.tau_voice.run_multiple --providers openai,gemini --save-to data/exp/my_run
     python -m experiments.tau_voice.run_multiple --providers openai:gpt-realtime-1.5:high --save-to data/exp/run --num-tasks 5
     python -m experiments.tau_voice.run_multiple --providers livekit,livekit::openai-thinking --save-to data/exp/run
+
+By default the grid runs sequentially, one `tau2 run` subprocess per combo.
+With --workers N the combos are registered as producers in one controller and
+run concurrently across N worker processes (see docs/designs/parallel-runner.md):
+
+    python -m experiments.tau_voice.run_multiple --providers openai,gemini \\
+        --save-to data/exp/run --workers 4 --provider-limit openai=20,gemini=20
 """
 
 import argparse
@@ -128,6 +135,46 @@ def build_command(
     return cmd
 
 
+def build_config(
+    domain: str,
+    spec: ProviderSpec,
+    complexity: str,
+    save_to: str,
+    *,
+    num_tasks: int | None = None,
+    seed: int = DEFAULT_SEED,
+    user_llm: str = DEFAULT_LLM_USER,
+    max_concurrency: int = 8,
+    max_steps_seconds: int | None = None,
+):
+    """The same run build_command() shells out for, as a VoiceRunConfig —
+    used by --workers mode to register combos with one controller."""
+    from tau2.data_model.simulation import AudioNativeConfig, VoiceRunConfig
+
+    audio_kwargs = dict(
+        provider=spec.provider,
+        model=spec.model,
+        cascaded_config_name=spec.cascaded_config,
+        reasoning_effort=spec.reasoning_effort,
+    )
+    if max_steps_seconds is not None:
+        audio_kwargs["max_steps_seconds"] = max_steps_seconds
+
+    return VoiceRunConfig(
+        domain=domain,
+        num_tasks=num_tasks,
+        llm_user=user_llm,
+        seed=seed,
+        max_concurrency=max_concurrency,
+        verbose_logs=True,
+        auto_review=True,
+        auto_resume=True,
+        save_to=save_to,
+        audio_native_config=AudioNativeConfig(**audio_kwargs),
+        speech_complexity=complexity,
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Run audio-native evals across providers and speech complexities."
@@ -166,6 +213,19 @@ def main():
         required=True,
         help="Base directory for results (e.g. data/exp/my_run)",
     )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=0,
+        help="Run all combos concurrently under one controller with N worker "
+        "processes (0 = sequential subprocess per combo, the default).",
+    )
+    parser.add_argument(
+        "--provider-limit",
+        type=str,
+        default=None,
+        help='Per-provider concurrency caps with --workers, e.g. "openai=20,gemini=20".',
+    )
     args = parser.parse_args()
 
     specs = [parse_provider(p.strip()) for p in args.providers.split(",")]
@@ -182,24 +242,51 @@ def main():
     ]
     total = len(combos)
 
+    combo_kwargs = dict(
+        num_tasks=args.num_tasks,
+        seed=args.seed,
+        user_llm=args.user_llm,
+        max_concurrency=args.max_concurrency,
+        max_steps_seconds=args.max_steps_seconds,
+    )
+
+    def combo_save_to(domain, spec, complexity) -> str:
+        run_name = f"{domain}_{complexity}_{spec.display_name}".replace(":", "_")
+        return str(base_dir / run_name)
+
+    if args.workers > 0:
+        from tau2.runner.batch import run_domains
+        from tau2.runner.work import parse_provider_limits
+
+        print(
+            f"Running {total} combinations concurrently -> {base_dir} "
+            f"({args.workers} workers x {args.max_concurrency} slots)\n"
+        )
+        configs = [
+            build_config(
+                domain,
+                spec,
+                complexity,
+                combo_save_to(domain, spec, complexity),
+                **combo_kwargs,
+            )
+            for domain, spec, complexity in combos
+        ]
+        run_domains(
+            configs,
+            workers=args.workers,
+            provider_limits=parse_provider_limits(args.provider_limit),
+        )
+        print(f"Done. Results in {base_dir}")
+        return
+
     print(f"Running {total} combinations -> {base_dir}\n")
 
     for i, (domain, spec, complexity) in enumerate(combos, 1):
-        run_name = f"{domain}_{complexity}_{spec.display_name}".replace(":", "_")
-        save_to = str(base_dir / run_name)
+        save_to = combo_save_to(domain, spec, complexity)
 
-        print(f"[{i}/{total}] {run_name}")
-        cmd = build_command(
-            domain,
-            spec,
-            complexity,
-            save_to,
-            num_tasks=args.num_tasks,
-            seed=args.seed,
-            user_llm=args.user_llm,
-            max_concurrency=args.max_concurrency,
-            max_steps_seconds=args.max_steps_seconds,
-        )
+        print(f"[{i}/{total}] {Path(save_to).name}")
+        cmd = build_command(domain, spec, complexity, save_to, **combo_kwargs)
         print(f"  $ {' '.join(cmd)}")
         result = subprocess.run(cmd)
         if result.returncode != 0:

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -41,6 +41,7 @@ from tau2.data_model.simulation import (
 )
 from tau2.domains.banking_knowledge.retrieval import get_all_variant_names
 from tau2.run import get_options, run_domain
+from tau2.runner.work import parse_provider_limits
 
 
 def get_all_retrieval_config_names():
@@ -154,7 +155,24 @@ def add_run_args(parser):
         "--max-concurrency",
         type=int,
         default=DEFAULT_MAX_CONCURRENCY,
-        help=f"The maximum number of concurrent simulations to run. Default is {DEFAULT_MAX_CONCURRENCY}.",
+        help=f"The maximum number of concurrent simulations to run. Default is {DEFAULT_MAX_CONCURRENCY}. "
+        "With --workers, this is the number of simulations each worker process holds.",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=0,
+        help="Number of worker processes to spawn. 0 (default) runs simulations in this "
+        "process. N > 0 makes this process a controller that schedules and checkpoints "
+        "while N worker processes execute (N x --max-concurrency simulations in flight); "
+        "use when scaling beyond the single-process concurrency ceiling.",
+    )
+    parser.add_argument(
+        "--provider-limit",
+        type=str,
+        default=None,
+        help='Per-provider concurrency caps in controller mode, e.g. "openai=40,gemini=20". '
+        "Requires --workers.",
     )
     parser.add_argument(
         "--seed",
@@ -647,6 +665,8 @@ def main():
             timeout=args.timeout,
             save_to=args.save_to,
             max_concurrency=args.max_concurrency,
+            workers=args.workers,
+            provider_limits=parse_provider_limits(args.provider_limit),
             seed=args.seed,
             log_level=args.log_level,
             verbose_logs=args.verbose_logs,
@@ -742,6 +762,40 @@ def main():
     # Start command
     start_parser = subparsers.add_parser("start", help="Start all servers")
     start_parser.set_defaults(func=lambda args: run_start_servers())
+
+    # Worker command (executes simulations for a `tau2 run --workers N` controller)
+    worker_parser = subparsers.add_parser(
+        "worker",
+        help="Run a worker process that executes simulations for a tau2 controller "
+        "(see `tau2 run --workers`).",
+    )
+    worker_parser.add_argument(
+        "--controller",
+        type=str,
+        required=True,
+        help="Controller base URL, e.g. http://127.0.0.1:8321",
+    )
+    worker_parser.add_argument(
+        "--slots",
+        type=int,
+        default=10,
+        help="Concurrent simulations this worker holds (default: 10).",
+    )
+    worker_parser.add_argument(
+        "--worker-id",
+        type=str,
+        default=None,
+        help="Worker identity in controller logs (default: hostname-pid).",
+    )
+
+    def worker_command(args):
+        from tau2.runner.worker import run_worker_command
+
+        return run_worker_command(
+            controller=args.controller, slots=args.slots, worker_id=args.worker_id
+        )
+
+    worker_parser.set_defaults(func=worker_command)
 
     # Intro command
     intro_parser = subparsers.add_parser(

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -361,6 +361,25 @@ class BaseRunConfig(BaseModel):
             default=DEFAULT_MAX_CONCURRENCY,
         ),
     ]
+    workers: Annotated[
+        int,
+        Field(
+            description="Number of worker processes to spawn. 0 (default) runs "
+            "simulations in this process; N > 0 makes this process a controller "
+            "that schedules and checkpoints while N workers execute, each "
+            "holding up to max_concurrency simulations in flight.",
+            default=0,
+        ),
+    ]
+    provider_limits: Annotated[
+        Optional[dict[str, int]],
+        Field(
+            description="Max concurrently-running simulations per provider, "
+            "enforced at lease time in controller mode (workers > 0), "
+            'e.g. {"openai": 40, "gemini": 20}.',
+            default=None,
+        ),
+    ]
     seed: Annotated[
         Optional[int],
         Field(

--- a/src/tau2/data_model/usage.py
+++ b/src/tau2/data_model/usage.py
@@ -148,7 +148,9 @@ class UsageRecord(BaseModel):
         Thought tokens are billed as (text) output tokens.
         """
 
-        def _modality(details: Optional[List[Dict[str, Any]]], name: str) -> Optional[int]:
+        def _modality(
+            details: Optional[List[Dict[str, Any]]], name: str
+        ) -> Optional[int]:
             if not details:
                 return None
             total = None

--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -18,14 +18,16 @@ import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextvars import ContextVar
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from loguru import logger
 
 from tau2.data_model.persona import InterruptTendency, PersonaConfig, Verbosity
 from tau2.data_model.simulation import (
     AudioNativeConfig,
+    Info,
     Results,
     RunConfig,
     SimulationRun,
@@ -48,6 +50,7 @@ from tau2.runner.checkpoint import (
 from tau2.runner.helpers import get_info, get_tasks, make_run_name
 from tau2.runner.progress import StatusMonitor, run_with_retry
 from tau2.runner.simulation import run_simulation
+from tau2.runner.work import WorkQueue, WorkUnit, make_unit_id
 from tau2.user.user_simulator import (
     get_global_user_sim_guidelines,
     get_global_user_sim_guidelines_voice,
@@ -455,11 +458,264 @@ def run_single_task(
 
 
 # =============================================================================
-# Batch runner
+# Batch preparation and per-unit execution
+# (shared by the local loop, the controller, and worker processes)
 # =============================================================================
 
 
-def run_tasks(
+@dataclass
+class _BatchContext:
+    """Everything run_unit() needs besides the unit itself.
+
+    The local loop builds one with checkpoint fns and a monitor; a worker
+    process builds one without them — the controller is the single
+    checkpoint writer, so workers only return results.
+    """
+
+    config: RunConfig
+    evaluation_type: EvaluationType
+    save_dir: Optional[Path]
+    user_voice_settings: Optional[VoiceSettings]
+    user_persona_config: Optional[PersonaConfig]
+    info: Info
+    console_display: bool = True
+    save_fn: Optional[Callable] = None
+    replace_fn: Optional[Callable] = None
+    monitor: Optional[StatusMonitor] = None
+    shutdown_event: Optional[threading.Event] = None
+    llm_log_mode_value: Optional[str] = None
+
+
+def make_voice_run_settings(
+    config: RunConfig,
+) -> tuple[Optional[VoiceSettings], Optional[PersonaConfig]]:
+    """Run-level voice settings and persona config, derived deterministically
+    from the config (so a worker process re-derives the same values)."""
+    if not isinstance(config, VoiceRunConfig):
+        return None, None
+    user_voice_settings = VoiceSettings(
+        transcription_config=None,
+        synthesis_config=SynthesisConfig(),
+    )
+    complexity_config = COMPLEXITY_CONFIGS[config.speech_complexity]
+    user_persona_config = PersonaConfig(
+        verbosity=Verbosity(complexity_config["verbosity"]),
+        interrupt_tendency=InterruptTendency(complexity_config["interrupt_tendency"]),
+    )
+    return user_voice_settings, user_persona_config
+
+
+def unit_provider(config: RunConfig) -> Optional[str]:
+    """The resource a unit consumes, for per-provider lease caps.
+
+    Voice runs report the audio-native provider; text runs fall back to the
+    litellm prefix of the agent model when one is present.
+    """
+    provider = config.effective_agent_provider
+    if provider:
+        return provider
+    llm = getattr(config, "llm_agent", None)
+    if llm and "/" in llm:
+        return llm.split("/", 1)[0]
+    return None
+
+
+def run_unit(
+    ctx: _BatchContext, task: Task, trial: int, seed: int, progress_str: str = ""
+) -> SimulationRun:
+    """Execute one work unit: a single task/trial with retry and hallucination
+    retry. This is the code a worker process runs; the local loop runs it too."""
+    config = ctx.config
+    is_voice = isinstance(config, VoiceRunConfig)
+    hallucination_retries = config.hallucination_retries
+    save_dir = ctx.save_dir
+    monitor = ctx.monitor
+
+    if ctx.shutdown_event is not None and ctx.shutdown_event.is_set():
+        raise KeyboardInterrupt("Shutdown requested")
+
+    _init_thread_event_loop()
+    if ctx.llm_log_mode_value is not None:
+        set_llm_log_mode(ctx.llm_log_mode_value)
+    task_key = f"{task.id}.{trial}"
+    if monitor:
+        monitor.task_started(task_key, trial)
+
+    console_text = Text(
+        text=f"{progress_str}. Running task {task.id}, trial {trial + 1}"
+        if progress_str
+        else f"Running task {task.id}, trial {trial + 1}",
+        style="bold green",
+    )
+    ConsoleDisplay.console.print(console_text)
+
+    def _execute(
+        run_seed: int = seed,
+        hallucination_feedback: Optional[str] = None,
+    ):
+        return run_single_task(
+            config,
+            task,
+            seed=run_seed,
+            evaluation_type=ctx.evaluation_type,
+            save_dir=save_dir,
+            user_voice_settings=ctx.user_voice_settings,
+            user_persona_config=ctx.user_persona_config,
+            verbose_logs=config.verbose_logs,
+            audio_debug=config.audio_debug if is_voice else False,
+            audio_taps=config.audio_taps if is_voice else False,
+            auto_review=config.auto_review,
+            review_mode=config.review_mode,
+            review_model=config.review_model,
+            hallucination_feedback=hallucination_feedback,
+        )
+
+    try:
+        result = run_with_retry(
+            _execute,
+            task=task,
+            trial=trial,
+            seed=seed,
+            max_retries=config.max_retries,
+            retry_delay=config.retry_delay,
+            console_display=ctx.console_display,
+            save_fn=ctx.save_fn,
+            on_retry=(lambda: monitor.task_restarted(task_key)) if monitor else None,
+            shutdown_event=ctx.shutdown_event,
+        )
+
+        # Hallucination retry: if check detects fabricated info, re-run
+        is_full_duplex = result.ticks is not None and len(result.ticks) > 0
+        if hallucination_retries > 0 and is_full_duplex:
+            hallucination_retry_count = 0
+            while hallucination_retry_count < hallucination_retries:
+                h_check = check_hallucination(result, task)
+                result.hallucination_check = h_check
+
+                if not h_check.hallucination_found:
+                    break
+
+                hallucination_retry_count += 1
+                n_errors = len(h_check.errors)
+
+                retry_text = Text(
+                    text=f"  Hallucination detected on task {task.id} ({n_errors} instance(s)). "
+                    f"Re-running with feedback ({hallucination_retry_count}/{hallucination_retries})...",
+                    style="yellow",
+                )
+                ConsoleDisplay.console.print(retry_text)
+
+                # Save discarded run
+                if save_dir is not None:
+                    discarded_dir = save_dir / "hallucination_discarded"
+                    discarded_dir.mkdir(parents=True, exist_ok=True)
+                    discarded_path = discarded_dir / "results_user_hallucination.json"
+
+                    if discarded_path.exists():
+                        with open(discarded_path, "r") as fp:
+                            discarded_data = json.load(fp)
+                        discarded_data["simulations"].append(
+                            result.model_dump(mode="json")
+                        )
+                        existing_task_ids = {t["id"] for t in discarded_data["tasks"]}
+                        if task.id not in existing_task_ids:
+                            discarded_data["tasks"].append(task.model_dump(mode="json"))
+                        with open(discarded_path, "w") as fp:
+                            json.dump(discarded_data, fp, indent=2)
+                    else:
+                        discarded_results = Results(
+                            info=ctx.info,
+                            tasks=[task],
+                            simulations=[result],
+                        )
+                        with open(discarded_path, "w") as fp:
+                            fp.write(discarded_results.model_dump_json(indent=2))
+
+                    logger.info(
+                        f"Saved discarded hallucination run to {discarded_path} "
+                        f"(task {task.id}, retry {hallucination_retry_count})"
+                    )
+
+                # Mark the discarded sim directory
+                if save_dir is not None:
+                    sim_dir = (
+                        save_dir / "artifacts" / f"task_{task.id}" / f"sim_{result.id}"
+                    )
+                    if sim_dir.exists():
+                        try:
+                            status = {
+                                "status": "discarded",
+                                "reason": "user_hallucination",
+                                "hallucination_errors": n_errors,
+                            }
+                            status_path = sim_dir / "sim_status.json"
+                            with open(status_path, "w") as f:
+                                json.dump(status, f, indent=2)
+                        except Exception:
+                            pass
+
+                # Build feedback and re-run
+                if monitor:
+                    monitor.task_restarted(task_key)
+                feedback = format_hallucination_feedback(h_check)
+                retry_seed = seed + hallucination_retry_count * 1000
+                result = _execute(
+                    run_seed=retry_seed,
+                    hallucination_feedback=feedback,
+                )
+                result.trial = trial
+
+            result.hallucination_retries_used = hallucination_retry_count
+
+            if hallucination_retry_count > 0:
+                # Replace the eagerly-saved hallucinated result in the
+                # checkpoint with the clean retry.  Use the original seed
+                # so resume matching stays consistent.
+                result.seed = seed
+                if ctx.replace_fn:
+                    ctx.replace_fn((trial, task.id, seed), result)
+
+        # Mark the final sim as the one used in results
+        if save_dir is not None:
+            sim_dir = save_dir / "artifacts" / f"task_{task.id}" / f"sim_{result.id}"
+            if sim_dir.exists():
+                try:
+                    status = {"status": "used"}
+                    status_path = sim_dir / "sim_status.json"
+                    with open(status_path, "w") as f:
+                        json.dump(status, f, indent=2)
+                except Exception:
+                    pass
+
+        return result
+    finally:
+        if monitor:
+            monitor.task_finished(task_key)
+        _cleanup_thread_event_loop()
+
+
+@dataclass
+class BatchPrep:
+    """A run made ready to execute: resumed results, checkpoint fns, and the
+    work units still owed. The queue is derived state — recomputable from the
+    checkpoint — so nothing here is persisted."""
+
+    config: RunConfig
+    tasks: list[Task]
+    simulation_results: Results
+    done_runs: set
+    units: list[WorkUnit]
+    save_fn: Optional[Callable]
+    replace_fn: Optional[Callable]
+    user_voice_settings: Optional[VoiceSettings]
+    user_persona_config: Optional[PersonaConfig]
+    save_dir: Optional[Path]
+    evaluation_type: EvaluationType
+    console_display: bool
+    run_id: str
+
+
+def prepare_batch(
     config: RunConfig,
     tasks: list[Task],
     *,
@@ -468,38 +724,15 @@ def run_tasks(
     evaluation_type: EvaluationType = EvaluationType.ALL,
     console_display: bool = True,
     results_format: str = "json",
-) -> Results:
-    """Run simulations for a list of tasks with concurrency, checkpointing, and retries.
+    run_id: Optional[str] = None,
+) -> BatchPrep:
+    """Validate a run, resume its checkpoint, and compute the units still owed.
 
-    This is the main batch execution function. It handles:
-    - Seed management and trial repetition
-    - Voice/persona config setup for audio-native mode
-    - Checkpoint save/resume
-    - Concurrent execution via thread pool
-    - Progress monitoring
-    - Retry on failure
-
-    Args:
-        config: Full run configuration (includes domain, agent, user, LLM settings,
-            num_trials, max_concurrency, retry settings, etc.).
-        tasks: The tasks to run.
-        save_path: Path to the results JSON file. If None, results are not persisted.
-        save_dir: Directory for saving logs, audio, etc. If None, derived from save_path.
-        evaluation_type: Evaluation type to use for all simulations.
-        console_display: Whether to show console output for each simulation.
-
-    Returns:
-        Results object with all simulation runs.
-
-    Raises:
-        ValueError: If no tasks are provided, or trial/step/error counts are invalid.
+    Shared by run_tasks (local execution) and the controller (which registers
+    the prep and hands its units to worker processes).
     """
     if isinstance(save_path, str):
         save_path = Path(save_path)
-
-    # Set log level from config
-    logger.remove()
-    logger.add(lambda msg: print(msg), level=config.log_level)
 
     if len(tasks) == 0:
         raise ValueError("No tasks to run")
@@ -510,8 +743,6 @@ def run_tasks(
         raise ValueError("Max steps must be greater than 0")
     if config.max_errors <= 0:
         raise ValueError("Max errors must be greater than 0")
-
-    is_voice = isinstance(config, VoiceRunConfig)
 
     # Seed management
     random.seed(config.seed)
@@ -528,20 +759,7 @@ def run_tasks(
     lock = multiprocessing.Lock()
 
     # Create run-level voice settings and persona config for voice mode
-    user_voice_settings = None
-    user_persona_config = None
-    if is_voice:
-        user_voice_settings = VoiceSettings(
-            transcription_config=None,
-            synthesis_config=SynthesisConfig(),
-        )
-        complexity_config = COMPLEXITY_CONFIGS[config.speech_complexity]
-        user_persona_config = PersonaConfig(
-            verbosity=Verbosity(complexity_config["verbosity"]),
-            interrupt_tendency=InterruptTendency(
-                complexity_config["interrupt_tendency"]
-            ),
-        )
+    user_voice_settings, user_persona_config = make_voice_run_settings(config)
 
     # Warm knowledge base cache for banking_knowledge domain
     policy_override = None
@@ -596,8 +814,11 @@ def run_tasks(
     # Create checkpoint saver and replacer (shared state for dir format)
     save_fn, replace_fn = create_checkpoint_fns(save_path, lock)
 
-    # Build argument list (skip already-completed runs)
-    args = []
+    # Build unit list (skip already-completed runs)
+    if run_id is None:
+        run_id = config.save_to or "run"
+    provider = unit_provider(config)
+    units: list[WorkUnit] = []
     for trial in range(config.num_trials):
         for i, task in enumerate(tasks):
             if (trial, task.id, seeds[trial]) in done_runs:
@@ -608,17 +829,39 @@ def run_tasks(
                 ConsoleDisplay.console.print(console_text)
                 continue
             progress_str = f"{i}/{len(tasks)} (trial {trial + 1}/{config.num_trials})"
-            args.append((task, trial, seeds[trial], progress_str))
+            units.append(
+                WorkUnit(
+                    unit_id=make_unit_id(run_id, task.id, trial),
+                    run_id=run_id,
+                    task_id=task.id,
+                    trial=trial,
+                    seed=seeds[trial],
+                    provider=provider,
+                    progress_str=progress_str,
+                )
+            )
 
-    # Status monitor
-    total_count = len(tasks) * config.num_trials
-    monitor = StatusMonitor(total_count, initial_completed=len(done_runs))
-    monitor.set_results(simulation_results)
-    monitor.start()
+    return BatchPrep(
+        config=config,
+        tasks=tasks,
+        simulation_results=simulation_results,
+        done_runs=done_runs,
+        units=units,
+        save_fn=save_fn,
+        replace_fn=replace_fn,
+        user_voice_settings=user_voice_settings,
+        user_persona_config=user_persona_config,
+        save_dir=save_dir,
+        evaluation_type=evaluation_type,
+        console_display=console_display,
+        run_id=run_id,
+    )
 
-    # Pre-register LiveKit plugins on main thread before workers spawn
+
+def preregister_voice_plugins(config: RunConfig) -> None:
+    """Pre-register LiveKit plugins on the main thread before sim threads spawn."""
     if (
-        is_voice
+        isinstance(config, VoiceRunConfig)
         and config.audio_native_config is not None
         and config.audio_native_config.provider == "livekit"
     ):
@@ -626,194 +869,154 @@ def run_tasks(
 
         preregister_livekit_plugins()
 
-    hallucination_retries = config.hallucination_retries
-    shutdown_event = threading.Event()
 
-    # Capture ContextVar values from the main thread so worker threads
-    # (which get a fresh default context) can re-apply them.
-    _main_thread_llm_log_mode = llm_log_mode.get()
+# =============================================================================
+# Batch runner
+# =============================================================================
 
-    def _run_tracked(
-        task: Task, trial: int, seed: int, progress_str: str
-    ) -> SimulationRun:
-        """Run a single task with tracking, retry, and hallucination retry."""
-        if shutdown_event.is_set():
-            raise KeyboardInterrupt("Shutdown requested")
 
-        _init_thread_event_loop()
-        set_llm_log_mode(_main_thread_llm_log_mode)
-        task_key = f"{task.id}.{trial}"
-        monitor.task_started(task_key, trial)
+def run_tasks(
+    config: RunConfig,
+    tasks: list[Task],
+    *,
+    save_path: Optional[Path] = None,
+    save_dir: Optional[Path] = None,
+    evaluation_type: EvaluationType = EvaluationType.ALL,
+    console_display: bool = True,
+    results_format: str = "json",
+) -> Results:
+    """Run simulations for a list of tasks with concurrency, checkpointing, and retries.
 
-        console_text = Text(
-            text=f"{progress_str}. Running task {task.id}, trial {trial + 1}",
-            style="bold green",
-        )
-        ConsoleDisplay.console.print(console_text)
+    This is the main batch execution function. It handles:
+    - Seed management and trial repetition
+    - Voice/persona config setup for audio-native mode
+    - Checkpoint save/resume
+    - Concurrent execution via thread pool
+    - Progress monitoring
+    - Retry on failure
 
-        def _execute(
-            run_seed: int = seed,
-            hallucination_feedback: Optional[str] = None,
-        ):
-            return run_single_task(
-                config,
-                task,
-                seed=run_seed,
-                evaluation_type=evaluation_type,
-                save_dir=save_dir,
-                user_voice_settings=user_voice_settings,
-                user_persona_config=user_persona_config,
-                verbose_logs=config.verbose_logs,
-                audio_debug=config.audio_debug if is_voice else False,
-                audio_taps=config.audio_taps if is_voice else False,
-                auto_review=config.auto_review,
-                review_mode=config.review_mode,
-                review_model=config.review_model,
-                hallucination_feedback=hallucination_feedback,
-            )
+    Args:
+        config: Full run configuration (includes domain, agent, user, LLM settings,
+            num_trials, max_concurrency, retry settings, etc.).
+        tasks: The tasks to run.
+        save_path: Path to the results JSON file. If None, results are not persisted.
+        save_dir: Directory for saving logs, audio, etc. If None, derived from save_path.
+        evaluation_type: Evaluation type to use for all simulations.
+        console_display: Whether to show console output for each simulation.
+
+    Returns:
+        Results object with all simulation runs.
+
+    Raises:
+        ValueError: If no tasks are provided, or trial/step/error counts are invalid.
+    """
+    if isinstance(save_path, str):
+        save_path = Path(save_path)
+
+    # Set log level from config
+    logger.remove()
+    logger.add(lambda msg: print(msg), level=config.log_level)
+
+    prep = prepare_batch(
+        config,
+        tasks,
+        save_path=save_path,
+        save_dir=save_dir,
+        evaluation_type=evaluation_type,
+        console_display=console_display,
+        results_format=results_format,
+    )
+    tasks = prep.tasks
+    simulation_results = prep.simulation_results
+
+    # Status monitor
+    total_count = len(tasks) * config.num_trials
+    monitor = StatusMonitor(total_count, initial_completed=len(prep.done_runs))
+    monitor.set_results(simulation_results)
+    monitor.start()
+
+    # Controller mode: this process schedules and checkpoints; worker
+    # processes execute. See tau2.runner.controller.
+    workers = getattr(config, "workers", 0) or 0
+    if workers > 0:
+        from tau2.runner.controller import drive_batches
 
         try:
-            result = run_with_retry(
-                _execute,
-                task=task,
-                trial=trial,
-                seed=seed,
-                max_retries=config.max_retries,
-                retry_delay=config.retry_delay,
-                console_display=console_display,
-                save_fn=save_fn,
-                on_retry=lambda: monitor.task_restarted(task_key),
-                shutdown_event=shutdown_event,
+            drive_batches(
+                [prep],
+                workers=workers,
+                slots=config.max_concurrency,
+                provider_limits=getattr(config, "provider_limits", None),
+                monitor=monitor,
             )
-
-            # Hallucination retry: if check detects fabricated info, re-run
-            is_full_duplex = result.ticks is not None and len(result.ticks) > 0
-            if hallucination_retries > 0 and is_full_duplex:
-                hallucination_retry_count = 0
-                while hallucination_retry_count < hallucination_retries:
-                    h_check = check_hallucination(result, task)
-                    result.hallucination_check = h_check
-
-                    if not h_check.hallucination_found:
-                        break
-
-                    hallucination_retry_count += 1
-                    n_errors = len(h_check.errors)
-
-                    retry_text = Text(
-                        text=f"  Hallucination detected on task {task.id} ({n_errors} instance(s)). "
-                        f"Re-running with feedback ({hallucination_retry_count}/{hallucination_retries})...",
-                        style="yellow",
-                    )
-                    ConsoleDisplay.console.print(retry_text)
-
-                    # Save discarded run
-                    if save_dir is not None:
-                        discarded_dir = save_dir / "hallucination_discarded"
-                        discarded_dir.mkdir(parents=True, exist_ok=True)
-                        discarded_path = (
-                            discarded_dir / "results_user_hallucination.json"
-                        )
-
-                        if discarded_path.exists():
-                            with open(discarded_path, "r") as fp:
-                                discarded_data = json.load(fp)
-                            discarded_data["simulations"].append(
-                                result.model_dump(mode="json")
-                            )
-                            existing_task_ids = {
-                                t["id"] for t in discarded_data["tasks"]
-                            }
-                            if task.id not in existing_task_ids:
-                                discarded_data["tasks"].append(
-                                    task.model_dump(mode="json")
-                                )
-                            with open(discarded_path, "w") as fp:
-                                json.dump(discarded_data, fp, indent=2)
-                        else:
-                            discarded_results = Results(
-                                info=simulation_results.info,
-                                tasks=[
-                                    t
-                                    for t in simulation_results.tasks
-                                    if t.id == task.id
-                                ],
-                                simulations=[result],
-                            )
-                            with open(discarded_path, "w") as fp:
-                                fp.write(discarded_results.model_dump_json(indent=2))
-
-                        logger.info(
-                            f"Saved discarded hallucination run to {discarded_path} "
-                            f"(task {task.id}, retry {hallucination_retry_count})"
-                        )
-
-                    # Mark the discarded sim directory
-                    if save_dir is not None:
-                        sim_dir = (
-                            save_dir
-                            / "artifacts"
-                            / f"task_{task.id}"
-                            / f"sim_{result.id}"
-                        )
-                        if sim_dir.exists():
-                            try:
-                                status = {
-                                    "status": "discarded",
-                                    "reason": "user_hallucination",
-                                    "hallucination_errors": n_errors,
-                                }
-                                status_path = sim_dir / "sim_status.json"
-                                with open(status_path, "w") as f:
-                                    json.dump(status, f, indent=2)
-                            except Exception:
-                                pass
-
-                    # Build feedback and re-run
-                    monitor.task_restarted(task_key)
-                    feedback = format_hallucination_feedback(h_check)
-                    retry_seed = seed + hallucination_retry_count * 1000
-                    result = _execute(
-                        run_seed=retry_seed,
-                        hallucination_feedback=feedback,
-                    )
-                    result.trial = trial
-
-                result.hallucination_retries_used = hallucination_retry_count
-
-                if hallucination_retry_count > 0:
-                    # Replace the eagerly-saved hallucinated result in the
-                    # checkpoint with the clean retry.  Use the original seed
-                    # so resume matching stays consistent.
-                    result.seed = seed
-                    replace_fn((trial, task.id, seed), result)
-
-            # Mark the final sim as the one used in results
-            if save_dir is not None:
-                sim_dir = (
-                    save_dir / "artifacts" / f"task_{task.id}" / f"sim_{result.id}"
-                )
-                if sim_dir.exists():
-                    try:
-                        status = {"status": "used"}
-                        status_path = sim_dir / "sim_status.json"
-                        with open(status_path, "w") as f:
-                            json.dump(status, f, indent=2)
-                    except Exception:
-                        pass
-
-            return result
         finally:
-            monitor.task_finished(task_key)
-            _cleanup_thread_event_loop()
+            monitor.stop()
+        ConsoleDisplay.console.print(
+            "\n[bold green]Successfully completed all simulations![/bold green]\n"
+            "To review the simulations, run: [bold blue]tau2 view[/bold blue]"
+        )
+        return simulation_results
+
+    # Pre-register LiveKit plugins on main thread before sim threads spawn
+    preregister_voice_plugins(config)
+
+    shutdown_event = threading.Event()
+
+    ctx = _BatchContext(
+        config=config,
+        evaluation_type=evaluation_type,
+        save_dir=save_dir,
+        user_voice_settings=prep.user_voice_settings,
+        user_persona_config=prep.user_persona_config,
+        info=simulation_results.info,
+        console_display=console_display,
+        save_fn=prep.save_fn,
+        replace_fn=prep.replace_fn,
+        monitor=monitor,
+        shutdown_event=shutdown_event,
+        # Capture ContextVar values from the main thread so worker threads
+        # (which get a fresh default context) can re-apply them.
+        llm_log_mode_value=llm_log_mode.get(),
+    )
+
+    # Local execution: max_concurrency consumer threads pull from the queue.
+    # The queue is the TaskSource seam — the controller serves the same queue
+    # to worker processes. Locally each unit runs exactly once (max_attempts=1:
+    # retries happen inside run_unit via run_with_retry) and leases never
+    # expire (no heartbeats; a sim legitimately runs for a long time).
+    tasks_by_id = {task.id: task for task in tasks}
+    queue = WorkQueue(prep.units, max_attempts=1, lease_ttl_seconds=float("inf"))
+    results_lock = threading.Lock()
+
+    def _consume(consumer_idx: int) -> None:
+        worker_id = f"local-{consumer_idx}"
+        while not shutdown_event.is_set():
+            unit = queue.lease(worker_id)
+            if unit is None:
+                return
+            try:
+                result = run_unit(
+                    ctx,
+                    tasks_by_id[unit.task_id],
+                    unit.trial,
+                    unit.seed,
+                    unit.progress_str,
+                )
+            except BaseException as e:
+                queue.fail(unit.unit_id, str(e), worker_id=worker_id)
+                raise
+            queue.complete(unit.unit_id, worker_id=worker_id)
+            with results_lock:
+                simulation_results.simulations.append(result)
 
     executor = ThreadPoolExecutor(max_workers=config.max_concurrency)
     futures: dict = {}
     try:
-        futures = {executor.submit(_run_tracked, *arg): arg for arg in args}
+        futures = {
+            executor.submit(_consume, i): i for i in range(config.max_concurrency)
+        }
         for future in as_completed(futures):
-            result = future.result()
-            simulation_results.simulations.append(result)
+            future.result()
     except KeyboardInterrupt:
         ConsoleDisplay.console.print(
             "\n[bold red]Ctrl+C received — cancelling remaining tasks...[/bold red]"
@@ -849,6 +1052,43 @@ def run_tasks(
 # =============================================================================
 
 
+def _load_run_tasks(config: RunConfig) -> list[Task]:
+    """Load a config's tasks and apply the agent's registered task filter."""
+    task_set_name = config.task_set_name or config.domain
+    tasks = get_tasks(
+        task_set_name=task_set_name,
+        task_split_name=config.task_split_name,
+        task_ids=config.task_ids,
+        num_tasks=config.num_tasks,
+    )
+
+    effective_agent = config.effective_agent
+    task_filter = registry.get_agent_task_filter(effective_agent)
+    if task_filter is not None:
+        total_num_tasks = len(tasks)
+        tasks = [task for task in tasks if task_filter(task)]
+        num_tasks = len(tasks)
+        console_text = Text(
+            text=f"Running {num_tasks} out of {total_num_tasks} tasks for {effective_agent} (filtered).",
+            style="bold green",
+        )
+        ConsoleDisplay.console.print(console_text)
+    return tasks
+
+
+def _run_save_paths(config: RunConfig) -> tuple[str, Path, Path, str]:
+    """(run_name, save_dir, save_path, results_format) for a config.
+
+    Voice runs use directory format (individual sim files) because voice
+    simulations with tick data are very large; text runs use monolithic JSON.
+    """
+    run_name = config.save_to or make_run_name(config)
+    save_dir = DATA_DIR / "simulations" / run_name
+    save_path = save_dir / "results.json"
+    results_format = "dir" if isinstance(config, VoiceRunConfig) else "json"
+    return run_name, save_dir, save_path, results_format
+
+
 def run_domain(config: RunConfig) -> Results:
     """Run simulations for a domain from a RunConfig.
 
@@ -871,37 +1111,8 @@ def run_domain(config: RunConfig) -> Results:
     if isinstance(config, VoiceRunConfig):
         warn_if_non_official_voices()
 
-    # Load tasks
-    task_set_name = config.task_set_name or config.domain
-    tasks = get_tasks(
-        task_set_name=task_set_name,
-        task_split_name=config.task_split_name,
-        task_ids=config.task_ids,
-        num_tasks=config.num_tasks,
-    )
-
-    # Filter tasks based on agent's registered task filter (if any)
-    effective_agent = config.effective_agent
-    task_filter = registry.get_agent_task_filter(effective_agent)
-    if task_filter is not None:
-        total_num_tasks = len(tasks)
-        tasks = [task for task in tasks if task_filter(task)]
-        num_tasks = len(tasks)
-        console_text = Text(
-            text=f"Running {num_tasks} out of {total_num_tasks} tasks for {effective_agent} (filtered).",
-            style="bold green",
-        )
-        ConsoleDisplay.console.print(console_text)
-
-    # Determine save paths
-    run_name = config.save_to or make_run_name(config)
-    save_dir = DATA_DIR / "simulations" / run_name
-    save_path = save_dir / "results.json"
-
-    # Voice runs use directory format (individual sim files) because voice
-    # simulations with tick data are very large; text runs use monolithic JSON.
-    is_voice = isinstance(config, VoiceRunConfig)
-    results_format = "dir" if is_voice else "json"
+    tasks = _load_run_tasks(config)
+    _, save_dir, save_path, results_format = _run_save_paths(config)
 
     # Run batch
     simulation_results = run_tasks(
@@ -917,3 +1128,75 @@ def run_domain(config: RunConfig) -> Results:
     ConsoleDisplay.display_agent_metrics(metrics)
 
     return simulation_results
+
+
+def run_domains(
+    configs: list[RunConfig],
+    *,
+    workers: int,
+    provider_limits: Optional[dict[str, int]] = None,
+    global_limit: Optional[int] = None,
+) -> dict[str, Results]:
+    """Run several configs concurrently under one controller.
+
+    This is the producer API for grid drivers (e.g. run_multiple.py): every
+    config keeps its own results dir and resume semantics, while the
+    controller interleaves their units across one worker fleet under shared
+    provider caps. Returns {run_name: Results}.
+    """
+    from tau2.runner.controller import drive_batches
+
+    if workers <= 0:
+        raise ValueError("run_domains requires workers >= 1")
+    if not configs:
+        raise ValueError("No configs to run")
+
+    logger.remove()
+    logger.add(lambda msg: print(msg), level=configs[0].log_level)
+
+    preps: list[BatchPrep] = []
+    for config in configs:
+        config.validate()
+        ConsoleDisplay.display_run_config(config)
+        if isinstance(config, VoiceRunConfig):
+            warn_if_non_official_voices()
+        tasks = _load_run_tasks(config)
+        run_name, save_dir, save_path, results_format = _run_save_paths(config)
+        preps.append(
+            prepare_batch(
+                config,
+                tasks,
+                save_path=save_path,
+                save_dir=save_dir,
+                results_format=results_format,
+                run_id=run_name,
+            )
+        )
+
+    total_count = sum(len(p.tasks) * p.config.num_trials for p in preps)
+    done_count = sum(len(p.done_runs) for p in preps)
+    monitor = StatusMonitor(total_count, initial_completed=done_count)
+    monitor.start()
+
+    slots = max(config.max_concurrency for config in configs)
+    try:
+        drive_batches(
+            preps,
+            workers=workers,
+            slots=slots,
+            provider_limits=provider_limits,
+            global_limit=global_limit,
+            monitor=monitor,
+        )
+    finally:
+        monitor.stop()
+
+    results_by_run: dict[str, Results] = {}
+    for prep in preps:
+        ConsoleDisplay.console.print(
+            Text(text=f"\n=== {prep.run_id} ===", style="bold green")
+        )
+        metrics = compute_metrics(prep.simulation_results)
+        ConsoleDisplay.display_agent_metrics(metrics)
+        results_by_run[prep.run_id] = prep.simulation_results
+    return results_by_run

--- a/src/tau2/runner/controller.py
+++ b/src/tau2/runner/controller.py
@@ -1,0 +1,463 @@
+"""Parallel-run controller: schedules work units and writes all checkpoints.
+
+The controller owns the queue and the results files; worker processes
+(``tau2 worker`` / ``python -m tau2.runner.worker``) lease units over HTTP,
+execute them, and post results back. One controller can drive many runs at
+once — that is what makes per-provider caps and the global in-flight cap
+actually global. See docs/designs/parallel-runner.md.
+
+Locally, ``tau2 run --workers N`` binds 127.0.0.1 on an ephemeral port and
+spawns its own workers. Remote workers are the same binary pointed at a
+routable address, authenticated with TAU2_CONTROLLER_TOKEN.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Callable, Optional
+
+from fastapi import FastAPI, HTTPException, Request
+from loguru import logger
+
+from tau2.data_model.simulation import (
+    Results,
+    RunConfig,
+    SimulationRun,
+    TerminationReason,
+    VoiceRunConfig,
+)
+from tau2.data_model.tasks import Task
+from tau2.evaluator.evaluator import EvaluationType
+from tau2.runner.batch import BatchPrep
+from tau2.runner.progress import StatusMonitor
+from tau2.runner.work import (
+    DEFAULT_LEASE_TTL_SECONDS,
+    DEFAULT_UNIT_ATTEMPTS,
+    FailOutcome,
+    WorkQueue,
+    WorkUnit,
+)
+from tau2.utils.display import ConsoleDisplay, Text
+from tau2.utils.utils import DATA_DIR, get_now
+
+AUTH_TOKEN_ENV = "TAU2_CONTROLLER_TOKEN"
+
+# How long drive_batches waits for workers to notice "done" and exit on their
+# own before terminating them.
+WORKER_EXIT_GRACE_SECONDS = 30.0
+
+
+def make_infra_failure_sim(
+    task_id: str, trial: int, seed: int, error: str
+) -> SimulationRun:
+    """Placeholder result for a unit that died in the queue (worker crashes,
+    expired leases) — same shape run_with_retry produces on exhausted retries,
+    so resume repairs it the usual way."""
+    now = get_now()
+    return SimulationRun(
+        id=str(uuid.uuid4()),
+        task_id=task_id,
+        timestamp=now,
+        start_time=now,
+        end_time=now,
+        duration=0.0,
+        termination_reason=TerminationReason.INFRASTRUCTURE_ERROR,
+        messages=[],
+        trial=trial,
+        seed=seed,
+        info={"error": error, "error_type": "WorkerFailure"},
+    )
+
+
+class ControllerRun:
+    """One registered run: its config, tasks, results, and checkpoint writer."""
+
+    def __init__(
+        self,
+        run_id: str,
+        config: RunConfig,
+        tasks: list[Task],
+        simulation_results: Results,
+        units: list[WorkUnit],
+        save_fn: Optional[Callable],
+        save_dir: Optional[Path],
+        evaluation_type: EvaluationType,
+    ):
+        self.run_id = run_id
+        self.config = config
+        self.tasks_by_id = {task.id: task for task in tasks}
+        self.simulation_results = simulation_results
+        # Re-key units onto this run_id so a prep prepared under a default id
+        # can be registered under a controller-unique one.
+        self.units = [
+            u.model_copy(update={"run_id": run_id, "unit_id": _rekey(u, run_id)})
+            for u in units
+        ]
+        self.save_fn = save_fn
+        self.save_dir = save_dir
+        self.evaluation_type = evaluation_type
+
+    @classmethod
+    def from_prep(cls, run_id: str, prep: BatchPrep) -> "ControllerRun":
+        return cls(
+            run_id=run_id,
+            config=prep.config,
+            tasks=prep.tasks,
+            simulation_results=prep.simulation_results,
+            units=prep.units,
+            save_fn=prep.save_fn,
+            save_dir=prep.save_dir,
+            evaluation_type=prep.evaluation_type,
+        )
+
+    def lease_payload(self, unit: WorkUnit) -> dict:
+        """Everything a worker needs to execute the unit: the run config, the
+        task, and where artifacts go. Workers share the filesystem locally;
+        cross-machine artifact upload is a later addition."""
+        return {
+            "config_kind": "voice"
+            if isinstance(self.config, VoiceRunConfig)
+            else "text",
+            "config": self.config.model_dump(mode="json"),
+            "task": self.tasks_by_id[unit.task_id].model_dump(mode="json"),
+            "evaluation_type": self.evaluation_type.value,
+            "save_dir": str(self.save_dir) if self.save_dir else None,
+        }
+
+
+def _rekey(unit: WorkUnit, run_id: str) -> str:
+    from tau2.runner.work import make_unit_id
+
+    return make_unit_id(run_id, unit.task_id, unit.trial)
+
+
+class Controller:
+    """Queue + policy + single checkpoint writer, exposed as a FastAPI app."""
+
+    def __init__(
+        self,
+        runs: list[ControllerRun],
+        *,
+        provider_limits: Optional[dict[str, int]] = None,
+        global_limit: Optional[int] = None,
+        max_attempts: int = DEFAULT_UNIT_ATTEMPTS,
+        lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS,
+        monitor: Optional[StatusMonitor] = None,
+    ):
+        if len({run.run_id for run in runs}) != len(runs):
+            raise ValueError("Controller runs must have unique run_ids")
+        self.runs = {run.run_id: run for run in runs}
+        self.queue = WorkQueue(
+            [unit for run in runs for unit in run.units],
+            max_attempts=max_attempts,
+            lease_ttl_seconds=lease_ttl_seconds,
+            provider_limits=provider_limits,
+            global_limit=global_limit,
+        )
+        self.lease_ttl_seconds = lease_ttl_seconds
+        self.monitor = monitor
+        self._written: set[str] = set()
+        self._write_lock = threading.Lock()
+        self._units_by_id = {unit.unit_id: unit for run in runs for unit in run.units}
+        self._run_by_unit_id = {unit.unit_id: run for run in runs for unit in run.units}
+
+    # ---- Core handlers (transport-independent) ----
+
+    def handle_lease(self, worker_id: str) -> dict:
+        unit = self.queue.lease(worker_id)
+        if unit is None:
+            if self.queue.all_resolved():
+                return {"status": "done"}
+            return {"status": "wait"}
+        run = self.runs[unit.run_id]
+        if self.monitor:
+            self.monitor.task_started(f"{unit.task_id}.{unit.trial}", unit.trial)
+        return {
+            "status": "unit",
+            "unit": unit.model_dump(mode="json"),
+            "run": run.lease_payload(unit),
+            "lease_ttl_seconds": self.lease_ttl_seconds,
+        }
+
+    def handle_complete(self, worker_id: str, unit_id: str, result: dict) -> dict:
+        sim = SimulationRun.model_validate(result)
+        run = self._run_for_unit(unit_id)
+        if run is None:
+            return {"status": "stale"}
+        unit = self._unit_from_id(unit_id)
+
+        if sim.termination_reason == TerminationReason.INFRASTRUCTURE_ERROR:
+            # Don't checkpoint a result that can't enter an analysis frame —
+            # requeue the unit instead. Only the final attempt is written, so
+            # the run completes with an honest record of the failure.
+            outcome = self.queue.fail(
+                unit_id, "infrastructure_error result", worker_id=worker_id
+            )
+            if outcome == FailOutcome.REQUEUED:
+                if self.monitor:
+                    self.monitor.task_restarted(f"{unit.task_id}.{unit.trial}")
+                return {"status": "requeued"}
+            if outcome == FailOutcome.STALE:
+                return {"status": "stale"}
+            self._write(run, unit_id, sim)
+            return {"status": "ok"}
+
+        if not self.queue.complete(unit_id, worker_id=worker_id):
+            return {"status": "stale"}
+        self._write(run, unit_id, sim)
+        return {"status": "ok"}
+
+    def handle_fail(self, worker_id: str, unit_id: str, error: str) -> dict:
+        outcome = self.queue.fail(unit_id, error, worker_id=worker_id)
+        if outcome == FailOutcome.REQUEUED and self.monitor:
+            unit = self._unit_from_id(unit_id)
+            if unit:
+                self.monitor.task_restarted(f"{unit.task_id}.{unit.trial}")
+        return {"status": outcome.value}
+
+    def handle_heartbeat(self, worker_id: str, unit_ids: list[str]) -> dict:
+        return {
+            "leases": {
+                unit_id: self.queue.heartbeat(unit_id, worker_id=worker_id)
+                for unit_id in unit_ids
+            }
+        }
+
+    def flush_dead_units(self) -> int:
+        """Write placeholder infra sims for units that died in the queue
+        (worker crashes, expired leases) and were never checkpointed."""
+        flushed = 0
+        for unit, error in list(self.queue.dead_units):
+            run = self.runs.get(unit.run_id)
+            if run is None or unit.unit_id in self._written:
+                continue
+            sim = make_infra_failure_sim(unit.task_id, unit.trial, unit.seed, error)
+            self._write(run, unit.unit_id, sim)
+            flushed += 1
+        return flushed
+
+    def _write(self, run: ControllerRun, unit_id: str, sim: SimulationRun) -> None:
+        with self._write_lock:
+            if unit_id in self._written:
+                return
+            self._written.add(unit_id)
+            if run.save_fn:
+                run.save_fn(sim)
+            run.simulation_results.simulations.append(sim)
+        if self.monitor:
+            self.monitor.task_finished(f"{sim.task_id}.{sim.trial}")
+
+    def _run_for_unit(self, unit_id: str) -> Optional[ControllerRun]:
+        return self._run_by_unit_id.get(unit_id)
+
+    def _unit_from_id(self, unit_id: str) -> Optional[WorkUnit]:
+        return self._units_by_id.get(unit_id)
+
+    # ---- HTTP layer ----
+
+    def build_app(self) -> FastAPI:
+        app = FastAPI(title="tau2 controller")
+        expected_token = os.environ.get(AUTH_TOKEN_ENV)
+
+        def check_auth(request: Request) -> None:
+            if not expected_token:
+                return
+            header = request.headers.get("authorization", "")
+            if header != f"Bearer {expected_token}":
+                raise HTTPException(status_code=401, detail="bad or missing token")
+
+        @app.post("/lease")
+        async def lease(request: Request):
+            check_auth(request)
+            body = await request.json()
+            return self.handle_lease(body["worker_id"])
+
+        @app.post("/complete")
+        async def complete(request: Request):
+            check_auth(request)
+            body = await request.json()
+            return self.handle_complete(
+                body["worker_id"], body["unit_id"], body["result"]
+            )
+
+        @app.post("/fail")
+        async def fail(request: Request):
+            check_auth(request)
+            body = await request.json()
+            return self.handle_fail(
+                body["worker_id"], body["unit_id"], body.get("error", "")
+            )
+
+        @app.post("/heartbeat")
+        async def heartbeat(request: Request):
+            check_auth(request)
+            body = await request.json()
+            return self.handle_heartbeat(body["worker_id"], body["unit_ids"])
+
+        @app.get("/status")
+        async def status(request: Request):
+            check_auth(request)
+            return {
+                "counts": self.queue.counts(),
+                "done": self.queue.all_resolved(),
+            }
+
+        return app
+
+
+# =============================================================================
+# Driving a controller with locally-spawned workers
+# =============================================================================
+
+
+def _free_port(host: str) -> int:
+    sock = socket.socket()
+    sock.bind((host, 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _start_server(app, host: str, port: int):
+    import uvicorn
+
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 15
+    while not server.started:
+        if time.monotonic() > deadline:
+            raise RuntimeError("Controller HTTP server failed to start")
+        time.sleep(0.05)
+    return server
+
+
+def _spawn_worker(
+    controller_url: str, slots: int, index: int, log_dir: Path
+) -> subprocess.Popen:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"worker_{index}.log"
+    log_file = open(log_path, "w")
+    cmd = [
+        sys.executable,
+        "-m",
+        "tau2.runner.worker",
+        "--controller",
+        controller_url,
+        "--slots",
+        str(slots),
+        "--worker-id",
+        f"local-{index}",
+    ]
+    logger.info(f"Spawning worker {index}: {' '.join(cmd)} (log: {log_path})")
+    return subprocess.Popen(
+        cmd, stdout=log_file, stderr=subprocess.STDOUT, env=os.environ.copy()
+    )
+
+
+def drive_batches(
+    preps: list[BatchPrep],
+    *,
+    workers: int,
+    slots: int,
+    provider_limits: Optional[dict[str, int]] = None,
+    global_limit: Optional[int] = None,
+    monitor: Optional[StatusMonitor] = None,
+    worker_log_dir: Optional[Path] = None,
+    host: str = "127.0.0.1",
+) -> Controller:
+    """Drive prepared runs to completion with locally-spawned worker processes.
+
+    Fills each prep's ``simulation_results`` in place (results are also
+    checkpointed as they arrive, exactly as in local mode).
+    """
+    if workers <= 0:
+        raise ValueError("drive_batches needs workers >= 1")
+
+    runs = [ControllerRun.from_prep(prep.run_id, prep) for prep in preps]
+    controller = Controller(
+        runs,
+        provider_limits=provider_limits,
+        global_limit=global_limit,
+        monitor=monitor,
+    )
+
+    total_units = sum(len(run.units) for run in runs)
+    if total_units == 0:
+        return controller
+
+    port = _free_port(host)
+    server = _start_server(controller.build_app(), host, port)
+    controller_url = f"http://{host}:{port}"
+
+    if worker_log_dir is None:
+        first_save_dir = next(
+            (run.save_dir for run in runs if run.save_dir is not None), None
+        )
+        worker_log_dir = (
+            first_save_dir / "workers"
+            if first_save_dir
+            else DATA_DIR / "simulations" / "workers"
+        )
+
+    procs = [
+        _spawn_worker(controller_url, slots, i, worker_log_dir) for i in range(workers)
+    ]
+    ConsoleDisplay.console.print(
+        Text(
+            text=f"Controller on {controller_url}: {total_units} unit(s), "
+            f"{workers} worker(s) x {slots} slot(s). Worker logs: {worker_log_dir}",
+            style="bold green",
+        )
+    )
+
+    try:
+        while not controller.queue.all_resolved():
+            if all(proc.poll() is not None for proc in procs):
+                # Every worker exited while work remains: reap what their
+                # leases owe, then surface the failure with the logs to read.
+                controller.flush_dead_units()
+                if not controller.queue.all_resolved():
+                    raise RuntimeError(
+                        f"All {workers} workers exited with work remaining "
+                        f"({controller.queue.counts()}). "
+                        f"See logs in {worker_log_dir}"
+                    )
+                break
+            time.sleep(2.0)
+
+        # Workers exit on their own once the queue reports done.
+        deadline = time.monotonic() + WORKER_EXIT_GRACE_SECONDS
+        while any(proc.poll() is None for proc in procs):
+            if time.monotonic() > deadline:
+                for proc in procs:
+                    if proc.poll() is None:
+                        proc.terminate()
+                break
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        ConsoleDisplay.console.print(
+            "\n[bold red]Ctrl+C received — stopping workers...[/bold red]"
+        )
+        for proc in procs:
+            if proc.poll() is None:
+                proc.terminate()
+        n = sum(len(run.simulation_results.simulations) for run in runs)
+        ConsoleDisplay.console.print(
+            f"[bold yellow]{n} simulation(s) already checkpointed. "
+            f"Use --auto-resume to continue later.[/bold yellow]"
+        )
+        os._exit(130)
+    finally:
+        controller.flush_dead_units()
+        server.should_exit = True
+
+    return controller

--- a/src/tau2/runner/controller.py
+++ b/src/tau2/runner/controller.py
@@ -176,6 +176,14 @@ class Controller:
 
     # ---- Core handlers (transport-independent) ----
 
+    def _monitor_key(self, unit: WorkUnit) -> str:
+        # task_id.trial collides across runs (every run has a task 0), which
+        # made 8 in-flight sims display as 6 — so multi-run controllers scope
+        # the key by run. Single runs keep the familiar short form.
+        if len(self.runs) > 1:
+            return f"{unit.run_id}/{unit.task_id}.{unit.trial}"
+        return f"{unit.task_id}.{unit.trial}"
+
     def handle_lease(self, worker_id: str) -> dict:
         unit = self.queue.lease(worker_id)
         if unit is None:
@@ -184,7 +192,7 @@ class Controller:
             return {"status": "wait"}
         run = self.runs[unit.run_id]
         if self.monitor:
-            self.monitor.task_started(f"{unit.task_id}.{unit.trial}", unit.trial)
+            self.monitor.task_started(self._monitor_key(unit), unit.trial)
         return {
             "status": "unit",
             "unit": unit.model_dump(mode="json"),
@@ -208,7 +216,7 @@ class Controller:
             )
             if outcome == FailOutcome.REQUEUED:
                 if self.monitor:
-                    self.monitor.task_restarted(f"{unit.task_id}.{unit.trial}")
+                    self.monitor.task_restarted(self._monitor_key(unit))
                 return {"status": "requeued"}
             if outcome == FailOutcome.STALE:
                 return {"status": "stale"}
@@ -225,7 +233,7 @@ class Controller:
         if outcome == FailOutcome.REQUEUED and self.monitor:
             unit = self._unit_from_id(unit_id)
             if unit:
-                self.monitor.task_restarted(f"{unit.task_id}.{unit.trial}")
+                self.monitor.task_restarted(self._monitor_key(unit))
         return {"status": outcome.value}
 
     def handle_heartbeat(self, worker_id: str, unit_ids: list[str]) -> dict:
@@ -258,7 +266,9 @@ class Controller:
                 run.save_fn(sim)
             run.simulation_results.simulations.append(sim)
         if self.monitor:
-            self.monitor.task_finished(f"{sim.task_id}.{sim.trial}")
+            unit = self._unit_from_id(unit_id)
+            key = self._monitor_key(unit) if unit else f"{sim.task_id}.{sim.trial}"
+            self.monitor.task_finished(key)
 
     def _run_for_unit(self, unit_id: str) -> Optional[ControllerRun]:
         return self._run_by_unit_id.get(unit_id)

--- a/src/tau2/runner/controller.py
+++ b/src/tau2/runner/controller.py
@@ -45,6 +45,7 @@ from tau2.runner.work import (
     WorkUnit,
 )
 from tau2.utils.display import ConsoleDisplay, Text
+from tau2.utils.llm_utils import llm_log_mode
 from tau2.utils.utils import DATA_DIR, get_now
 
 AUTH_TOKEN_ENV = "TAU2_CONTROLLER_TOKEN"
@@ -103,6 +104,10 @@ class ControllerRun:
         self.save_fn = save_fn
         self.save_dir = save_dir
         self.evaluation_type = evaluation_type
+        # Captured at registration time (main thread): uvicorn handler threads
+        # get a fresh ContextVar context, and workers are separate processes,
+        # so the CLI's --llm-log-mode has to travel in the lease payload.
+        self.llm_log_mode = llm_log_mode.get()
 
     @classmethod
     def from_prep(cls, run_id: str, prep: BatchPrep) -> "ControllerRun":
@@ -129,6 +134,7 @@ class ControllerRun:
             "task": self.tasks_by_id[unit.task_id].model_dump(mode="json"),
             "evaluation_type": self.evaluation_type.value,
             "save_dir": str(self.save_dir) if self.save_dir else None,
+            "llm_log_mode": self.llm_log_mode,
         }
 
 

--- a/src/tau2/runner/work.py
+++ b/src/tau2/runner/work.py
@@ -1,0 +1,235 @@
+"""Work units and the in-memory lease queue for parallel batch execution.
+
+A **work unit** is one simulation attempt: ``(run_id, task_id, trial, seed)``.
+Units are in-memory only and never persisted — the checkpoint (results.json)
+is the single source of truth, and the queue is recomputed from it on resume.
+See docs/designs/parallel-runner.md.
+
+The queue is transport-agnostic: the local batch loop consumes it directly,
+and the HTTP controller serves it to worker processes. Policy lives at lease
+time — per-provider caps, a global in-flight cap — which is what lets one
+controller interleave many runs.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from enum import Enum
+from typing import Callable, Optional, Protocol
+
+from pydantic import BaseModel
+
+# One requeue after a failed attempt. Sim-level retries already happen inside
+# the attempt (run_with_retry); this cap bounds whole-unit retries after a
+# worker death or an infrastructure_error result.
+DEFAULT_UNIT_ATTEMPTS = 2
+
+# Leases are kept alive by heartbeats (workers beat every ~30s), so the TTL
+# only needs to outlive a heartbeat gap, not a simulation.
+DEFAULT_LEASE_TTL_SECONDS = 180.0
+
+
+def make_unit_id(run_id: str, task_id: str, trial: int) -> str:
+    return f"{run_id}/{task_id}/t{trial}"
+
+
+def parse_provider_limits(spec: Optional[str]) -> Optional[dict[str, int]]:
+    """Parse a CLI cap spec like "openai=40,gemini=20"."""
+    if not spec:
+        return None
+    limits: dict[str, int] = {}
+    for part in spec.split(","):
+        name, sep, value = part.partition("=")
+        name = name.strip()
+        if not sep or not name or not value.strip().isdigit():
+            raise ValueError(
+                f"Invalid provider limit {part!r}; expected e.g. 'openai=40,gemini=20'"
+            )
+        limits[name] = int(value)
+    return limits
+
+
+class WorkUnit(BaseModel):
+    """One simulation attempt. Fully determines the simulation: any worker
+    executing it produces the same run (seeds are computed by the producer)."""
+
+    unit_id: str
+    run_id: str
+    task_id: str
+    trial: int
+    seed: int
+    provider: Optional[str] = None
+    attempt: int = 0
+    progress_str: str = ""
+
+
+class FailOutcome(str, Enum):
+    REQUEUED = "requeued"
+    DEAD = "dead"
+    STALE = "stale"
+
+
+class TaskSource(Protocol):
+    """What a consumer needs from a queue of work units.
+
+    ``WorkQueue`` implements it in-process; ``ControllerClient`` implements it
+    over HTTP for worker processes.
+    """
+
+    def lease(self, worker_id: str) -> Optional[WorkUnit]: ...
+
+    def complete(self, unit_id: str, worker_id: Optional[str] = None) -> bool: ...
+
+    def fail(
+        self, unit_id: str, error: str = "", worker_id: Optional[str] = None
+    ) -> FailOutcome: ...
+
+    def heartbeat(self, unit_id: str, worker_id: Optional[str] = None) -> bool: ...
+
+
+class _Lease:
+    __slots__ = ("unit", "worker_id", "expires_at")
+
+    def __init__(self, unit: WorkUnit, worker_id: str, expires_at: float):
+        self.unit = unit
+        self.worker_id = worker_id
+        self.expires_at = expires_at
+
+
+class WorkQueue:
+    """Thread-safe in-memory queue with leases, TTL expiry, and lease-time caps.
+
+    Every mutation happens under one lock; expired leases are reaped lazily on
+    each public call, so no background thread is needed. ``clock`` is
+    injectable for tests (monotonic seconds).
+    """
+
+    def __init__(
+        self,
+        units: list[WorkUnit],
+        *,
+        max_attempts: int = DEFAULT_UNIT_ATTEMPTS,
+        lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS,
+        provider_limits: Optional[dict[str, int]] = None,
+        global_limit: Optional[int] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be >= 1")
+        self._pending: deque[WorkUnit] = deque(units)
+        self._leases: dict[str, _Lease] = {}
+        self._completed: set[str] = set()
+        self.dead_units: list[tuple[WorkUnit, str]] = []
+        self._max_attempts = max_attempts
+        self._lease_ttl_seconds = lease_ttl_seconds
+        self._provider_limits = provider_limits or {}
+        self._global_limit = global_limit
+        self._clock = clock
+        self._lock = threading.Lock()
+
+    # ---- Internal helpers (call with lock held) ----
+
+    def _reap_expired(self) -> None:
+        now = self._clock()
+        for unit_id in [
+            uid for uid, lease in self._leases.items() if lease.expires_at <= now
+        ]:
+            lease = self._leases.pop(unit_id)
+            self._retire_or_requeue(lease.unit, "lease expired")
+
+    def _retire_or_requeue(self, unit: WorkUnit, error: str) -> FailOutcome:
+        if unit.attempt + 1 >= self._max_attempts:
+            self.dead_units.append((unit, error))
+            return FailOutcome.DEAD
+        retry = unit.model_copy(update={"attempt": unit.attempt + 1})
+        self._pending.append(retry)
+        return FailOutcome.REQUEUED
+
+    def _provider_inflight(self, provider: Optional[str]) -> int:
+        return sum(
+            1 for lease in self._leases.values() if lease.unit.provider == provider
+        )
+
+    def _leasable_index(self) -> Optional[int]:
+        if self._global_limit is not None and len(self._leases) >= self._global_limit:
+            return None
+        for i, unit in enumerate(self._pending):
+            limit = self._provider_limits.get(unit.provider)
+            if limit is None or self._provider_inflight(unit.provider) < limit:
+                return i
+        return None
+
+    def _lease_matches(self, unit_id: str, worker_id: Optional[str]) -> bool:
+        lease = self._leases.get(unit_id)
+        if lease is None:
+            return False
+        if worker_id is not None and lease.worker_id != worker_id:
+            return False
+        return True
+
+    # ---- TaskSource interface ----
+
+    def lease(self, worker_id: str) -> Optional[WorkUnit]:
+        """The first pending unit whose provider has capacity; None if nothing
+        is leasable right now (distinct from done — see all_resolved())."""
+        with self._lock:
+            self._reap_expired()
+            index = self._leasable_index()
+            if index is None:
+                return None
+            self._pending.rotate(-index)
+            unit = self._pending.popleft()
+            self._pending.rotate(index)
+            self._leases[unit.unit_id] = _Lease(
+                unit, worker_id, self._clock() + self._lease_ttl_seconds
+            )
+            return unit
+
+    def complete(self, unit_id: str, worker_id: Optional[str] = None) -> bool:
+        """Resolve a leased unit. False means stale: the lease expired (and the
+        unit was requeued to another worker) or was already resolved."""
+        with self._lock:
+            self._reap_expired()
+            if not self._lease_matches(unit_id, worker_id):
+                return False
+            del self._leases[unit_id]
+            self._completed.add(unit_id)
+            return True
+
+    def fail(
+        self, unit_id: str, error: str = "", worker_id: Optional[str] = None
+    ) -> FailOutcome:
+        with self._lock:
+            self._reap_expired()
+            if not self._lease_matches(unit_id, worker_id):
+                return FailOutcome.STALE
+            lease = self._leases.pop(unit_id)
+            return self._retire_or_requeue(lease.unit, error)
+
+    def heartbeat(self, unit_id: str, worker_id: Optional[str] = None) -> bool:
+        with self._lock:
+            self._reap_expired()
+            if not self._lease_matches(unit_id, worker_id):
+                return False
+            self._leases[unit_id].expires_at = self._clock() + self._lease_ttl_seconds
+            return True
+
+    # ---- Introspection ----
+
+    def all_resolved(self) -> bool:
+        """Every unit either completed or dead — nothing pending, nothing leased."""
+        with self._lock:
+            self._reap_expired()
+            return not self._pending and not self._leases
+
+    def counts(self) -> dict[str, int]:
+        with self._lock:
+            self._reap_expired()
+            return {
+                "pending": len(self._pending),
+                "leased": len(self._leases),
+                "completed": len(self._completed),
+                "dead": len(self.dead_units),
+            }

--- a/src/tau2/runner/work.py
+++ b/src/tau2/runner/work.py
@@ -26,9 +26,12 @@ from pydantic import BaseModel
 # worker death or an infrastructure_error result.
 DEFAULT_UNIT_ATTEMPTS = 2
 
-# Leases are kept alive by heartbeats (workers beat every ~30s), so the TTL
-# only needs to outlive a heartbeat gap, not a simulation.
-DEFAULT_LEASE_TTL_SECONDS = 180.0
+# Leases are kept alive by heartbeats (a dedicated worker thread beats every
+# ~30s), so the TTL only needs to outlive a heartbeat gap, not a simulation.
+# 300s = 10 missed beats: on a loaded host running many voice sims, a few
+# slow beats must not expire a live lease — the first field run showed a
+# requeued-while-alive sim costs a full duplicate execution.
+DEFAULT_LEASE_TTL_SECONDS = 300.0
 
 
 def make_unit_id(run_id: str, task_id: str, trial: int) -> str:

--- a/src/tau2/runner/worker.py
+++ b/src/tau2/runner/worker.py
@@ -145,6 +145,12 @@ class HeartbeatThread(threading.Thread):
                     "and this attempt's result will be discarded as stale"
                 )
 
+    def leased(self, unit_id: str) -> None:
+        """A fresh lease supersedes a lost one. Unit ids omit the attempt
+        number, so a requeued unit re-leased by this same worker would
+        otherwise stay muted forever and expire mid-sim again."""
+        self.lost.discard(unit_id)
+
     def stop(self) -> None:
         self._stop_event.set()
 
@@ -249,6 +255,7 @@ def worker_loop(
                 body = client.lease(worker_id)
                 if body["status"] == "unit":
                     _maybe_preregister_livekit(body["run"], preregistered)
+                    heartbeats.leased(body["unit"]["unit_id"])
                     future = executor.submit(execute_lease, body)
                     with inflight_lock:
                         inflight[future] = body["unit"]["unit_id"]

--- a/src/tau2/runner/worker.py
+++ b/src/tau2/runner/worker.py
@@ -1,0 +1,223 @@
+"""tau2 worker process: leases simulation units from a controller, runs them,
+and posts results back. It never touches results.json — the controller is the
+single checkpoint writer. Kill a worker and its leases expire back into the
+queue; nothing is lost.
+
+Run as ``tau2 worker --controller http://host:port --slots 10`` or
+``python -m tau2.runner.worker ...``. See docs/designs/parallel-runner.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import socket
+import sys
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from pathlib import Path
+from typing import Optional
+
+import httpx
+from loguru import logger
+
+from tau2.data_model.simulation import SimulationRun, TextRunConfig, VoiceRunConfig
+from tau2.data_model.tasks import Task
+from tau2.evaluator.evaluator import EvaluationType
+from tau2.runner.work import WorkUnit
+
+AUTH_TOKEN_ENV = "TAU2_CONTROLLER_TOKEN"
+
+DEFAULT_SLOTS = 10
+HEARTBEAT_INTERVAL_SECONDS = 30.0
+POLL_INTERVAL_SECONDS = 1.0
+POST_RETRIES = 3
+
+
+class ControllerClient:
+    """HTTP TaskSource client. ``client`` is injectable for in-process tests
+    (httpx ASGITransport)."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        client: Optional[httpx.Client] = None,
+        token: Optional[str] = None,
+    ):
+        token = token or os.environ.get(AUTH_TOKEN_ENV)
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        self._client = client or httpx.Client(
+            base_url=base_url, headers=headers, timeout=30.0
+        )
+
+    def _post(self, path: str, payload: dict) -> dict:
+        last_error: Optional[Exception] = None
+        for attempt in range(POST_RETRIES):
+            try:
+                response = self._client.post(path, json=payload)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPError as e:
+                last_error = e
+                if attempt < POST_RETRIES - 1:
+                    time.sleep(1.0 * (attempt + 1))
+        raise last_error
+
+    def lease(self, worker_id: str) -> dict:
+        return self._post("/lease", {"worker_id": worker_id})
+
+    def complete(self, worker_id: str, unit_id: str, result: dict) -> dict:
+        return self._post(
+            "/complete",
+            {"worker_id": worker_id, "unit_id": unit_id, "result": result},
+        )
+
+    def fail(self, worker_id: str, unit_id: str, error: str) -> dict:
+        return self._post(
+            "/fail", {"worker_id": worker_id, "unit_id": unit_id, "error": error}
+        )
+
+    def heartbeat(self, worker_id: str, unit_ids: list[str]) -> dict:
+        return self._post("/heartbeat", {"worker_id": worker_id, "unit_ids": unit_ids})
+
+
+def execute_lease(payload: dict) -> SimulationRun:
+    """Execute one leased unit: rebuild the run context from the payload and
+    run the same code the local loop runs. No checkpoint fns, no monitor —
+    the result goes back to the controller."""
+    from tau2.runner.batch import _BatchContext, make_voice_run_settings, run_unit
+    from tau2.runner.helpers import get_info
+
+    unit = WorkUnit.model_validate(payload["unit"])
+    run = payload["run"]
+    config_cls = VoiceRunConfig if run["config_kind"] == "voice" else TextRunConfig
+    config = config_cls.model_validate(run["config"])
+    task = Task.model_validate(run["task"])
+    save_dir = Path(run["save_dir"]) if run.get("save_dir") else None
+
+    user_voice_settings, user_persona_config = make_voice_run_settings(config)
+    info = get_info(
+        config,
+        user_persona_config=user_persona_config,
+        user_voice_settings=user_voice_settings,
+    )
+    ctx = _BatchContext(
+        config=config,
+        evaluation_type=EvaluationType(run["evaluation_type"]),
+        save_dir=save_dir,
+        user_voice_settings=user_voice_settings,
+        user_persona_config=user_persona_config,
+        info=info,
+        console_display=False,
+    )
+    return run_unit(ctx, task, unit.trial, unit.seed, unit.progress_str)
+
+
+def _maybe_preregister_livekit(run_payload: dict, registered: set) -> None:
+    """LiveKit plugins must be registered on the worker's main thread before
+    sim threads spawn (same constraint as the local loop)."""
+    if "livekit" in registered:
+        return
+    audio_config = (run_payload.get("config") or {}).get("audio_native_config") or {}
+    if audio_config.get("provider") == "livekit":
+        from tau2.voice.audio_native.livekit import preregister_livekit_plugins
+
+        preregister_livekit_plugins()
+        registered.add("livekit")
+
+
+def worker_loop(
+    client: ControllerClient,
+    worker_id: str,
+    slots: int,
+    poll_interval: float = POLL_INTERVAL_SECONDS,
+    heartbeat_interval: float = HEARTBEAT_INTERVAL_SECONDS,
+) -> int:
+    """Lease → execute → report, keeping up to ``slots`` sims in flight.
+    Returns a process exit code; exits when the controller reports done."""
+    executor = ThreadPoolExecutor(max_workers=slots)
+    inflight: dict[Future, str] = {}
+    last_heartbeat = time.monotonic()
+    preregistered: set = set()
+
+    try:
+        while True:
+            # Report finished sims.
+            for future in [f for f in list(inflight) if f.done()]:
+                unit_id = inflight.pop(future)
+                try:
+                    sim = future.result()
+                except BaseException as e:
+                    logger.error(f"Unit {unit_id} failed in worker: {e}")
+                    client.fail(worker_id, unit_id, f"{type(e).__name__}: {e}")
+                else:
+                    client.complete(worker_id, unit_id, sim.model_dump(mode="json"))
+
+            # Keep leases alive while sims run.
+            if inflight and time.monotonic() - last_heartbeat >= heartbeat_interval:
+                client.heartbeat(worker_id, list(inflight.values()))
+                last_heartbeat = time.monotonic()
+
+            # Fill free slots.
+            if len(inflight) < slots:
+                body = client.lease(worker_id)
+                if body["status"] == "unit":
+                    _maybe_preregister_livekit(body["run"], preregistered)
+                    future = executor.submit(execute_lease, body)
+                    inflight[future] = body["unit"]["unit_id"]
+                    continue  # try to fill the next slot immediately
+                if body["status"] == "done" and not inflight:
+                    logger.info("Controller reports done; worker exiting")
+                    return 0
+
+            # Wait for a sim to finish (or poll again for work).
+            if inflight:
+                wait(list(inflight), timeout=poll_interval, return_when=FIRST_COMPLETED)
+            else:
+                time.sleep(poll_interval)
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+
+
+def run_worker_command(
+    controller: str, slots: int = DEFAULT_SLOTS, worker_id: Optional[str] = None
+) -> int:
+    if worker_id is None:
+        worker_id = f"{socket.gethostname()}-{os.getpid()}"
+    logger.info(f"Worker {worker_id} connecting to {controller} with {slots} slot(s)")
+    client = ControllerClient(base_url=controller)
+    try:
+        return worker_loop(client, worker_id=worker_id, slots=slots)
+    except httpx.HTTPError as e:
+        logger.error(f"Lost contact with controller {controller}: {e}")
+        return 1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="tau2 worker: executes simulations for a tau2 controller."
+    )
+    parser.add_argument(
+        "--controller",
+        required=True,
+        help="Controller base URL, e.g. http://127.0.0.1:8321",
+    )
+    parser.add_argument(
+        "--slots",
+        type=int,
+        default=DEFAULT_SLOTS,
+        help=f"Concurrent simulations this worker holds (default {DEFAULT_SLOTS}).",
+    )
+    parser.add_argument(
+        "--worker-id",
+        default=None,
+        help="Worker identity in controller logs (default: hostname-pid).",
+    )
+    args = parser.parse_args(argv)
+    return run_worker_command(
+        controller=args.controller, slots=args.slots, worker_id=args.worker_id
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/tau2/runner/worker.py
+++ b/src/tau2/runner/worker.py
@@ -13,6 +13,7 @@ import argparse
 import os
 import socket
 import sys
+import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from pathlib import Path
@@ -33,10 +34,14 @@ HEARTBEAT_INTERVAL_SECONDS = 30.0
 POLL_INTERVAL_SECONDS = 1.0
 POST_RETRIES = 3
 
-# /complete posts carry a full SimulationRun (voice sims with verbose tick
+# /complete and /fail carry a full SimulationRun (voice sims with verbose tick
 # logs run to many MB) and the controller may be mid-checkpoint-write when
 # the request lands, so read/write get minutes, not the httpx 5s default.
 HTTP_TIMEOUT = httpx.Timeout(300.0, connect=10.0)
+
+# /lease and /heartbeat are tiny; failing fast and retrying beats waiting
+# minutes on a stuck controller.
+CONTROL_TIMEOUT_SECONDS = 30.0
 
 
 class ControllerClient:
@@ -55,11 +60,12 @@ class ControllerClient:
             base_url=base_url, headers=headers, timeout=HTTP_TIMEOUT
         )
 
-    def _post(self, path: str, payload: dict) -> dict:
+    def _post(self, path: str, payload: dict, timeout: Optional[float] = None) -> dict:
         last_error: Optional[Exception] = None
         for attempt in range(POST_RETRIES):
             try:
-                response = self._client.post(path, json=payload)
+                kwargs = {} if timeout is None else {"timeout": timeout}
+                response = self._client.post(path, json=payload, **kwargs)
                 response.raise_for_status()
                 return response.json()
             except httpx.HTTPError as e:
@@ -69,7 +75,9 @@ class ControllerClient:
         raise last_error
 
     def lease(self, worker_id: str) -> dict:
-        return self._post("/lease", {"worker_id": worker_id})
+        return self._post(
+            "/lease", {"worker_id": worker_id}, timeout=CONTROL_TIMEOUT_SECONDS
+        )
 
     def complete(self, worker_id: str, unit_id: str, result: dict) -> dict:
         return self._post(
@@ -83,7 +91,62 @@ class ControllerClient:
         )
 
     def heartbeat(self, worker_id: str, unit_ids: list[str]) -> dict:
-        return self._post("/heartbeat", {"worker_id": worker_id, "unit_ids": unit_ids})
+        return self._post(
+            "/heartbeat",
+            {"worker_id": worker_id, "unit_ids": unit_ids},
+            timeout=CONTROL_TIMEOUT_SECONDS,
+        )
+
+
+class HeartbeatThread(threading.Thread):
+    """Keeps leases alive independently of the worker's main loop.
+
+    The main loop blocks on /complete posts (multi-MB voice results) and on
+    execute_lease setup, so heartbeating from there starves under load: in the
+    first field run a ~3-minute stall expired live leases and the controller
+    re-ran sims that were still going. A lease the controller reports lost is
+    remembered so its zombie sim stops being heartbeated and its eventual
+    result is expected to come back stale.
+    """
+
+    def __init__(
+        self,
+        client: ControllerClient,
+        worker_id: str,
+        inflight_ids,
+        interval: float,
+    ):
+        super().__init__(daemon=True, name="tau2-worker-heartbeat")
+        self._client = client
+        self._worker_id = worker_id
+        self._inflight_ids = inflight_ids
+        self._interval = interval
+        self._stop_event = threading.Event()
+        self.lost: set[str] = set()
+
+    def run(self) -> None:
+        while not self._stop_event.wait(self._interval):
+            self.beat()
+
+    def beat(self) -> None:
+        unit_ids = [u for u in self._inflight_ids() if u not in self.lost]
+        if not unit_ids:
+            return
+        try:
+            leases = self._client.heartbeat(self._worker_id, unit_ids)["leases"]
+        except Exception as e:
+            logger.warning(f"Heartbeat failed (will retry): {e}")
+            return
+        for unit_id, alive in leases.items():
+            if not alive:
+                self.lost.add(unit_id)
+                logger.warning(
+                    f"Lease lost for {unit_id}; the controller has requeued it "
+                    "and this attempt's result will be discarded as stale"
+                )
+
+    def stop(self) -> None:
+        self._stop_event.set()
 
 
 def execute_lease(payload: dict) -> SimulationRun:
@@ -143,26 +206,43 @@ def worker_loop(
     Returns a process exit code; exits when the controller reports done."""
     executor = ThreadPoolExecutor(max_workers=slots)
     inflight: dict[Future, str] = {}
-    last_heartbeat = time.monotonic()
+    inflight_lock = threading.Lock()
     preregistered: set = set()
+
+    def inflight_ids() -> list[str]:
+        with inflight_lock:
+            return list(inflight.values())
+
+    heartbeats = HeartbeatThread(
+        client, worker_id, inflight_ids, interval=heartbeat_interval
+    )
+    heartbeats.start()
 
     try:
         while True:
             # Report finished sims.
             for future in [f for f in list(inflight) if f.done()]:
-                unit_id = inflight.pop(future)
+                with inflight_lock:
+                    unit_id = inflight.pop(future)
                 try:
                     sim = future.result()
                 except BaseException as e:
                     logger.error(f"Unit {unit_id} failed in worker: {e}")
-                    client.fail(worker_id, unit_id, f"{type(e).__name__}: {e}")
+                    resp = client.fail(worker_id, unit_id, f"{type(e).__name__}: {e}")
                 else:
-                    client.complete(worker_id, unit_id, sim.model_dump(mode="json"))
-
-            # Keep leases alive while sims run.
-            if inflight and time.monotonic() - last_heartbeat >= heartbeat_interval:
-                client.heartbeat(worker_id, list(inflight.values()))
-                last_heartbeat = time.monotonic()
+                    resp = client.complete(
+                        worker_id, unit_id, sim.model_dump(mode="json")
+                    )
+                status = resp.get("status")
+                if status == "stale":
+                    logger.warning(
+                        f"Result for {unit_id} arrived after its lease was lost; "
+                        "the controller discarded it as stale"
+                    )
+                elif status == "requeued":
+                    logger.info(
+                        f"Controller requeued {unit_id} (infrastructure_error result)"
+                    )
 
             # Fill free slots.
             if len(inflight) < slots:
@@ -170,7 +250,8 @@ def worker_loop(
                 if body["status"] == "unit":
                     _maybe_preregister_livekit(body["run"], preregistered)
                     future = executor.submit(execute_lease, body)
-                    inflight[future] = body["unit"]["unit_id"]
+                    with inflight_lock:
+                        inflight[future] = body["unit"]["unit_id"]
                     continue  # try to fill the next slot immediately
                 if body["status"] == "done" and not inflight:
                     logger.info("Controller reports done; worker exiting")
@@ -182,6 +263,7 @@ def worker_loop(
             else:
                 time.sleep(poll_interval)
     finally:
+        heartbeats.stop()
         executor.shutdown(wait=False, cancel_futures=True)
 
 

--- a/src/tau2/runner/worker.py
+++ b/src/tau2/runner/worker.py
@@ -33,6 +33,11 @@ HEARTBEAT_INTERVAL_SECONDS = 30.0
 POLL_INTERVAL_SECONDS = 1.0
 POST_RETRIES = 3
 
+# /complete posts carry a full SimulationRun (voice sims with verbose tick
+# logs run to many MB) and the controller may be mid-checkpoint-write when
+# the request lands, so read/write get minutes, not the httpx 5s default.
+HTTP_TIMEOUT = httpx.Timeout(300.0, connect=10.0)
+
 
 class ControllerClient:
     """HTTP TaskSource client. ``client`` is injectable for in-process tests
@@ -47,7 +52,7 @@ class ControllerClient:
         token = token or os.environ.get(AUTH_TOKEN_ENV)
         headers = {"Authorization": f"Bearer {token}"} if token else {}
         self._client = client or httpx.Client(
-            base_url=base_url, headers=headers, timeout=30.0
+            base_url=base_url, headers=headers, timeout=HTTP_TIMEOUT
         )
 
     def _post(self, path: str, payload: dict) -> dict:
@@ -109,6 +114,7 @@ def execute_lease(payload: dict) -> SimulationRun:
         user_persona_config=user_persona_config,
         info=info,
         console_display=False,
+        llm_log_mode_value=run.get("llm_log_mode"),
     )
     return run_unit(ctx, task, unit.trial, unit.seed, unit.progress_str)
 

--- a/src/tau2/scripts/leaderboard/review_submission.py
+++ b/src/tau2/scripts/leaderboard/review_submission.py
@@ -176,9 +176,7 @@ def _compute_interaction_metrics(
     for results in results_list:
         domain = results.info.environment_info.domain_name
         if domain in domain_metrics:
-            raise ValueError(
-                f"Domain {domain} appears in multiple trajectory files"
-            )
+            raise ValueError(f"Domain {domain} appears in multiple trajectory files")
         try:
             domain_metrics[domain] = compute_metrics_for_loaded_results(results)
             resolved_configs.append(resolve_experiment_config(results))

--- a/src/tau2/utils/display.py
+++ b/src/tau2/utils/display.py
@@ -1819,8 +1819,7 @@ class ConsoleDisplay:
             agent_results = ""
             if tick.agent_tool_results:
                 agent_results = "\n".join(
-                    cls.truncate_tool_result(r.content)
-                    for r in tick.agent_tool_results
+                    cls.truncate_tool_result(r.content) for r in tick.agent_tool_results
                 )
 
             agent_turn_action = ""
@@ -1847,8 +1846,7 @@ class ConsoleDisplay:
             user_results = ""
             if tick.user_tool_results:
                 user_results = "\n".join(
-                    cls.truncate_tool_result(r.content)
-                    for r in tick.user_tool_results
+                    cls.truncate_tool_result(r.content) for r in tick.user_tool_results
                 )
 
             user_turn_action = ""
@@ -1996,8 +1994,7 @@ class ConsoleDisplay:
                 )
             if tick.agent_tool_results:
                 info["agent_results"] = "\n".join(
-                    cls.truncate_tool_result(r.content)
-                    for r in tick.agent_tool_results
+                    cls.truncate_tool_result(r.content) for r in tick.agent_tool_results
                 )
             if (
                 tick.agent_chunk
@@ -2020,8 +2017,7 @@ class ConsoleDisplay:
                 )
             if tick.user_tool_results:
                 info["user_results"] = "\n".join(
-                    cls.truncate_tool_result(r.content)
-                    for r in tick.user_tool_results
+                    cls.truncate_tool_result(r.content) for r in tick.user_tool_results
                 )
             if (
                 tick.user_chunk

--- a/src/tau2/voice/audio_native/gemini/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/gemini/discrete_time_adapter.py
@@ -510,7 +510,9 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
                     thoughts_token_count=event.thoughts_token_count,
                     prompt_tokens_details=event.prompt_tokens_details,
                     response_tokens_details=event.response_tokens_details,
-                    raw=event.model_dump(exclude={"type", "event_id"}, exclude_none=True),
+                    raw=event.model_dump(
+                        exclude={"type", "event_id"}, exclude_none=True
+                    ),
                 )
             )
 

--- a/src/tau2/voice/audio_native/nova/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/nova/discrete_time_adapter.py
@@ -51,13 +51,13 @@ from tau2.voice.audio_native.nova.events import (
     NovaAudioOutputEvent,
     NovaBargeInEvent,
     NovaCompletionEndEvent,
-    NovaUsageEvent,
     NovaContentStartEvent,
     NovaSpeechEndedEvent,
     NovaSpeechStartedEvent,
     NovaTextOutputEvent,
     NovaTimeoutEvent,
     NovaToolUseEvent,
+    NovaUsageEvent,
 )
 from tau2.voice.audio_native.nova.provider import (
     NOVA_BYTES_PER_SECOND,

--- a/src/tau2/voice/pricing.py
+++ b/src/tau2/voice/pricing.py
@@ -274,8 +274,14 @@ def compute_record_cost(record: UsageRecord) -> Optional[float]:
 
     has_tokens = any(
         getattr(record, f) is not None
-        for f in ("input_tokens", "output_tokens", "input_text_tokens",
-                  "input_audio_tokens", "output_text_tokens", "output_audio_tokens")
+        for f in (
+            "input_tokens",
+            "output_tokens",
+            "input_text_tokens",
+            "input_audio_tokens",
+            "output_text_tokens",
+            "output_audio_tokens",
+        )
     )
     if has_tokens:
         token_part = _token_cost(record, rates)
@@ -288,9 +294,7 @@ def compute_record_cost(record: UsageRecord) -> Optional[float]:
 
     if record.audio_input_seconds:
         if rates.per_audio_input_minute is None:
-            logger.warning(
-                f"No per-minute rate for {record.provider}/{record.model}"
-            )
+            logger.warning(f"No per-minute rate for {record.provider}/{record.model}")
             return None
         total += record.audio_input_seconds / 60 * rates.per_audio_input_minute
 

--- a/tests/test_evaluate_trajectories.py
+++ b/tests/test_evaluate_trajectories.py
@@ -327,8 +327,7 @@ class TestRegradingOptions:
         captured = self._capture_eval_kwargs(monkeypatch, results, fresh_tasks=True)
         current_task = get_tasks("mock", task_ids=["create_task_1"])[0]
         assert (
-            captured[0]["task"].evaluation_criteria
-            == current_task.evaluation_criteria
+            captured[0]["task"].evaluation_criteria == current_task.evaluation_criteria
         )
         assert captured[0]["task"].evaluation_criteria != EvaluationCriteria()
 

--- a/tests/test_runner/test_controller.py
+++ b/tests/test_runner/test_controller.py
@@ -1,0 +1,275 @@
+"""Tests for the parallel-run controller and worker loop.
+
+Everything runs in-process: the controller's FastAPI app is exercised through
+httpx's ASGI transport (no sockets, no subprocesses), and the worker loop's
+simulation execution is monkeypatched so no LLM is called.
+"""
+
+import json
+import uuid
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from tau2.data_model.simulation import SimulationRun, TerminationReason, TextRunConfig
+from tau2.run import get_tasks
+from tau2.runner import worker as worker_mod
+from tau2.runner.batch import prepare_batch
+from tau2.runner.controller import Controller, ControllerRun
+from tau2.runner.work import WorkUnit
+from tau2.runner.worker import ControllerClient, worker_loop
+
+
+def _make_config(**overrides) -> TextRunConfig:
+    defaults = dict(
+        domain="mock",
+        agent="llm_agent",
+        user="user_simulator",
+        task_ids=["create_task_1", "update_task_1"],
+        llm_agent="gpt-3.5-turbo",
+        llm_args_agent={},
+        llm_user="gpt-3.5-turbo",
+        llm_args_user={},
+        num_trials=1,
+        max_steps=20,
+        max_errors=10,
+        save_to=None,
+        max_concurrency=2,
+        auto_resume=True,
+    )
+    defaults.update(overrides)
+    return TextRunConfig(**defaults)
+
+
+def _make_sim(
+    unit: WorkUnit,
+    termination_reason: TerminationReason = TerminationReason.USER_STOP,
+) -> SimulationRun:
+    return SimulationRun(
+        id=str(uuid.uuid4()),
+        task_id=unit.task_id,
+        start_time="2026-01-01T00:00:00",
+        end_time="2026-01-01T00:01:00",
+        duration=60.0,
+        termination_reason=termination_reason,
+        messages=[],
+        trial=unit.trial,
+        seed=unit.seed,
+    )
+
+
+@pytest.fixture
+def controller(tmp_path):
+    config = _make_config()
+    tasks = get_tasks("mock", task_ids=config.task_ids)
+    save_path = tmp_path / "results.json"
+    prep = prepare_batch(
+        config,
+        tasks,
+        save_path=save_path,
+        save_dir=tmp_path,
+        console_display=False,
+    )
+    run = ControllerRun.from_prep("test_run", prep)
+    ctrl = Controller([run], max_attempts=2)
+    ctrl.save_path = save_path  # for test assertions only
+    return ctrl
+
+
+def _client(ctrl: Controller) -> httpx.Client:
+    return TestClient(ctrl.build_app())
+
+
+def _load_sims(save_path) -> list[dict]:
+    with open(save_path) as f:
+        return json.load(f)["simulations"]
+
+
+class TestControllerHttpContract:
+    def test_lease_returns_unit_config_and_task(self, controller):
+        with _client(controller) as client:
+            resp = client.post("/lease", json={"worker_id": "w1"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["status"] == "unit"
+            unit = body["unit"]
+            assert unit["run_id"] == "test_run"
+            run = body["run"]
+            assert run["config_kind"] == "text"
+            assert run["config"]["domain"] == "mock"
+            assert run["task"]["id"] == unit["task_id"]
+
+    def test_complete_writes_exactly_one_checkpoint_entry(self, controller):
+        with _client(controller) as client:
+            body = client.post("/lease", json={"worker_id": "w1"}).json()
+            unit = WorkUnit.model_validate(body["unit"])
+            sim = _make_sim(unit)
+            resp = client.post(
+                "/complete",
+                json={
+                    "worker_id": "w1",
+                    "unit_id": unit.unit_id,
+                    "result": sim.model_dump(mode="json"),
+                },
+            )
+            assert resp.json()["status"] == "ok"
+            sims = _load_sims(controller.save_path)
+            assert len(sims) == 1
+            assert sims[0]["task_id"] == unit.task_id
+
+            # A duplicate complete must not write a second entry.
+            resp = client.post(
+                "/complete",
+                json={
+                    "worker_id": "w1",
+                    "unit_id": unit.unit_id,
+                    "result": sim.model_dump(mode="json"),
+                },
+            )
+            assert resp.json()["status"] == "stale"
+            assert len(_load_sims(controller.save_path)) == 1
+
+    def test_infra_error_result_requeues_then_writes_when_exhausted(self, controller):
+        with _client(controller) as client:
+            body = client.post("/lease", json={"worker_id": "w1"}).json()
+            unit = WorkUnit.model_validate(body["unit"])
+            infra_sim = _make_sim(
+                unit, termination_reason=TerminationReason.INFRASTRUCTURE_ERROR
+            )
+
+            resp = client.post(
+                "/complete",
+                json={
+                    "worker_id": "w1",
+                    "unit_id": unit.unit_id,
+                    "result": infra_sim.model_dump(mode="json"),
+                },
+            )
+            assert resp.json()["status"] == "requeued"
+            assert _load_sims(controller.save_path) == []
+
+            # The requeued attempt comes back around; max_attempts=2 means this
+            # infra failure is final and must be checkpointed.
+            leases = [client.post("/lease", json={"worker_id": "w2"}).json()]
+            if leases[0]["unit"]["task_id"] != unit.task_id:
+                leases.append(client.post("/lease", json={"worker_id": "w2"}).json())
+            retry_unit = WorkUnit.model_validate(leases[-1]["unit"])
+            assert retry_unit.task_id == unit.task_id
+            assert retry_unit.attempt == 1
+
+            infra_sim_2 = _make_sim(
+                retry_unit, termination_reason=TerminationReason.INFRASTRUCTURE_ERROR
+            )
+            resp = client.post(
+                "/complete",
+                json={
+                    "worker_id": "w2",
+                    "unit_id": retry_unit.unit_id,
+                    "result": infra_sim_2.model_dump(mode="json"),
+                },
+            )
+            assert resp.json()["status"] == "ok"
+            sims = _load_sims(controller.save_path)
+            infra_written = [
+                s for s in sims if s["termination_reason"] == "infrastructure_error"
+            ]
+            assert len(infra_written) == 1
+
+    def test_fail_requeues_then_dead_unit_gets_placeholder_sim(self, controller):
+        with _client(controller) as client:
+            body = client.post("/lease", json={"worker_id": "w1"}).json()
+            unit = WorkUnit.model_validate(body["unit"])
+
+            resp = client.post(
+                "/fail",
+                json={"worker_id": "w1", "unit_id": unit.unit_id, "error": "boom"},
+            )
+            assert resp.json()["status"] == "requeued"
+
+            leases = [client.post("/lease", json={"worker_id": "w1"}).json()]
+            if leases[0]["unit"]["task_id"] != unit.task_id:
+                leases.append(client.post("/lease", json={"worker_id": "w1"}).json())
+            retry_unit = WorkUnit.model_validate(leases[-1]["unit"])
+            resp = client.post(
+                "/fail",
+                json={
+                    "worker_id": "w1",
+                    "unit_id": retry_unit.unit_id,
+                    "error": "boom again",
+                },
+            )
+            assert resp.json()["status"] == "dead"
+
+        # Draining flushes placeholder infra sims for dead units.
+        controller.flush_dead_units()
+        sims = _load_sims(controller.save_path)
+        placeholder = [s for s in sims if s["task_id"] == unit.task_id]
+        assert len(placeholder) == 1
+        assert placeholder[0]["termination_reason"] == "infrastructure_error"
+
+    def test_status_endpoint_reports_counts(self, controller):
+        with _client(controller) as client:
+            client.post("/lease", json={"worker_id": "w1"})
+            counts = client.get("/status").json()["counts"]
+            assert counts["leased"] == 1
+            assert counts["pending"] == 1
+
+    def test_done_when_all_resolved(self, controller):
+        with _client(controller) as client:
+            while True:
+                body = client.post("/lease", json={"worker_id": "w1"}).json()
+                if body["status"] != "unit":
+                    break
+                unit = WorkUnit.model_validate(body["unit"])
+                client.post(
+                    "/complete",
+                    json={
+                        "worker_id": "w1",
+                        "unit_id": unit.unit_id,
+                        "result": _make_sim(unit).model_dump(mode="json"),
+                    },
+                )
+            assert body["status"] == "done"
+
+
+class TestWorkerLoop:
+    def test_worker_loop_completes_all_units(self, controller, monkeypatch):
+        executed: list[str] = []
+
+        def fake_execute(payload: dict) -> SimulationRun:
+            unit = WorkUnit.model_validate(payload["unit"])
+            executed.append(unit.task_id)
+            return _make_sim(unit)
+
+        monkeypatch.setattr(worker_mod, "execute_lease", fake_execute)
+
+        with TestClient(controller.build_app()) as http_client:
+            client = ControllerClient(client=http_client)
+            exit_code = worker_loop(client, worker_id="w1", slots=2)
+
+        assert exit_code == 0
+        assert sorted(executed) == ["create_task_1", "update_task_1"]
+        assert len(_load_sims(controller.save_path)) == 2
+        assert controller.queue.all_resolved()
+
+    def test_worker_loop_reports_execution_errors_as_fail(
+        self, controller, monkeypatch
+    ):
+        def broken_execute(payload: dict) -> SimulationRun:
+            raise RuntimeError("worker exploded")
+
+        monkeypatch.setattr(worker_mod, "execute_lease", broken_execute)
+
+        with TestClient(controller.build_app()) as http_client:
+            client = ControllerClient(client=http_client)
+            exit_code = worker_loop(client, worker_id="w1", slots=1)
+
+        assert exit_code == 0
+        # max_attempts=2, both attempts fail -> both units dead.
+        assert controller.queue.all_resolved()
+        assert len(controller.queue.dead_units) == 2
+        controller.flush_dead_units()
+        sims = _load_sims(controller.save_path)
+        assert len(sims) == 2
+        assert all(s["termination_reason"] == "infrastructure_error" for s in sims)

--- a/tests/test_runner/test_controller.py
+++ b/tests/test_runner/test_controller.py
@@ -99,6 +99,9 @@ class TestControllerHttpContract:
             assert run["config_kind"] == "text"
             assert run["config"]["domain"] == "mock"
             assert run["task"]["id"] == unit["task_id"]
+            # The CLI's --llm-log-mode only reaches worker processes through
+            # the lease payload ("latest" is the ContextVar default).
+            assert run["llm_log_mode"] == "latest"
 
     def test_complete_writes_exactly_one_checkpoint_entry(self, controller):
         with _client(controller) as client:

--- a/tests/test_runner/test_controller.py
+++ b/tests/test_runner/test_controller.py
@@ -338,3 +338,58 @@ class TestHeartbeatThread:
         hb.join(timeout=2.0)
         assert len(client.calls) >= 3
         assert not hb.is_alive()
+
+
+class _RecordingMonitor:
+    def __init__(self):
+        self.started: list[str] = []
+        self.finished: list[str] = []
+
+    def task_started(self, key, trial):
+        self.started.append(key)
+
+    def task_finished(self, key):
+        self.finished.append(key)
+
+    def task_restarted(self, key):
+        pass
+
+
+class TestMultiRunMonitorKeys:
+    def test_monitor_keys_are_run_scoped_so_runs_do_not_collide(self, tmp_path):
+        """Two runs share task ids; 4 in-flight sims must show as 4, not 2."""
+        monitor = _RecordingMonitor()
+        runs = []
+        for name in ["run_a", "run_b"]:
+            config = _make_config()
+            tasks = get_tasks("mock", task_ids=config.task_ids)
+            prep = prepare_batch(
+                config,
+                tasks,
+                save_path=tmp_path / name / "results.json",
+                save_dir=tmp_path / name,
+                console_display=False,
+            )
+            runs.append(ControllerRun.from_prep(name, prep))
+        ctrl = Controller(runs, max_attempts=2, monitor=monitor)
+
+        with TestClient(ctrl.build_app()) as client:
+            leased = []
+            while True:
+                body = client.post("/lease", json={"worker_id": "w1"}).json()
+                if body["status"] != "unit":
+                    break
+                leased.append(WorkUnit.model_validate(body["unit"]))
+            assert len(leased) == 4
+            assert len(set(monitor.started)) == 4
+
+            for unit in leased:
+                client.post(
+                    "/complete",
+                    json={
+                        "worker_id": "w1",
+                        "unit_id": unit.unit_id,
+                        "result": _make_sim(unit).model_dump(mode="json"),
+                    },
+                )
+        assert sorted(monitor.finished) == sorted(monitor.started)

--- a/tests/test_runner/test_controller.py
+++ b/tests/test_runner/test_controller.py
@@ -393,3 +393,15 @@ class TestMultiRunMonitorKeys:
                     },
                 )
         assert sorted(monitor.finished) == sorted(monitor.started)
+
+    def test_releasing_a_lost_unit_resumes_its_heartbeats(self):
+        """Unit ids omit the attempt number: a requeued unit re-leased by the
+        same worker must be heartbeated again, not stay muted forever."""
+        client = _RecordingClient([{"u1": False}, {"u1": True}])
+        hb = worker_mod.HeartbeatThread(client, "w1", lambda: ["u1"], interval=999)
+        hb.beat()
+        assert hb.lost == {"u1"}
+        hb.leased("u1")
+        hb.beat()
+        assert client.calls[-1] == ["u1"]
+        assert hb.lost == set()

--- a/tests/test_runner/test_controller.py
+++ b/tests/test_runner/test_controller.py
@@ -6,6 +6,7 @@ simulation execution is monkeypatched so no LLM is called.
 """
 
 import json
+import time
 import uuid
 
 import httpx
@@ -276,3 +277,64 @@ class TestWorkerLoop:
         sims = _load_sims(controller.save_path)
         assert len(sims) == 2
         assert all(s["termination_reason"] == "infrastructure_error" for s in sims)
+
+
+class _RecordingClient:
+    """Stands in for ControllerClient in HeartbeatThread tests."""
+
+    def __init__(self, leases_by_call: list[dict]):
+        self.calls: list[list[str]] = []
+        self._leases_by_call = leases_by_call
+
+    def heartbeat(self, worker_id: str, unit_ids: list[str]) -> dict:
+        self.calls.append(list(unit_ids))
+        return {
+            "leases": self._leases_by_call[
+                min(len(self.calls) - 1, len(self._leases_by_call) - 1)
+            ]
+        }
+
+
+class TestHeartbeatThread:
+    def test_beat_posts_inflight_ids(self):
+        client = _RecordingClient([{"u1": True, "u2": True}])
+        hb = worker_mod.HeartbeatThread(
+            client, "w1", lambda: ["u1", "u2"], interval=999
+        )
+        hb.beat()
+        hb.beat()
+        assert client.calls == [["u1", "u2"], ["u1", "u2"]]
+        assert hb.lost == set()
+
+    def test_lost_lease_is_remembered_and_not_beaten_again(self):
+        client = _RecordingClient([{"u1": False, "u2": True}, {"u2": True}])
+        hb = worker_mod.HeartbeatThread(
+            client, "w1", lambda: ["u1", "u2"], interval=999
+        )
+        hb.beat()
+        assert hb.lost == {"u1"}
+        hb.beat()
+        assert client.calls[1] == ["u2"]
+
+    def test_heartbeat_errors_do_not_kill_the_thread(self):
+        class ExplodingClient:
+            def heartbeat(self, worker_id, unit_ids):
+                raise RuntimeError("controller unreachable")
+
+        hb = worker_mod.HeartbeatThread(
+            ExplodingClient(), "w1", lambda: ["u1"], interval=999
+        )
+        hb.beat()  # must not raise
+        assert hb.lost == set()
+
+    def test_thread_beats_periodically_until_stopped(self):
+        client = _RecordingClient([{"u1": True}])
+        hb = worker_mod.HeartbeatThread(client, "w1", lambda: ["u1"], interval=0.01)
+        hb.start()
+        deadline = time.monotonic() + 2.0
+        while len(client.calls) < 3 and time.monotonic() < deadline:
+            time.sleep(0.01)
+        hb.stop()
+        hb.join(timeout=2.0)
+        assert len(client.calls) >= 3
+        assert not hb.is_alive()

--- a/tests/test_runner/test_local_seam.py
+++ b/tests/test_runner/test_local_seam.py
@@ -1,0 +1,102 @@
+"""run_tasks with workers=0 must behave exactly as before the TaskSource seam.
+
+run_single_task is monkeypatched so no LLM is called; what's under test is the
+batch loop itself: every (task, trial) executes once, results are
+checkpointed, and a resume runs nothing.
+"""
+
+import json
+import uuid
+
+from tau2.data_model.simulation import (
+    SimulationRun,
+    TerminationReason,
+    TextRunConfig,
+)
+from tau2.run import get_tasks
+from tau2.runner import batch as batch_mod
+from tau2.runner.batch import run_tasks
+
+
+def _make_config(**overrides) -> TextRunConfig:
+    defaults = dict(
+        domain="mock",
+        agent="llm_agent",
+        user="user_simulator",
+        task_ids=["create_task_1", "update_task_1"],
+        llm_agent="gpt-3.5-turbo",
+        llm_args_agent={},
+        llm_user="gpt-3.5-turbo",
+        llm_args_user={},
+        num_trials=2,
+        max_steps=20,
+        max_errors=10,
+        save_to=None,
+        max_concurrency=2,
+        auto_resume=True,
+    )
+    defaults.update(overrides)
+    return TextRunConfig(**defaults)
+
+
+def _install_fake_run_single_task(monkeypatch, calls: list):
+    def fake_run_single_task(config, task, *, seed=None, **kwargs):
+        calls.append((task.id, seed))
+        return SimulationRun(
+            id=str(uuid.uuid4()),
+            task_id=task.id,
+            start_time="2026-01-01T00:00:00",
+            end_time="2026-01-01T00:01:00",
+            duration=1.0,
+            termination_reason=TerminationReason.USER_STOP,
+            messages=[],
+            seed=seed,
+        )
+
+    monkeypatch.setattr(batch_mod, "run_single_task", fake_run_single_task)
+
+
+def test_all_task_trials_execute_and_checkpoint(tmp_path, monkeypatch):
+    calls: list = []
+    _install_fake_run_single_task(monkeypatch, calls)
+
+    config = _make_config()
+    tasks = get_tasks("mock", task_ids=config.task_ids)
+    save_path = tmp_path / "results.json"
+
+    results = run_tasks(
+        config,
+        tasks,
+        save_path=save_path,
+        save_dir=tmp_path,
+        console_display=False,
+    )
+
+    assert len(calls) == 4  # 2 tasks x 2 trials
+    assert len(results.simulations) == 4
+    with open(save_path) as f:
+        saved = json.load(f)
+    assert len(saved["simulations"]) == 4
+    pairs = {(s["task_id"], s["trial"]) for s in saved["simulations"]}
+    assert len(pairs) == 4
+
+
+def test_resume_runs_nothing_when_complete(tmp_path, monkeypatch):
+    calls: list = []
+    _install_fake_run_single_task(monkeypatch, calls)
+
+    config = _make_config()
+    tasks = get_tasks("mock", task_ids=config.task_ids)
+    save_path = tmp_path / "results.json"
+
+    run_tasks(
+        config, tasks, save_path=save_path, save_dir=tmp_path, console_display=False
+    )
+    first_run_calls = len(calls)
+
+    results = run_tasks(
+        config, tasks, save_path=save_path, save_dir=tmp_path, console_display=False
+    )
+
+    assert len(calls) == first_run_calls  # nothing re-ran
+    assert len(results.simulations) == 4

--- a/tests/test_runner/test_work_queue.py
+++ b/tests/test_runner/test_work_queue.py
@@ -1,0 +1,181 @@
+"""Tests for the in-memory work queue (lease/complete/fail/heartbeat semantics)."""
+
+from tau2.runner.work import (
+    FailOutcome,
+    WorkQueue,
+    WorkUnit,
+    make_unit_id,
+)
+
+
+def _make_units(
+    n: int, provider: str | None = None, run_id: str = "run"
+) -> list[WorkUnit]:
+    return [
+        WorkUnit(
+            unit_id=make_unit_id(run_id, f"task_{i}", 0),
+            run_id=run_id,
+            task_id=f"task_{i}",
+            trial=0,
+            seed=42,
+            provider=provider,
+        )
+        for i in range(n)
+    ]
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float):
+        self.now += seconds
+
+
+class TestLeaseAndComplete:
+    def test_lease_is_fifo_and_complete_resolves(self):
+        queue = WorkQueue(_make_units(2))
+        first = queue.lease("w1")
+        second = queue.lease("w1")
+        assert first.task_id == "task_0"
+        assert second.task_id == "task_1"
+        assert queue.lease("w1") is None
+        assert not queue.all_resolved()
+
+        assert queue.complete(first.unit_id)
+        assert queue.complete(second.unit_id)
+        assert queue.all_resolved()
+
+    def test_complete_unknown_or_duplicate_is_stale(self):
+        queue = WorkQueue(_make_units(1))
+        unit = queue.lease("w1")
+        assert queue.complete(unit.unit_id)
+        assert not queue.complete(unit.unit_id)
+        assert not queue.complete("nonexistent")
+
+    def test_counts_snapshot(self):
+        queue = WorkQueue(_make_units(3))
+        unit = queue.lease("w1")
+        queue.complete(unit.unit_id)
+        counts = queue.counts()
+        assert counts == {"pending": 2, "leased": 0, "completed": 1, "dead": 0}
+
+
+class TestProviderAndGlobalLimits:
+    def test_provider_limit_gates_leasing(self):
+        units = _make_units(2, provider="openai")
+        queue = WorkQueue(units, provider_limits={"openai": 1})
+        first = queue.lease("w1")
+        assert first is not None
+        assert queue.lease("w2") is None  # provider at capacity
+        queue.complete(first.unit_id)
+        assert queue.lease("w2") is not None  # capacity released
+
+    def test_unlimited_provider_not_gated(self):
+        units = _make_units(2, provider="gemini")
+        queue = WorkQueue(units, provider_limits={"openai": 1})
+        assert queue.lease("w1") is not None
+        assert queue.lease("w1") is not None
+
+    def test_capped_provider_skipped_in_favor_of_uncapped(self):
+        capped = _make_units(2, provider="openai")
+        free = _make_units(1, provider="gemini", run_id="other")
+        queue = WorkQueue(capped + free, provider_limits={"openai": 1})
+        assert queue.lease("w1").provider == "openai"
+        # openai is at capacity, so the gemini unit is leased even though it
+        # sits behind an openai unit in FIFO order.
+        assert queue.lease("w1").provider == "gemini"
+        assert queue.lease("w1") is None
+
+    def test_global_limit(self):
+        queue = WorkQueue(_make_units(3), global_limit=2)
+        assert queue.lease("w1") is not None
+        assert queue.lease("w1") is not None
+        assert queue.lease("w1") is None
+
+
+class TestFailureAndRetry:
+    def test_fail_requeues_with_incremented_attempt(self):
+        queue = WorkQueue(_make_units(1), max_attempts=2)
+        unit = queue.lease("w1")
+        assert unit.attempt == 0
+        assert queue.fail(unit.unit_id, "boom") == FailOutcome.REQUEUED
+        retried = queue.lease("w1")
+        assert retried.task_id == unit.task_id
+        assert retried.attempt == 1
+
+    def test_fail_exhausts_attempts_to_dead(self):
+        queue = WorkQueue(_make_units(1), max_attempts=2)
+        unit = queue.lease("w1")
+        queue.fail(unit.unit_id, "boom")
+        retried = queue.lease("w1")
+        assert queue.fail(retried.unit_id, "boom again") == FailOutcome.DEAD
+        assert queue.lease("w1") is None
+        assert queue.all_resolved()
+        assert len(queue.dead_units) == 1
+        dead_unit, error = queue.dead_units[0]
+        assert dead_unit.task_id == "task_0"
+        assert error == "boom again"
+
+    def test_fail_unknown_is_stale(self):
+        queue = WorkQueue(_make_units(1))
+        assert queue.fail("nonexistent", "boom") == FailOutcome.STALE
+
+
+class TestLeaseExpiry:
+    def test_expired_lease_requeues(self):
+        clock = FakeClock()
+        queue = WorkQueue(
+            _make_units(1), lease_ttl_seconds=10, max_attempts=3, clock=clock
+        )
+        unit = queue.lease("w1")
+        assert queue.lease("w2") is None
+        clock.advance(11)
+        retried = queue.lease("w2")
+        assert retried is not None
+        assert retried.attempt == unit.attempt + 1
+
+    def test_heartbeat_extends_lease(self):
+        clock = FakeClock()
+        queue = WorkQueue(_make_units(1), lease_ttl_seconds=10, clock=clock)
+        unit = queue.lease("w1")
+        clock.advance(8)
+        assert queue.heartbeat(unit.unit_id)
+        clock.advance(8)
+        assert queue.lease("w2") is None  # still leased thanks to heartbeat
+
+    def test_expiry_exhausts_attempts_to_dead(self):
+        clock = FakeClock()
+        queue = WorkQueue(
+            _make_units(1), lease_ttl_seconds=10, max_attempts=1, clock=clock
+        )
+        queue.lease("w1")
+        clock.advance(11)
+        assert queue.lease("w2") is None
+        assert queue.all_resolved()
+        assert len(queue.dead_units) == 1
+
+    def test_stale_complete_after_expiry_requeue_is_ignored(self):
+        clock = FakeClock()
+        queue = WorkQueue(
+            _make_units(1), lease_ttl_seconds=10, max_attempts=3, clock=clock
+        )
+        unit = queue.lease("w1")
+        clock.advance(11)
+        retried = queue.lease("w2")
+        # Original worker finally reports; its lease was reaped, and the
+        # unit_id now identifies the requeued copy held by w2, so the
+        # late complete must not resolve w2's live lease.
+        assert not queue.complete(unit.unit_id, worker_id="w1")
+        assert queue.complete(retried.unit_id, worker_id="w2")
+        assert queue.all_resolved()
+
+    def test_heartbeat_on_expired_lease_fails(self):
+        clock = FakeClock()
+        queue = WorkQueue(_make_units(1), lease_ttl_seconds=10, clock=clock)
+        unit = queue.lease("w1")
+        clock.advance(11)
+        assert not queue.heartbeat(unit.unit_id)

--- a/tests/test_voice/test_usage_pricing.py
+++ b/tests/test_voice/test_usage_pricing.py
@@ -41,7 +41,9 @@ class TestOpenAIStyleParsing:
 
     def test_ga_payload(self):
         record = UsageRecord.from_openai_realtime_usage(
-            self.OPENAI_USAGE, provider="openai", model="gpt-realtime-1.5",
+            self.OPENAI_USAGE,
+            provider="openai",
+            model="gpt-realtime-1.5",
             scope_id="resp_1",
         )
         assert record.provider == "openai"
@@ -75,7 +77,9 @@ class TestOpenAIStyleParsing:
 
     def test_missing_details(self):
         record = UsageRecord.from_openai_realtime_usage(
-            {"input_tokens": 10, "output_tokens": 5}, provider="xai", model="xai-realtime"
+            {"input_tokens": 10, "output_tokens": 5},
+            provider="xai",
+            model="xai-realtime",
         )
         assert record.input_tokens == 10
         assert record.input_text_tokens is None
@@ -238,8 +242,12 @@ class TestPricing:
         # dated snapshot resolves via longest prefix
         r = lookup_rates("openai", "gpt-realtime-1.5-2026-03-01")
         assert r is not None and r.input_audio == 32.00
-        assert lookup_rates("deepgram", "aura-asteria-en").per_million_characters == 15.0
-        assert lookup_rates("deepgram", "aura-2-thalia-en").per_million_characters == 30.0
+        assert (
+            lookup_rates("deepgram", "aura-asteria-en").per_million_characters == 15.0
+        )
+        assert (
+            lookup_rates("deepgram", "aura-2-thalia-en").per_million_characters == 30.0
+        )
         assert lookup_rates("openai", "no-such-model") is None
 
     def test_openai_realtime_cost_math(self):


### PR DESCRIPTION
## Summary

Generic producer/consumer parallelism for tau runs, per [docs/designs/parallel-runner.md](docs/designs/parallel-runner.md) (included in this PR). Motivation: per-process throughput ceilings out around `--max-concurrency` 8–10 (main-process Python compute); more processes are needed to scale, as measured in the private repo (`bench-concurrency`: 1 proc @ conc 30 ≈ 272 sims/hr vs 6 procs @ conc 10 ≈ 626 sims/hr).

- **Work units** — one simulation attempt `(run_id, task_id, trial, seed)`; in-memory only, recomputed from the checkpoint on resume. The checkpoint stays the single source of truth; **storage layout and resume semantics are unchanged**.
- **`WorkQueue`** — thread-safe lease queue with TTL + heartbeats, retry-with-cap, and lease-time policy (per-provider caps, global cap).
- **Controller** — small FastAPI app; single checkpoint writer; leases units to workers; requeues `infrastructure_error` results instead of checkpointing them (up to 2 attempts, then a placeholder infra sim so runs terminate).
- **Workers** — separate processes (`tau2 worker --controller URL --slots N`, or spawned automatically); rebuild the config from the lease payload and execute the same `run_unit` code path as the local loop. Heartbeats run on a dedicated thread so multi-MB result posts can't starve them.
- **CLI** — `tau2 run --workers N [--provider-limit "openai=40,gemini=20"]`; `--workers 0` (default) keeps today's in-process behavior via the same queue.
- **`run_domains()` + `run_multiple.py --workers`** — many runs (each with its own results dir) under one controller sharing a worker fleet, with per-provider caps across all of them.

Scope per discussion: standard tau + tau-voice + tau-multi. Follow-ups (separate items): port the private-repo pool/preset drivers and remove tau-multi-specific orchestration; hyper-tau; multi-machine workers.

The first commit fixes pre-existing lint/format drift on main (from #454) so pre-commit's repo-wide `make check-all` passes.

## Post-review fixes (field-tested on live voice runs)

- **Bugbot** (`a0c2d83a`): `--llm-log-mode` now travels in the lease payload to worker processes; worker HTTP timeout widened for multi-MB `/complete` posts.
- **Heartbeats from a dedicated thread** (`bfd1321c`): a live 12-sim airline voice run (xai + openai realtime, 2 workers × 4 slots, `--provider-limit xai=2`) exposed heartbeat starvation — the main worker loop blocked on back-to-back multi-MB result posts, leases expired mid-sim, and the controller re-ran sims that were still going (correctness held: stale duplicates were discarded; the cost was wasted work and delay). Heartbeats now run on their own thread; workers log lost-lease/stale/requeued responses instead of ignoring them; `/lease`+`/heartbeat` get fail-fast 30s timeouts; default TTL 180s → 300s. A rerun of the same voice grid showed 0 lease losses, 0 stale results, 0 duplicate executions, with the xai cap holding at exactly 2 concurrent.
- **Run-scoped status keys** (`472ceb9b`): multi-run controllers keyed the progress display by `task_id.trial`, which collides across runs (8 in-flight sims displayed as "6 running"); keys are now `run_id/task_id.trial` when driving multiple runs. Display only.

## Testing

- 30 tests in `tests/test_runner/` (queue semantics incl. TTL/heartbeat/provider caps via fake clock; controller HTTP contract, infra-requeue, dead-unit flush; worker loop; heartbeat thread; multi-run monitor keys; local seam + resume).
- Full suite green except 15 pre-existing/environmental failures unrelated to this change (banking_knowledge retrieval e2e — confirmed failing with these changes stashed; `test_data_dir_fallback_to_source` env-dependent; `test_run_tasks_nl_assertions` flaky live-LLM, passes on rerun).
- Manual, mock domain (gpt-4o-mini): `--workers 0` baseline; `--workers 2` end-to-end; resume skips completed; kill mid-run then resume with a different worker count → 8/8 unique, 0 infra errors; two runs under one controller via `run_domains`.
- Manual, live text: airline, `xai/grok-3-mini` + `openai/gpt-4o-mini` under one controller, `xai=2` cap → 6/6 sims, xai peak concurrency exactly 2 (from sim timestamps), openai uncapped at 3.
- Manual, live voice: `run_multiple.py --workers 2 --provider-limit xai=2`, airline, xai + openai realtime, 6 tasks each — surfaced and then verified the heartbeat fix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
