### PR TITLE
Set default voice provider concurrency limits

### DIFF
--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -19,7 +19,7 @@ With --workers N the combos are registered as producers in one controller and
 run concurrently across N worker processes (see docs/designs/parallel-runner.md):
 
     python -m experiments.tau_voice.run_multiple --providers openai,gemini \\
-        --save-to data/exp/run --workers 4 --provider-limit openai=20,gemini=20
+        --save-to data/exp/run --workers 4
 """
 
 import argparse
@@ -33,6 +33,7 @@ from tau2.config import DEFAULT_AUDIO_NATIVE_MODELS, DEFAULT_LLM_USER, DEFAULT_S
 
 DEFAULT_DOMAINS = ["airline", "retail"]
 DEFAULT_COMPLEXITIES = ["control", "regular"]
+DEFAULT_PROVIDER_LIMITS = "gemini=40,openai=40,xai=40,livekit=10,nova=5,qwen=5"
 
 
 @dataclass
@@ -223,8 +224,9 @@ def main():
     parser.add_argument(
         "--provider-limit",
         type=str,
-        default=None,
-        help='Per-provider concurrency caps with --workers, e.g. "openai=20,gemini=20".',
+        default=DEFAULT_PROVIDER_LIMITS,
+        help="Per-provider concurrency caps with --workers. "
+        f"Default: {DEFAULT_PROVIDER_LIMITS}",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- add default provider concurrency limits to the tau-voice multi-runner
- cap Gemini, OpenAI, and xAI at 40; LiveKit at 10; Nova and Qwen at 5
- keep explicit provider-limit values available as overrides

## Verification
- Ruff lint passed across the repository
- Ruff formatting check passed across the repository
- Python syntax compilation passed for run_multiple.py