### PR TITLE
AAI voice provider: TTS concurrency bound, failure/STT reports, and the A/B runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ OPENROUTER_API_KEY=<your_key_here>
 
 # AAI voice-agent host WebSocket URL (local host mode)
 # AAI_WS_URL=ws://localhost:3000/websocket
+# Required only when AAI_WS_URL points at a *deployed* agent on the AAI
+# platform: host mode there replaces the agent's prompt and tools while
+# spending the owner's credentials, so the platform requires the owner's key.
+# A local `aai dev` host gates on AAI_ALLOW_HOST and ignores this.
+# ASSEMBLYAI_API_KEY=<your_key_here>
 
 # ── Voice Persona Overrides ────────────────────────────────────────────
 # The default voice IDs are Sierra-internal and won't work for external users.

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ DEEPGRAM_API_KEY=<your_key_here>
 # Required for banking_knowledge qwen_embeddings* retrieval configs (via OpenRouter)
 OPENROUTER_API_KEY=<your_key_here>
 
+# AAI voice-agent host WebSocket URL (local host mode)
+# AAI_WS_URL=ws://localhost:3000/websocket
+
 # ── Voice Persona Overrides ────────────────────────────────────────────
 # The default voice IDs are Sierra-internal and won't work for external users.
 # Create your own voices in ElevenLabs and set the IDs here.

--- a/docs/superpowers/plans/2026-07-15-aai-voice-agent-host.md
+++ b/docs/superpowers/plans/2026-07-15-aai-voice-agent-host.md
@@ -1,0 +1,425 @@
+# aai voice-agent host + tau2 `aai` provider — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the aai framework a "voice-agent host" (external harness supplies prompt + tool schemas per session; tool calls relay to the client) and add a tau2 `aai` audio-native provider that benchmarks it, with tool execution in tau2's environment.
+
+**Architecture:** Phase A (repo `~/Code/aai`) adds host mode to the WS protocol + runtime. Phase B (repo `~/Code/tau2-bench`) adds a `DiscreteTimeAdapter`-based `aai` provider that injects the domain policy + tools, streams PCM16 audio (μ-law↔PCM16 conversion), and returns tool results.
+
+**Tech Stack:** aai — TypeScript, zod, `ws`, vitest, the `@alexkroman1/aai/host` runtime. tau2 — Python 3.12+, `websockets`, Pydantic v2, pytest, `uv`.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-07-15-aai-voice-agent-host-design.md`.
+- aai WS endpoint: `ws://localhost:3000/websocket`. Client sends `config` first, then **raw binary PCM16** audio frames. Server streams **binary PCM16** audio + JSON events.
+- aai audio: **PCM16, input 16000 Hz, output 24000 Hz** (`DEFAULT_STT_SAMPLE_RATE`/`DEFAULT_TTS_SAMPLE_RATE`).
+- aai `ToolSchema` = `{ type:"function", name, description, parameters: <JSON Schema object> }`. Parameters are JSON Schema **directly** (no zod conversion).
+- aai `ExecuteTool` signature: `(name, args, sessionId?, messages?, opts?: { signal?, toolCallId? }) => Promise<unknown>`.
+- aai runtime hooks: `createRuntime({ agent, env, executeTool?, toolSchemas?, systemPrompt?/via agent, stt?, llm?, tts? })`; `toolSchemas` is **required when** `executeTool` is set.
+- Host mode is gated behind env `AAI_ALLOW_HOST` (default **on** in the dev server, off otherwise).
+- tau2 tool schema source: `tool.openai_schema` → `{"type":"function","function":{"name","description","parameters"}}`.
+- tau2 telephony format is μ-law 8 kHz mono; conversion via `tau2.voice.utils.audio_preprocessing` (`convert_to_pcm16`, `convert_to_ulaw`, `resample_audio`).
+- New protocol messages: client→server `tool_result { type:"tool_result", toolCallId, result, error? }`; client `config` gains optional `host { systemPrompt, greeting?, tools: ToolSchema[] }`.
+
+---
+
+# Phase A — aai host mode (repo `~/Code/aai/agent`)
+
+### Task A1: Map the session config → runtime wiring (discovery + contract)
+
+Unfamiliar-code discovery. Produces the exact integration contract the next tasks implement against. No production code changes.
+
+**Files:** read `packages/aai/host/server.ts`, `packages/aai/host/ws-handler.ts`, `packages/aai/host/session-core.ts`, `packages/aai/host/runtime.ts` (`startSession`, `SessionStartOptions`, `RuntimeOptions`), `packages/aai-cli/_dev-server.ts`, `packages/aai-server/transport-websocket.ts`.
+
+- [ ] **Step 1: Answer these questions in a report**, each with a `file:line` citation:
+  1. Where is the inbound `config` message parsed for a WS session, and where is `runtime.startSession(ws, startOpts)` called?
+  2. Does `SessionStartOptions` (or `startSession`) already allow per-session overrides of system prompt, `toolSchemas`, and `executeTool`? If yes, name the fields. If no, what is the smallest change to thread a per-session `{ systemPrompt, toolSchemas, executeTool }` into the session's pipeline/S2S transport (`buildPipelineTransport` in `runtime.ts:382`)?
+  3. How does an inbound WS JSON message get dispatched to a handler (so a new `tool_result` type can be routed), and how does a session send a JSON event to the client (to emit `tool_call`)?
+  4. What does `_dev-server.ts` pass as the agent, and how would a session with `config.host` bypass the deployed agent?
+  5. The zod schema location for inbound client messages (confirm it is `packages/aai-server/schemas.ts` vs a schema in `packages/aai`).
+
+- [ ] **Step 2: Write the contract** to `~/Code/aai/agent/HOST_MODE_CONTRACT.md` (gitignored scratch): the chosen wiring point, the per-session override mechanism (field names or the new plumbing), and the dispatch/send functions for `tool_result`/`tool_call`. Subsequent tasks cite this.
+
+No test. Deliverable = the contract doc.
+
+---
+
+### Task A2: Protocol schema — `config.host` + `tool_result`
+
+**Files:**
+- Modify: the inbound-client-message zod schema (confirmed in A1; likely `packages/aai-server/schemas.ts` and/or `packages/aai/sdk/_internal-types.ts`)
+- Test: the sibling schema test (e.g. `packages/aai-server/schemas.test.ts`)
+
+**Interfaces:**
+- Produces: `HostConfigSchema` = `{ systemPrompt: string (min 1), greeting?: string, tools: ToolSchemaSchema[] }`; `config` message gains optional `host: HostConfigSchema`; new inbound message `{ type:"tool_result", toolCallId: string (min 1), result: string, error?: string }` added to the client→server union.
+
+- [ ] **Step 1: Write the failing test** (adapt to the repo's vitest style; use the real schema import path from A1):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { ClientMessageSchema } from "./<path-from-A1>.ts"; // the inbound union
+
+describe("host mode schema", () => {
+  it("accepts config.host with tool schemas", () => {
+    const msg = {
+      type: "config", audioFormat: "pcm16", sampleRate: 16000, ttsSampleRate: 24000,
+      host: {
+        systemPrompt: "You are a retail agent.",
+        tools: [{ type: "function", name: "get_order_details",
+          description: "Look up an order.",
+          parameters: { type: "object", properties: { order_id: { type: "string" } }, required: ["order_id"] } }],
+      },
+    };
+    expect(ClientMessageSchema.parse(msg)).toMatchObject({ host: { systemPrompt: "You are a retail agent." } });
+  });
+
+  it("accepts tool_result", () => {
+    expect(ClientMessageSchema.parse({ type: "tool_result", toolCallId: "c1", result: "{}" }))
+      .toMatchObject({ type: "tool_result", toolCallId: "c1" });
+  });
+
+  it("rejects host with empty systemPrompt", () => {
+    expect(() => ClientMessageSchema.parse({
+      type: "config", audioFormat: "pcm16", sampleRate: 16000, ttsSampleRate: 24000,
+      host: { systemPrompt: "", tools: [] },
+    })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect FAIL** (`config.host`/`tool_result` unknown). Command: the repo's test runner scoped to the schema test (e.g. `npx vitest run <schema>.test.ts` or `deno task test` — use what the repo's `package.json`/`CLAUDE.md` prescribes).
+
+- [ ] **Step 3: Implement** — reuse the existing `ToolSchemaSchema` (`packages/aai/sdk/_internal-types.ts`) for `host.tools`; add `HostConfigSchema`; add `host: HostConfigSchema.optional()` to the config message; add the `tool_result` variant to the inbound union.
+
+- [ ] **Step 4: Run it, expect PASS.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(host): config.host + tool_result protocol schema"` (on a new branch `feat/voice-agent-host` in the aai repo).
+
+---
+
+### Task A3: Host runtime — inject prompt/tools + relay executeTool
+
+**Files:**
+- Modify: the WS session wiring point (from A1) + a new helper `packages/aai/host/host-mode.ts` for the relay executor
+- Test: `packages/aai/host/host-mode.test.ts`
+
+**Interfaces:**
+- Consumes: A2 schemas; `createRuntime`/`startSession`/`buildPipelineTransport` (per A1 contract); `ExecuteTool`, `ToolSchema`.
+- Produces: `createRelayExecuteTool({ send, register, timeoutMs })` returning `{ executeTool: ExecuteTool, onToolResult(msg), dispose() }` where:
+  - `executeTool(name, args, sessionId, messages, opts)` generates/uses `opts.toolCallId`, sends `{type:"tool_call", toolCallId, toolName:name, args}` via `send`, and returns a Promise stored by `toolCallId`.
+  - `onToolResult({toolCallId, result, error})` resolves/rejects the stored Promise (JSON-parse `result`).
+  - a `timeoutMs` (default 120000) rejects the Promise with a tool error and cleans up.
+- A session with `config.host` present builds its pipeline with `systemPrompt = host.systemPrompt`, `toolSchemas = host.tools`, `executeTool = relay.executeTool`, gated by `AAI_ALLOW_HOST` (default on in dev). Inbound `tool_result` routes to `relay.onToolResult`.
+
+- [ ] **Step 1: Write the failing test** for the relay executor (pure, no WS):
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { createRelayExecuteTool } from "./host-mode.ts";
+
+describe("relay executeTool", () => {
+  it("emits tool_call and resolves on matching tool_result", async () => {
+    const sent: any[] = [];
+    const relay = createRelayExecuteTool({ send: (m) => sent.push(m), timeoutMs: 1000 });
+    const p = relay.executeTool("get_order_details", { order_id: "#W1" }, "s1", [], { toolCallId: "c1" });
+    expect(sent[0]).toMatchObject({ type: "tool_call", toolCallId: "c1", toolName: "get_order_details", args: { order_id: "#W1" } });
+    relay.onToolResult({ toolCallId: "c1", result: JSON.stringify({ status: "pending" }) });
+    await expect(p).resolves.toMatchObject({ status: "pending" });
+  });
+
+  it("times out when no tool_result arrives", async () => {
+    vi.useFakeTimers();
+    const relay = createRelayExecuteTool({ send: () => {}, timeoutMs: 50 });
+    const p = relay.executeTool("x", {}, "s1", [], { toolCallId: "c2" });
+    vi.advanceTimersByTime(60);
+    await expect(p).rejects.toThrow();
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run it, expect FAIL** (`host-mode.ts` missing).
+
+- [ ] **Step 3: Implement `host-mode.ts`** — a `Map<string, {resolve, reject, timer}>`; `executeTool` creates the entry, sends the `tool_call`, returns the Promise; `onToolResult` looks up by `toolCallId`, clears the timer, JSON-parses `result` (or rejects on `error`); timeout rejects + deletes. Then wire it at the session point (A1): when `config.host` and `AAI_ALLOW_HOST`, build the session pipeline with the host prompt/tools/executeTool and route inbound `tool_result` to `relay.onToolResult`.
+
+- [ ] **Step 4: Run it, expect PASS.**
+
+- [ ] **Step 5: Integration test** — extend the repo's existing WS integration test (`packages/aai-server/ws-integration.test.ts` pattern): open a session with `config.host`, drive a fake LLM (the repo's test LLM provider) to call a tool, assert the client receives `tool_call` and that sending `tool_result` unblocks the turn (`reply_done`). If the repo's test harness can't easily force a tool call, assert the wiring path (host runtime built, `tool_result` routed) and note the live check is deferred to Task A4.
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(host): relay executeTool + per-session host prompt/tools"`.
+
+---
+
+### Task A4: Local host-mode smoke check
+
+**Files:** none (verification). Optionally add `packages/aai-cli/scripts/host-smoke.mjs`.
+
+- [ ] **Step 1:** Start the dev server (`npm run dev` / the repo's dev command; confirm `AAI_ALLOW_HOST` defaults on).
+- [ ] **Step 2:** Connect a throwaway node/deno script to `ws://localhost:3000/websocket`, send `config` with a `host` block (systemPrompt "You are a test agent. When asked, call ping." + one tool `ping`), send a short PCM16 silence buffer, and log inbound events. Confirm: server accepts `config.host`, session becomes ready, and if the model calls `ping` you receive a `tool_call` and can reply with `tool_result`. Report the observed event sequence.
+- [ ] **Step 3:** If host mode isn't reachable (gating/wiring), fix and re-run before declaring Phase A done.
+
+---
+
+# Phase B — tau2 `aai` provider (repo `~/Code/tau2-bench`)
+
+### Task B1: Event models (`aai/events.py`)
+
+**Files:**
+- Create: `src/tau2/voice/audio_native/aai/__init__.py` (empty marker)
+- Create: `src/tau2/voice/audio_native/aai/events.py`
+- Test: `tests/test_voice/test_audio_native/test_aai_events.py`
+
+**Interfaces:**
+- Produces: `parse_aai_event(data: dict) -> BaseAAIEvent`; classes `AAIConfigEvent`, `AAISpeechStartedEvent`, `AAISpeechStoppedEvent`, `AAIUserTranscriptEvent{text, turn_order?}`, `AAIAgentTranscriptEvent{text}`, `AAIToolCallEvent{tool_call_id, tool_name, args}`, `AAIReplyDoneEvent`, `AAIAudioDoneEvent`, `AAICancelledEvent`, `AAIResetEvent`, `AAIIdleTimeoutEvent`, `AAIErrorEvent{code, message}`, `AAICustomEvent{event, data}`, `AAITimeoutEvent`, `AAIUnknownEvent`. (Binary audio frames are NOT parsed here — handled in the provider.)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from tau2.voice.audio_native.aai.events import (
+    AAIAgentTranscriptEvent, AAIToolCallEvent, AAIErrorEvent, AAIUnknownEvent,
+    parse_aai_event,
+)
+
+def test_parse_agent_transcript():
+    ev = parse_aai_event({"type": "agent_transcript", "text": "hello"})
+    assert isinstance(ev, AAIAgentTranscriptEvent) and ev.text == "hello"
+
+def test_parse_tool_call_maps_fields():
+    ev = parse_aai_event({"type": "tool_call", "toolCallId": "c1", "toolName": "get_order_details", "args": {"order_id": "#W1"}})
+    assert isinstance(ev, AAIToolCallEvent)
+    assert (ev.tool_call_id, ev.tool_name, ev.args) == ("c1", "get_order_details", {"order_id": "#W1"})
+
+def test_parse_error():
+    ev = parse_aai_event({"type": "error", "code": "llm", "message": "boom"})
+    assert isinstance(ev, AAIErrorEvent) and ev.code == "llm"
+
+def test_unknown():
+    assert isinstance(parse_aai_event({"type": "nope"}), AAIUnknownEvent)
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `uv run --extra dev --extra voice python -m pytest tests/test_voice/test_audio_native/test_aai_events.py -v`
+
+- [ ] **Step 3: Implement `events.py`** — Pydantic v2 models with `ConfigDict(extra="ignore")`, camelCase JSON fields mapped via `Field(alias=...)` + `populate_by_name=True` (e.g. `tool_call_id: str = Field("", alias="toolCallId")`, `tool_name` ← `toolName`). `_EVENT_TYPE_MAP` + `parse_aai_event` mirroring `assemblyai/events.py`. Include `AAITimeoutEvent`/`AAIUnknownEvent`.
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(voice): aai event models"`.
+
+---
+
+### Task B2: Provider client (`aai/provider.py`)
+
+**Files:**
+- Create: `src/tau2/voice/audio_native/aai/provider.py`
+- Modify: `src/tau2/config.py` (aai constants — see Global Constraints)
+- Test: `tests/test_voice/test_audio_native/test_aai_provider.py`
+
+**Interfaces:**
+- Consumes: B1 events; `Tool` (`tool.openai_schema`).
+- Produces:
+  - `AAIVADConfig(BaseModel)` — empty (aai does turn detection server-side); present for interface parity.
+  - `AAIVoiceAgentProvider(api_key=None, ws_url=DEFAULT_AAI_WS_URL, input_sample_rate=16000, tts_sample_rate=24000, system_prompt="", tools=())` with: `connect()` (open WS, send `config` incl. `host`, await server `config`), `send_audio(pcm16: bytes)` (binary frame), `send_tool_result(tool_call_id, result)` (`{"type":"tool_result",...}`), `receive_events()`/`receive_events_for_duration()` (JSON→events; **binary frames yielded as `AAIAudioChunkEvent(pcm16=<bytes>)`**), `is_connected`.
+  - Pure builders: `_build_config_message(system_prompt, tools)` and `_format_tools_for_api(tools) -> list[ToolSchema-dict]`.
+
+- [ ] **Step 1: Write the failing test** (pure builders, no network):
+
+```python
+from tau2.environment.tool import Tool
+from tau2.voice.audio_native.aai.provider import AAIVoiceAgentProvider
+
+def _p():
+    return AAIVoiceAgentProvider(system_prompt="You are a retail agent.")
+
+def test_config_message_has_host_and_pcm16():
+    def get_order(order_id: str) -> str:
+        """Look up an order.
+
+        Args:
+            order_id: the id.
+        """
+        return order_id
+    p = AAIVoiceAgentProvider(system_prompt="POLICY", tools=[Tool(func=get_order)])
+    msg = p._build_config_message("POLICY", p.tools)
+    assert msg["type"] == "config" and msg["audioFormat"] == "pcm16"
+    assert msg["sampleRate"] == 16000 and msg["ttsSampleRate"] == 24000
+    assert msg["host"]["systemPrompt"] == "POLICY"
+    t0 = msg["host"]["tools"][0]
+    assert t0["type"] == "function" and t0["name"] == "get_order"
+    assert "parameters" in t0 and "function" not in t0
+
+def test_tool_result_shape(monkeypatch):
+    # _build not needed; assert send_tool_result payload via a fake ws captured in B3-style test
+    pass
+```
+
+- [ ] **Step 2: Run, expect FAIL** (module/const missing).
+
+- [ ] **Step 3: Add config constants** to `src/tau2/config.py` near the provider block:
+
+```python
+# =============================================================================
+# AAI PROVIDER (local voice-agent host; overridable URL/rates)
+# =============================================================================
+DEFAULT_AAI_WS_URL = "ws://localhost:3000/websocket"  # overridable via AAI_WS_URL
+DEFAULT_AAI_MODEL = "host"  # fixed, determined by endpoint
+DEFAULT_AAI_INPUT_SAMPLE_RATE = 16000  # PCM16 sent to aai (STT)
+DEFAULT_AAI_OUTPUT_SAMPLE_RATE = 24000  # PCM16 received from aai (TTS)
+```
+
+- [ ] **Step 4: Implement `provider.py`** — mirror `assemblyai/provider.py` structure. `_format_tools_for_api` flattens `tool.openai_schema["function"]` into `{type:"function", name, description, parameters}`. `_build_config_message` returns `{"type":"config","audioFormat":"pcm16","sampleRate":self.input_sample_rate,"ttsSampleRate":self.tts_sample_rate,"host":{"systemPrompt":system_prompt,"tools":[...]}}`. `connect()` reads `AAI_WS_URL` env (fallback `DEFAULT_AAI_WS_URL`), opens WS, sends the config JSON, waits for server `config` (bounded per-frame `asyncio.wait_for`, buffering non-handshake frames — reuse the assemblyai handshake pattern). `receive_events()`: on `recv()`, if `bytes` → yield `AAIAudioChunkEvent(pcm16=raw)`; if `str` → `parse_aai_event(json.loads(...))`. `send_audio` sends bytes; `send_tool_result` sends the JSON. Add `AAIAudioChunkEvent` to `events.py` (or define in provider) as needed by B3.
+
+- [ ] **Step 5: Run, expect PASS** (the config-builder test).
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(voice): aai provider client (config.host + pcm16)"`.
+
+---
+
+### Task B3: Discrete-time adapter (`aai/discrete_time_adapter.py`)
+
+**Files:**
+- Create: `src/tau2/voice/audio_native/aai/discrete_time_adapter.py`
+- Test: `tests/test_voice/test_audio_native/test_aai_adapter.py`
+
+**Interfaces:**
+- Consumes: `DiscreteTimeAdapter`, `TickResult`, `UtteranceTranscript`, `BackgroundAsyncLoop`, B1 events, B2 provider; audio utils `convert_to_pcm16`, `convert_to_ulaw`, `resample_audio` (`tau2.voice.utils.audio_preprocessing`), `AudioData`/`AudioFormat`/`AudioEncoding` (`tau2.data_model.audio`).
+- Produces: `DiscreteTimeAAIAdapter(tick_duration_ms, send_audio_instant=True, reasoning_effort=None, voice=None, provider=None, system_prompt="", tools=())`. External format = telephony μ-law 8k (default). Public `_process_event(result, event)`.
+
+- [ ] **Step 1: Write the failing test** (drive `_process_event` with synthetic events; audio helpers stubbed via small μ-law/PCM buffers):
+
+```python
+from tau2.voice.audio_native.aai.discrete_time_adapter import DiscreteTimeAAIAdapter
+from tau2.voice.audio_native.aai.events import (
+    AAIAgentTranscriptEvent, AAIToolCallEvent, AAISpeechStartedEvent, AAIReplyDoneEvent, AAIAudioChunkEvent,
+)
+from tau2.voice.audio_native.tick_result import TickResult
+
+def _a():
+    return DiscreteTimeAAIAdapter(tick_duration_ms=200, send_audio_instant=True, system_prompt="P")
+
+def _r():
+    return TickResult(tick_number=1, audio_sent_bytes=0, audio_sent_duration_ms=0.0, bytes_per_tick=1600, bytes_per_second=8000)
+
+def test_reasoning_effort_rejected():
+    import pytest
+    with pytest.raises(ValueError):
+        DiscreteTimeAAIAdapter(tick_duration_ms=200, reasoning_effort="high")
+
+def test_audio_chunk_converted_and_appended():
+    a, r = _a(), _r()
+    # 24kHz PCM16: 240 samples = 480 bytes -> ~10ms; after resample to 8k ulaw -> 80 bytes
+    a._process_event(r, AAIAudioChunkEvent(pcm16=b"\x00\x01" * 240))
+    assert r.agent_audio_bytes > 0  # some μ-law bytes appended
+
+def test_agent_transcript_overwrites():
+    a, r = _a(), _r()
+    a._current_item_id = "t1"
+    a._process_event(r, AAIAgentTranscriptEvent(text="hi"))
+    a._process_event(r, AAIAgentTranscriptEvent(text="hi there"))
+    assert a._utterance_transcripts["t1"].transcript_received == "hi there"
+
+def test_tool_call_recorded():
+    a, r = _a(), _r()
+    a._process_event(r, AAIToolCallEvent(tool_call_id="c1", tool_name="get_order", args={"x": 1}))
+    assert (r.tool_calls[0].id, r.tool_calls[0].name, r.tool_calls[0].arguments) == ("c1", "get_order", {"x": 1})
+
+def test_barge_in_truncates():
+    a, r = _a(), _r()
+    a._process_event(r, AAISpeechStartedEvent())
+    assert r.was_truncated and "speech_started" in r.vad_events
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement** — mirror `assemblyai/discrete_time_adapter.py` for lifecycle/`_execute_tick`/`_flush_pending_tool_results`. Differences:
+  - `connect()` passes `system_prompt`/`tools` to the provider (so `config.host` carries them).
+  - **Audio out (send):** in `_execute_tick`, before sending, convert the tick's μ-law-8k `user_audio` → PCM16-16k: `resample_audio(convert_to_pcm16(AudioData(user_audio, TELEPHONY_FORMAT)), 16000)` → `.data`; send those bytes via `provider.send_audio`. Compute `_chunk_size` from the 16k PCM16 rate.
+  - **Audio in (`_process_event` for `AAIAudioChunkEvent`):** wrap `event.pcm16` as PCM16-24k `AudioData`, `resample_audio(..., 8000)` → `convert_to_ulaw(...)` → append `.data` to `result.agent_audio_chunks` under the current turn id; `UtteranceTranscript.add_audio`. Respect `result.skip_item_id` (barge-in) exactly like assemblyai.
+  - `AAIAgentTranscriptEvent` → set `ut.transcript_received = event.text` (overwrite). `AAIToolCallEvent` → `ToolCall(id=tool_call_id, name=tool_name, arguments=args)`. `AAISpeechStartedEvent` → barge-in truncate + clear buffer. `AAIReplyDoneEvent`/`AAIAudioDoneEvent` → turn end. `AAIErrorEvent` → `logger.error`. Loud-failure guard on reply/turn end with zero audio+transcript (as in assemblyai).
+  - `_flush_pending_tool_results`: for each `(call_id, result_str, _rr, _err)` → `await self.provider.send_tool_result(call_id, result_str)`.
+  - Use a running turn id: set `_current_item_id` on first audio/transcript of a turn; reset on `reply_done`.
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(voice): aai discrete-time adapter with pcm16 conversion"`.
+
+---
+
+### Task B4: Registration (config, factory, Literal, CLI, agent VAD, exports)
+
+**Files:**
+- Modify: `src/tau2/config.py` (registry dicts), `src/tau2/voice/audio_native/adapter.py` (factory + endpoint tuple), `src/tau2/data_model/simulation.py` (Literal), `src/tau2/cli.py` (choices), `src/tau2/agent/discrete_time_audio_native_agent.py` (**VAD branch + Literal + Union**), `src/tau2/voice/audio_native/aai/__init__.py` (exports)
+- Test: `tests/test_voice/test_audio_native/test_aai_registration.py`
+
+**Interfaces:**
+- Produces: `create_adapter(provider="aai", ...)` → `DiscreteTimeAAIAdapter`; `AudioNativeConfig(provider="aai")` validates; agent builds `AAIVADConfig` for `provider="aai"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+from tau2.config import AUDIO_NATIVE_PROVIDER_TYPES, DEFAULT_AUDIO_NATIVE_MODELS, DEFAULT_AUDIO_NATIVE_REASONING_EFFORT
+from tau2.data_model.simulation import AudioNativeConfig
+from tau2.voice.audio_native.adapter import create_adapter
+from tau2.voice.audio_native.aai.discrete_time_adapter import DiscreteTimeAAIAdapter
+
+def test_registry():
+    assert DEFAULT_AUDIO_NATIVE_MODELS["aai"] == "host"
+    assert DEFAULT_AUDIO_NATIVE_REASONING_EFFORT["aai"] is None
+    assert AUDIO_NATIVE_PROVIDER_TYPES["aai"] == "audio_native"
+
+def test_config_literal():
+    assert AudioNativeConfig(provider="aai").provider == "aai"
+
+def test_factory_builds_without_connecting():
+    adapter, model = create_adapter(provider="aai", tick_duration_ms=200, model=None)
+    assert isinstance(adapter, DiscreteTimeAAIAdapter) and model == "host"
+    assert adapter.is_connected is False
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement registration** — add `"aai"` to `DEFAULT_AUDIO_NATIVE_MODELS` (→ `DEFAULT_AAI_MODEL`), `DEFAULT_AUDIO_NATIVE_REASONING_EFFORT` (`None`), `AUDIO_NATIVE_PROVIDER_TYPES` (`"audio_native"`); add `"aai"` to `_PROVIDERS_WITH_ENDPOINT_DETERMINED_MODEL` and a `create_adapter()` branch constructing `DiscreteTimeAAIAdapter(tick_duration_ms=..., send_audio_instant=..., reasoning_effort=...)`; add `"aai"` to the `AudioNativeConfig.provider` Literal + description; add `"aai"` to the CLI `--audio-native-provider` choices; in `discrete_time_audio_native_agent.py` add an `elif provider == "aai":` branch importing and building `AAIVADConfig()`, and add `"aai"` to that file's `AudioNativeProvider` Literal + `VADConfig` union + TYPE_CHECKING import; fill `aai/__init__.py` exports.
+
+- [ ] **Step 4: Run, expect PASS**, then the full new group + ruff:
+
+```bash
+uv run --extra dev --extra voice python -m pytest tests/test_voice/test_audio_native/ -k aai -q
+uv run ruff check src/tau2/voice/audio_native/aai/ && uv run ruff format --check src/tau2/voice/audio_native/aai/
+```
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(voice): register aai audio-native provider"`.
+
+---
+
+### Task B5: Standalone smoke test + e2e
+
+**Files:**
+- Create: `src/tau2/voice/audio_native/aai/test_provider_standalone.py`
+- Modify: `.env.example` (comment: `AAI_WS_URL=ws://localhost:3000/websocket`), `src/tau2/voice/README.md` + `src/tau2/voice/audio_native/README.md` (provider rows)
+
+- [ ] **Step 1: Write the standalone smoke script** (mirrors the assemblyai one) — connect to `AAI_WS_URL`, send `config.host` with a tiny policy + one tool, push μ-law→PCM16 silence, collect events, assert `config`+events flow, exit 0; skip if the URL isn't reachable (short connect timeout → clear SKIP message).
+
+- [ ] **Step 2: Run it against the live dev server** — `uv run python src/tau2/voice/audio_native/aai/test_provider_standalone.py` (aai dev server must be running on :3000). Report the event sequence. **Verify open items:** binary audio arrives and decodes; `tool_call` round-trips via `tool_result`; agent produces a first turn.
+
+- [ ] **Step 3: Docs/env edits** (provider tables + `AAI_WS_URL`).
+
+- [ ] **Step 4: Commit** — `git commit -m "feat(voice): aai provider smoke test + docs"`.
+
+- [ ] **Step 5: End-to-end** (manual; aai dev server running, ElevenLabs personas + Deepgram + user-llm keys set):
+
+```bash
+uv run tau2 run --domain retail --audio-native --audio-native-provider aai \
+  --user-llm gpt-4.1 --speech-complexity control --num-tasks 1 --verbose-logs
+```
+Confirm a trajectory is produced with agent audio, tool calls executed by tau2's env, and a reward computed. Report the actual outcome.
+
+---
+
+## Self-Review
+
+**Spec coverage:** host mode protocol (`config.host` + `tool_result`) → A2; relay executeTool + per-session prompt/tools → A3; aai discovery of wiring → A1; local host verification → A4; tau2 events → B1; provider client + config.host builder + constants → B2; adapter + **PCM16↔μ-law conversion** + tool relay → B3; registration incl. **agent VAD branch** → B4; smoke + docs + e2e → B5. ✓
+
+**Placeholder scan:** aai Tasks A2/A3 reference paths "from A1" because the exact WS-session file is the one genuinely-unknown integration point in an unfamiliar repo; A1 exists precisely to resolve it and write the contract before code. All tau2 tasks carry concrete code. No "add error handling"-style hand-waves.
+
+**Type consistency:** provider `AAIVoiceAgentProvider`, adapter `DiscreteTimeAAIAdapter`, VAD `AAIVADConfig`, events `AAI*` + `parse_aai_event`, audio event `AAIAudioChunkEvent`, `ToolCall(id,name,arguments)`, `send_tool_result(call_id, result)` (2 args, matches flush) — consistent across B1–B5. aai `ToolSchema` `{type,name,description,parameters}` and `ExecuteTool(name,args,sessionId?,messages?,opts?)` used as defined in A2/A3.
+
+**Scope:** Phase A gates Phase B's live tests (B5) but B1–B4 (code + unit tests) are independent of Phase A and can proceed in parallel; note this at execution time.

--- a/docs/superpowers/specs/2026-07-15-aai-voice-agent-host-design.md
+++ b/docs/superpowers/specs/2026-07-15-aai-voice-agent-host-design.md
@@ -1,0 +1,98 @@
+# aai voice-agent host + tau2 `aai` provider
+
+**Date:** 2026-07-15
+**Status:** Approved — ready for implementation planning
+**Repos:** `~/Code/aai` (host-mode feature) and `~/Code/tau2-bench` (new `aai` provider)
+
+## Goal
+
+Benchmark the **aai** voice-agent framework on tau2. To do that, aai must become a
+**voice-agent host**: a mode where an *external* harness (tau2) supplies the system
+prompt + tool schemas at connect time, aai runs its own STT→LLM→TTS pipeline, and
+aai **relays each tool call back to the harness** to execute (so tau2's environment
+runs the domain tools against its DB — which is what the reward scores). A new tau2
+`aai` audio-native provider drives this over aai's existing WebSocket.
+
+### Why a host mode is required
+
+aai agents are normally defined in TypeScript (`agent({ systemPrompt, tools:{ name: tool({parameters, execute}) } })`) and their tools execute **server-side in a sandbox** against `ctx.kv`. tau2 requires the opposite: the agent runs the *domain's* policy + tool *schemas*, and **tau2's Python environment executes the tools**. Host mode bridges this: prompt + tool *schemas* are injected per session, and tool *execution* is relayed to the tau2 client.
+
+## Confirmed facts (from code inspection)
+
+- WS endpoint: `ws://localhost:3000/websocket` (`?sessionId=`/`?resume=1` optional). Server name `pipeline-simple`.
+- Client→server: `config` first (`{type:"config", audioFormat:"pcm16", sampleRate, ttsSampleRate, sessionId?}`), then **raw binary PCM16** audio frames; control msgs `audio_ready` / `cancel` / `reset` / `history{messages:[{role,content}]}`.
+- Server→client: **binary PCM16** audio (TTS) + JSON events `config`, `speech_started`, `speech_stopped`, `user_transcript{text,turnOrder?}`, `agent_transcript{text}`, `tool_call{toolCallId,toolName,args}`, `tool_call_done{toolCallId,result}`, `reply_done`, `audio_done`, `cancelled`, `reset`, `idle_timeout`, `error{code,message}`, `custom_event{event,data}`.
+- Default sample rates: **input 16000 Hz, output 24000 Hz**, PCM16 (`DEFAULT_STT_SAMPLE_RATE` / `DEFAULT_TTS_SAMPLE_RATE`; compat fixture `sampleRate:16000, ttsSampleRate:24000`).
+- The aai package already has a `host/` runtime (`runtime.ts`, `s2s.ts`, `session-core.ts`, `runtime-config.ts`, providers, `pipeline-transport.ts`) — the home for host mode.
+- Server message schemas are validated with zod in `packages/aai-server/schemas.ts` (+ the pipeline transport/session schemas in `packages/aai`). Tool execution + relay must integrate with the aai `host` runtime and its ws transport.
+
+## Part A — aai-side: host mode
+
+**Protocol additions (backward-compatible):**
+
+1. Extend the client `config` message with an optional `host` block:
+   ```
+   { type: "config", audioFormat: "pcm16", sampleRate, ttsSampleRate,
+     host: {
+       systemPrompt: string,
+       greeting?: string,
+       tools: Array<{ name: string, description: string, parameters: <JSON Schema object> }>
+     } }
+   ```
+   When `host` is present, the server builds the agent **dynamically** from it (instead of the deployed agent).
+2. Add a client→server message `tool_result`:
+   ```
+   { type: "tool_result", toolCallId: string, result: <JSON string>, error?: string }
+   ```
+
+**Behavior:**
+- Each injected tool's `execute(args, ctx)` emits the existing `tool_call{toolCallId, toolName, args}` and returns a Promise that resolves when the matching `tool_result` arrives (or rejects on `error`). A per-call **timeout** (configurable, default ~120s) rejects with a tool error so the pipeline continues.
+- `systemPrompt` and `greeting` come from the injected block. Everything else (pcm16 audio in/out, transcripts, `reply_done`, `audio_done`, barge-in, `speech_started/stopped`) is unchanged.
+- The injected `parameters` JSON Schema is converted to the internal tool-parameter representation (the runtime currently takes zod; add a JSON-Schema → runtime-schema path, or accept JSON Schema directly for host tools).
+
+**Safety:** host mode lets a client run arbitrary prompts/tools, so gate it behind an env flag (e.g. `AAI_ALLOW_HOST`, default **on for local dev**, off in production deploys). The relayed tools do NOT run sandbox code — they only round-trip to the client — so the sandbox threat surface is unchanged.
+
+**Files (aai):** primarily `packages/aai-server/schemas.ts` (config `host` + `tool_result`), the ws transport / orchestrator that dispatches inbound messages (`transport-websocket.ts`, `orchestrator.ts`), and the `packages/aai/host` runtime that builds the agent + defines relayed tools. Exact files finalized in the plan after reading the host runtime.
+
+## Part B — tau2-side: `aai` provider
+
+New provider `src/tau2/voice/audio_native/aai/`, modeled on the assemblyai provider but with **PCM16 audio conversion** (aai is not μ-law).
+
+- `provider.py` — `AAIVoiceAgentProvider` (WS client): `connect()` (open `AAI_WS_URL` default `ws://localhost:3000/websocket`, send `config` with `host{systemPrompt, tools}` + `audioFormat:"pcm16"` + sample rates, await server `config`), `send_audio(pcm16_bytes)` (binary frame), `send_tool_result(tool_call_id, result)` (`tool_result` JSON), `receive_events*()`. Plus `AAIVADConfig` (server-side VAD; likely a no-op/empty config since aai handles turn detection).
+- `events.py` — pydantic models for the aai server messages + `parse_aai_event()`; binary frames handled out-of-band (not JSON).
+- `discrete_time_adapter.py` — `DiscreteTimeAAIAdapter(DiscreteTimeAdapter)`:
+  - **Audio conversion at the WS boundary:** external format stays tau2 telephony **μ-law 8 kHz**; convert μ-law-8k → PCM16-16k when sending, PCM16-24k → μ-law-8k when receiving, using `tau2.voice.utils.audio_preprocessing` (`convert_to_pcm16`, `resample_audio`, `convert_to_ulaw`) / `StreamingTelephonyConverter`. `bytes_per_tick` etc. remain in telephony terms.
+  - `_execute_tick`: send converted audio + receive events/binary-audio for the tick window.
+  - `_process_event`: binary audio → convert → `agent_audio_chunks` (item = current `reply`/turn id); `agent_transcript{text}` → `UtteranceTranscript` (full-text overwrite, like assemblyai); `tool_call` → `ToolCall(id=toolCallId, name=toolName, arguments=args)`; `speech_started` → barge-in (truncate + clear buffer); `reply_done`/`audio_done` → turn end; `error` → log.
+  - `_flush_pending_tool_results`: for each queued `(call_id, result, ...)` send `tool_result{toolCallId=call_id, result}`. (No extra "continue" message — aai auto-continues on tool_result.)
+  - Lifecycle via `BackgroundAsyncLoop`; `reasoning_effort` unsupported → `None`.
+- `__init__.py` exports; `test_provider_standalone.py` smoke test against live `localhost:3000`.
+
+**Registration (tau2):**
+- `config.py`: `DEFAULT_AAI_WS_URL="ws://localhost:3000/websocket"`, `DEFAULT_AAI_MODEL="host"` (endpoint-determined), `DEFAULT_AAI_INPUT_SAMPLE_RATE=16000`, `DEFAULT_AAI_OUTPUT_SAMPLE_RATE=24000`; add `"aai"` to `DEFAULT_AUDIO_NATIVE_MODELS`, `DEFAULT_AUDIO_NATIVE_REASONING_EFFORT` (None), `AUDIO_NATIVE_PROVIDER_TYPES` ("audio_native").
+- `adapter.py`: add `"aai"` to `_PROVIDERS_WITH_ENDPOINT_DETERMINED_MODEL` and a `create_adapter()` branch.
+- `data_model/simulation.py`: add `"aai"` to the `AudioNativeConfig.provider` Literal + description.
+- `cli.py`: add `"aai"` to `--audio-native-provider` choices.
+- `agent/discrete_time_audio_native_agent.py`: add the **`aai` VAD-config branch** (build `AAIVADConfig`) + `"aai"` in that file's `AudioNativeProvider` Literal and `VADConfig` union. *(This is the integration point the assemblyai work initially missed — do not skip it.)*
+
+## Key differences from the assemblyai provider
+- **Audio is PCM16 (16k in / 24k out), not μ-law** → resampling both directions (assemblyai was passthrough).
+- **Prompt + tool schemas injected in `config.host`** (assemblyai used `session.update`).
+- **Tools relayed via `tool_call` → `tool_result`** with client execution (same need as tau2; aai must add `tool_result`).
+- **Two-repo change** (aai host mode + tau2 provider).
+
+## Testing
+- **aai**: vitest for (a) `config.host` builds a dynamic agent with the injected prompt/tools, (b) a `tool_call` round-trips through `tool_result` (with timeout path), following aai's existing test setup (`transport-websocket.test.ts`, `ws-integration.test.ts`, host runtime tests).
+- **tau2**: unit tests — `parse_aai_event`, the `config.host` builder + tool-schema formatting, `_process_event` mapping (audio/transcript/tool_call/barge-in), `_flush_pending_tool_results` sends `tool_result` and no extra continue; μ-law↔PCM16 conversion sanity. Standalone smoke test against live `localhost:3000`.
+- **End-to-end**: `uv run tau2 run --domain retail --audio-native --audio-native-provider aai --user-llm gpt-4.1 --speech-complexity control --num-tasks 1 --verbose-logs`.
+
+## Open items to resolve during planning
+- Exact aai host-runtime integration points (read `packages/aai/host/runtime.ts`, `s2s.ts`, `pipeline-transport.ts`, and `aai-server/orchestrator.ts` / `transport-websocket.ts`).
+- JSON-Schema → aai tool-parameter conversion (aai tools use zod today).
+- Whether aai VAD/turn-detection needs any client config, or is fully server-side (then `AAIVADConfig` is empty).
+- Confirm the aai input sample rate the pipeline actually expects (16000) and that arbitrary μ-law-derived PCM16 is accepted.
+
+## Non-goals
+- Deploying a persistent tau2 domain agent to aai (host mode is per-session, ephemeral).
+- Changing aai's sandbox/tool-execution model for normal (non-host) agents.
+- Multi-trial/leaderboard submission plumbing for aai (separate follow-up).

--- a/scripts/failure_report.py
+++ b/scripts/failure_report.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Print a tau2 run's failures as a report you can hand to a coding agent.
+
+    uv run python scripts/failure_report.py <run> [<run> ...] [--top N] [--out FILE]
+
+Answers the three questions a fix needs, in order:
+
+1. WHICH tasks failed, and did they fail at the reward or at the wire?
+2. WHAT did the agent do instead — expected action vs. the call it really made,
+   plus the judge's own justification for each missed assertion.
+3. Is the run even TRUSTWORTHY — rate-limited caller speech, unfinished tasks,
+   and the wire-level anomalies that make a score say more about the harness
+   than about the agent.
+
+Three things it is deliberate about, each a trap that has produced a wrong
+conclusion on this benchmark before:
+
+- **Retries are collapsed to the highest trial per task.** The runner retries,
+  and a retry OVERWRITES the earlier score, so counting every simulation row
+  double-counts a task and mixes a superseded score into the mean.
+- **Unfinished runs are labelled, not silently averaged.** A mean over 12 of 20
+  tasks is not the run's score, and the difference is invisible once it has been
+  pasted somewhere as a number.
+- **Wire anomalies are reported separately from reward.** A 0.0 caused by a
+  provider that never connected is not evidence about agent quality, and the two
+  want different fixes.
+
+Reads only the run directory (`data/simulations/<run>/`) — no API calls, no
+imports from tau2, so it works on a copied artifact directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+TS_RE = re.compile(r"^(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d\.\d+)")
+EVENT_RE = re.compile(r"AAI event: ([a-z_]+) - (\{.*\})\s*$")
+TEXT_RE = re.compile(r"'text': (\"(?:[^\"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')")
+
+# A turn whose first agent word lands later than this is dead air the caller
+# hears as an unanswered question; the pipeline's own hold phrase and dead-air
+# cover are supposed to keep any turn well under it.
+SLOW_FIRST_WORD_SEC = 10.0
+
+
+def _parse_events(path: Path) -> list[tuple[datetime, str, str | None]]:
+    """Timestamped wire events from one sim's task.log."""
+    events = []
+    with path.open(errors="replace") as fh:
+        for line in fh:
+            match = EVENT_RE.search(line)
+            if not match:
+                continue
+            stamp = TS_RE.match(line)
+            if not stamp:
+                continue
+            when = datetime.strptime(stamp.group(1), "%Y-%m-%d %H:%M:%S.%f")
+            text_match = TEXT_RE.search(match.group(2))
+            text = text_match.group(1)[1:-1] if text_match else None
+            events.append((when, match.group(1), text))
+    return events
+
+
+def _wire_anomalies(log_path: Path) -> dict:
+    """Protocol-level findings for one session.
+
+    Each of these is a client-visible ordering or timing property, not a style
+    preference: a transcript after the turn's terminal frame, a committed user
+    turn that never got a reply, or a gap long enough that the caller gives up.
+    """
+    events = _parse_events(log_path)
+    kinds = Counter(kind for _, kind, _ in events)
+    out = {
+        "events": kinds,
+        "transcript_after_cancel": [],
+        "slow_first_word": [],
+        "abandoned_turns": [],
+        "zero_duration_speech": 0,
+    }
+
+    for i, (when, kind, _) in enumerate(events):
+        if kind == "cancelled":
+            # `cancelled` is the terminal frame of an interrupted turn (a
+            # cancelled reply emits no reply_done), so text after it belongs to
+            # a reply the client has already flushed.
+            for when2, kind2, text2 in events[i + 1 :]:
+                if kind2 in ("cancelled", "reply_done", "user_transcript"):
+                    break
+                if kind2 == "agent_transcript":
+                    out["transcript_after_cancel"].append(
+                        {
+                            "delta_ms": round((when2 - when).total_seconds() * 1000, 1),
+                            "at": when2.strftime("%H:%M:%S.%f")[:-3],
+                            "text": (text2 or "")[:160],
+                        }
+                    )
+                    break
+
+        if kind == "user_transcript":
+            first_agent = done = next_user = None
+            for when2, kind2, _ in events[i + 1 :]:
+                if kind2 == "agent_transcript" and first_agent is None:
+                    first_agent = when2
+                if kind2 == "reply_done" and done is None:
+                    done = when2
+                if kind2 == "user_transcript":
+                    next_user = when2
+                    break
+            if first_agent:
+                gap = (first_agent - when).total_seconds()
+                if gap > SLOW_FIRST_WORD_SEC:
+                    out["slow_first_word"].append(
+                        {
+                            "gap_sec": round(gap, 1),
+                            "at": when.strftime("%H:%M:%S.%f")[:-3],
+                        }
+                    )
+            if done is None and (first_agent is None or next_user):
+                # The user committed a turn and the reply never completed.
+                until = next_user or events[-1][0]
+                out["abandoned_turns"].append(
+                    {
+                        "waited_sec": round((until - when).total_seconds(), 1),
+                        "at": when.strftime("%H:%M:%S.%f")[:-3],
+                    }
+                )
+
+    for i in range(len(events) - 1):
+        if events[i][1] == "speech_started" and events[i + 1][1] == "speech_stopped":
+            if (events[i + 1][0] - events[i][0]).total_seconds() < 0.05:
+                out["zero_duration_speech"] += 1
+
+    return out
+
+
+def _session_logs(run_dir: Path) -> dict[str, Path]:
+    """sim id -> task.log. The artifact dir names each session `sim_<id>`."""
+    logs = {}
+    for log in run_dir.glob("artifacts/task_*/sim_*/task.log"):
+        logs[log.parent.name.removeprefix("sim_")] = log
+    return logs
+
+
+def _rate_limit_hits(log: Path) -> int:
+    """429s on the caller's own voice synthesis.
+
+    Not cosmetic: a synthesis that burns its retries is a caller utterance that
+    arrives late or not at all, and the delayed ones are disproportionately the
+    spelled-out names and digits that authentication turns on.
+    """
+    try:
+        return sum(
+            1
+            for line in log.open(errors="replace")
+            if "synthesize_voice failed" in line
+        )
+    except OSError:
+        return 0
+
+
+def _latest_trials(index) -> dict[str, dict]:
+    """Collapse retries: the highest trial per task is the authoritative score.
+
+    `simulation_index` is a LIST of entries; accept a mapping too, so a
+    hand-assembled or older results.json still reports.
+    """
+    entries = index.values() if isinstance(index, dict) else (index or [])
+    best: dict[str, dict] = {}
+    for entry in entries:
+        if entry is None:
+            continue
+        task_id = str(entry.get("task_id"))
+        current = best.get(task_id)
+        if current is None or entry.get("trial", 0) >= current.get("trial", 0):
+            best[task_id] = entry
+    return best
+
+
+def _actual_calls(sim: dict) -> list[dict]:
+    """Every tool call the agent really made, in order, from the ticks.
+
+    `sim["messages"]` is empty in audio-native runs — the per-tick
+    `agent_tool_calls` are the only record.
+    """
+    calls = []
+    for tick in sim.get("ticks") or []:
+        for call in tick.get("agent_tool_calls") or []:
+            calls.append(
+                {"name": call.get("name"), "arguments": call.get("arguments") or {}}
+            )
+    return calls
+
+
+def _heard_chars(sim: dict) -> int:
+    """How much agent speech the simulated caller actually received."""
+    total = 0
+    for tick in sim.get("ticks") or []:
+        chunk = tick.get("agent_chunk") or {}
+        total += len(chunk.get("content") or "")
+    return total
+
+
+def _classify(sim: dict, actual: list[dict], failed_actions: list[dict]) -> str:
+    """Name the failure mode, because they want different fixes.
+
+    'RED' hides at least four problems: an agent that never got in the door, one
+    that acted on mis-heard arguments, one that ran out of steps, and one that
+    behaved correctly and merely failed to say something.
+    """
+    auth_tools = {"find_user_id_by_name_zip", "find_user_id_by_email"}
+    attempted_auth = [c for c in actual if c["name"] in auth_tools]
+    reward_info = sim.get("reward_info") or {}
+    breakdown = reward_info.get("reward_breakdown") or {}
+
+    if not actual:
+        return "NO_TOOL_CALLS — agent never acted at all"
+    if attempted_auth and len(actual) == len(attempted_auth):
+        # Tried to authenticate, never got past it: the task body is unreachable,
+        # so every expected action is missing for one upstream reason.
+        return "NEVER_AUTHENTICATED — only auth calls made; task body unreachable"
+    if failed_actions and breakdown.get("NL_ASSERTION", 0) == 1.0:
+        return "WRONG_ACTIONS_GOOD_TALK — converses well, acts wrong (check args)"
+    if failed_actions:
+        return "WRONG_OR_MISSING_ACTIONS"
+    if breakdown.get("DB") == 1.0:
+        return "COMMUNICATION_ONLY — actions correct, assertions missed"
+    return "OTHER"
+
+
+def _load_sims(run_dir: Path) -> dict[str, dict]:
+    sims = {}
+    for path in run_dir.glob("simulations/*.json"):
+        try:
+            sim = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"  ! unreadable {path.name}: {e}", file=sys.stderr)
+            continue
+        sims[sim.get("id", path.stem)] = sim
+    return sims
+
+
+def report(run: str, root: Path, top: int, out) -> None:
+    run_dir = root / "data" / "simulations" / run
+    results_path = run_dir / "results.json"
+    if not results_path.exists():
+        print(f"\n## {run}\n\nNo results.json at {results_path} — skipped.\n", file=out)
+        return
+
+    results = json.loads(results_path.read_text())
+    index = results.get("simulation_index") or {}
+    latest = _latest_trials(index)
+    sims = _load_sims(run_dir)
+    logs = _session_logs(run_dir)
+
+    expected = (results.get("info") or {}).get("num_tasks")
+    rewards = [e["reward"] for e in latest.values() if e.get("reward") is not None]
+    mean = sum(rewards) / len(rewards) if rewards else float("nan")
+    retried = sum(1 for e in latest.values() if e.get("trial", 0) > 0)
+
+    print(f"\n## {run}\n", file=out)
+    status = f"{len(latest)} tasks scored"
+    if expected and len(latest) < expected:
+        status += f" of {expected} — **RUN INCOMPLETE, this mean is not the score**"
+    print(f"- {status}", file=out)
+    print(
+        f"- mean reward **{mean:.3f}**  (retries collapsed; {retried} task(s) retried)",
+        file=out,
+    )
+    print(
+        f"- rewards: {Counter(round(r, 2) for r in rewards).most_common()}",
+        file=out,
+    )
+    print(
+        f"- termination: {Counter(e.get('termination_reason') for e in latest.values()).most_common()}",
+        file=out,
+    )
+
+    # Trust checks, before any per-task detail: if these are non-zero the scores
+    # below are partly measuring the harness.
+    total_429 = sum(_rate_limit_hits(p) for p in logs.values())
+    wire = {sid: _wire_anomalies(p) for sid, p in logs.items()}
+    all_events = Counter()
+    for w in wire.values():
+        all_events.update(w["events"])
+    n_after_cancel = sum(len(w["transcript_after_cancel"]) for w in wire.values())
+    n_abandoned = sum(len(w["abandoned_turns"]) for w in wire.values())
+    n_slow = sum(len(w["slow_first_word"]) for w in wire.values())
+    n_zero = sum(w["zero_duration_speech"] for w in wire.values())
+
+    print("\n### Run trust\n", file=out)
+    print(
+        f"- caller-voice 429s: **{total_429}**"
+        + (
+            "  ← delayed caller speech; treat comparisons as noisy" if total_429 else ""
+        ),
+        file=out,
+    )
+    print(
+        f"- wire `error` events: {all_events.get('error', 0)}   "
+        f"`idle_timeout`: {all_events.get('idle_timeout', 0)}",
+        file=out,
+    )
+    print(
+        f"- sessions: {len(logs)}   `config` frames: {all_events.get('config', 0)} "
+        f"(more than one per session = reconnects)",
+        file=out,
+    )
+    # A session that produced no scored row is a task that died before grading —
+    # an infrastructure error, or a run still in flight. Either way the mean
+    # above is over fewer conversations than were actually held.
+    unscored = len(logs) - len(latest)
+    if unscored > 0:
+        print(
+            f"- sessions with no scored result: **{unscored}** "
+            f"(died before grading, or still running)",
+            file=out,
+        )
+    print(
+        f"- `cancelled` / `reply_done`: {all_events.get('cancelled', 0)}"
+        f" / {all_events.get('reply_done', 0)}",
+        file=out,
+    )
+
+    print("\n### Wire anomalies (SDK-side, independent of reward)\n", file=out)
+    print(
+        f"- `agent_transcript` after `cancelled`: **{n_after_cancel}** "
+        f"(text emitted past the turn's terminal frame)",
+        file=out,
+    )
+    print(f"- user turns with no `reply_done`: **{n_abandoned}**", file=out)
+    print(
+        f"- turns >{SLOW_FIRST_WORD_SEC:.0f}s to first agent word: **{n_slow}**",
+        file=out,
+    )
+    print(f"- zero-duration speech windows (<50ms): **{n_zero}**", file=out)
+
+    worst_slow = sorted(
+        (s for w in wire.values() for s in w["slow_first_word"]),
+        key=lambda s: -s["gap_sec"],
+    )[:5]
+    if worst_slow:
+        print(
+            f"- worst first-word gaps: "
+            + ", ".join(f"{s['gap_sec']}s @ {s['at']}" for s in worst_slow),
+            file=out,
+        )
+    example = next(
+        (t for w in wire.values() for t in w["transcript_after_cancel"]), None
+    )
+    if example:
+        print(
+            f"- example post-cancel transcript (+{example['delta_ms']}ms @ "
+            f"{example['at']}): {example['text']!r}",
+            file=out,
+        )
+
+    # Failures, worst first.
+    failures = sorted(
+        (e for e in latest.values() if (e.get("reward") or 0) < 1.0),
+        key=lambda e: (e.get("reward") or 0, -(e.get("duration") or 0)),
+    )
+    print(f"\n### Failures ({len(failures)} of {len(latest)}), worst first\n", file=out)
+    if not failures:
+        print("None.\n", file=out)
+        return
+
+    for entry in failures[:top]:
+        sim = sims.get(entry["id"], {})
+        reward_info = sim.get("reward_info") or {}
+        breakdown = reward_info.get("reward_breakdown") or {}
+        actual = _actual_calls(sim)
+        failed_actions = [
+            c
+            for c in (reward_info.get("action_checks") or [])
+            if not c.get("action_match")
+        ]
+        missed = [
+            a for a in (reward_info.get("nl_assertions") or []) if not a.get("met")
+        ]
+
+        print(
+            f"#### task `{entry['task_id']}` — reward {entry.get('reward')} "
+            f"(trial {entry.get('trial')}, {entry.get('duration', 0):.0f}s, "
+            f"{entry.get('termination_reason')})\n",
+            file=out,
+        )
+        print(
+            f"- classification: **{_classify(sim, actual, failed_actions)}**", file=out
+        )
+        print(
+            f"- breakdown: {breakdown}   db_match: "
+            f"{(reward_info.get('db_check') or {}).get('db_match')}",
+            file=out,
+        )
+        print(
+            f"- agent speech the caller received: {_heard_chars(sim)} chars "
+            f"across {len(sim.get('ticks') or [])} ticks",
+            file=out,
+        )
+        print(
+            f"- sim: `data/simulations/{run}/simulations/{entry['id']}.json`", file=out
+        )
+        log = logs.get(entry["id"])
+        if log:
+            print(f"- wire log: `{log.relative_to(root)}`", file=out)
+
+        if failed_actions:
+            print("\n  **Expected actions not matched:**", file=out)
+            for check in failed_actions:
+                action = check.get("action") or {}
+                print(
+                    f"  - `{action.get('name')}` expected "
+                    f"`{json.dumps(action.get('arguments') or {}, sort_keys=True)}`",
+                    file=out,
+                )
+                # The same tool as actually called: for STT-bound domains the
+                # argument diff IS the finding.
+                same = [c for c in actual if c["name"] == action.get("name")]
+                if same:
+                    for call in same[:3]:
+                        print(
+                            f"    agent called `{json.dumps(call['arguments'], sort_keys=True)}`",
+                            file=out,
+                        )
+                else:
+                    print("    agent never called this tool", file=out)
+
+        if actual:
+            print(
+                f"\n  **Calls made** ({len(actual)}): "
+                + ", ".join(f"`{c['name']}`" for c in actual[:12])
+                + (" …" if len(actual) > 12 else ""),
+                file=out,
+            )
+
+        if missed:
+            print("\n  **Missed assertions (judge's words):**", file=out)
+            for a in missed[:4]:
+                print(f"  - {a.get('nl_assertion')}", file=out)
+                just = (a.get("justification") or "").strip().replace("\n", " ")
+                if just:
+                    print(f"    → {just[:300]}", file=out)
+
+        w = wire.get(entry["id"])
+        if w:
+            bits = []
+            if w["abandoned_turns"]:
+                bits.append(
+                    f"{len(w['abandoned_turns'])} turn(s) with no reply_done "
+                    f"(waited {max(t['waited_sec'] for t in w['abandoned_turns'])}s)"
+                )
+            if w["slow_first_word"]:
+                bits.append(
+                    f"{len(w['slow_first_word'])} slow first word "
+                    f"(max {max(s['gap_sec'] for s in w['slow_first_word'])}s)"
+                )
+            if w["transcript_after_cancel"]:
+                bits.append(
+                    f"{len(w['transcript_after_cancel'])} post-cancel transcript(s)"
+                )
+            hits = _rate_limit_hits(log) if log else 0
+            if hits:
+                bits.append(f"{hits} caller-voice 429s")
+            if bits:
+                print(f"\n  **Wire:** {'; '.join(bits)}", file=out)
+        print("", file=out)
+
+    if len(failures) > top:
+        print(
+            f"_({len(failures) - top} further failure(s) not shown; --top to raise.)_\n",
+            file=out,
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("runs", nargs="+", help="run name(s) under data/simulations/")
+    parser.add_argument("--top", type=int, default=8, help="failures to detail per run")
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="repo root")
+    parser.add_argument(
+        "--out", type=Path, help="write markdown here instead of stdout"
+    )
+    args = parser.parse_args()
+
+    out = args.out.open("w") if args.out else sys.stdout
+    try:
+        print("# tau2 failure report", file=out)
+        print(
+            "\nRetries collapsed to the highest trial per task. Wire anomalies are "
+            "SDK-side and independent of reward — a 0.0 from a provider that never "
+            "connected is not evidence about agent quality.",
+            file=out,
+        )
+        for run in args.runs:
+            report(run, args.root, args.top, out)
+    finally:
+        if args.out:
+            out.close()
+            print(f"wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/stt_errors.py
+++ b/scripts/stt_errors.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Diff what the caller SAID against what the agent HEARD, per utterance.
+
+    uv run python scripts/stt_errors.py <run> [<run> ...] [--all] [--out FILE]
+
+tau2 synthesizes the caller's speech from text, so ground truth exists: every
+`user_chunk` carries an `audio_script_gold` naming the exact utterance that was
+spoken. The agent's side of it is the `user_transcript` wire events in the
+session log. Pairing them turns "the agent did the wrong thing" into "the agent
+was told the wrong thing", which are different bugs with different owners.
+
+Defaults to FAILING tasks only (`--all` for every task), since a mis-hearing
+that changed nothing is not what you are looking for.
+
+## Why the comparison needs normalization
+
+A spoken ZIP is gold `"one, nine, one, two, two"` and heard `"19122"` — the
+same utterance, correctly transcribed. A spelled name is gold `"Y, U, S, U, F"`
+and heard `"Y-U-S-U-F"`. Diffing raw strings reports both as errors, which
+buries the real ones: on the run this was built against, unnormalized diffing
+flagged nearly every authentication utterance. So digit words are folded to
+digits, adjacent digits are joined, punctuation goes, and case goes — and only
+then is what remains a disagreement.
+
+## Why alignment is not positional
+
+STT decides utterance boundaries, the simulator decides utterances, and they
+disagree: a pause or a [sneeze] splits one utterance into two transcripts, and
+back-to-back short ones merge into one. Pairing by index silently shifts every
+later row after the first split, so every subsequent utterance reads as an
+error. This aligns greedily over 1:1, 1:2 (split) and 2:1 (merge), picking
+whichever scores best — and reports the cardinality, because a split IS a
+finding: the agent answered half a sentence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from pathlib import Path
+
+GOLD_CHUNK_RE = re.compile(r"<chunk id=\d+>(.*?)</chunk>", re.S)
+TRANSCRIPT_RE = re.compile(
+    r"AAI event: user_transcript - \{'type': 'user_transcript', 'text': "
+    r"(\"(?:[^\"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')"
+)
+# Speech effects the harness injects into the audio; they are not words the
+# caller said, so they must not count as text STT failed to hear.
+EFFECT_RE = re.compile(r"\[[a-z_]+\]")
+
+NUMBER_WORDS = {
+    "zero": "0",
+    "oh": "0",
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7",
+    "eight": "8",
+    "nine": "9",
+}
+
+# Utterances carrying these are the ones whose mis-hearing reaches a tool
+# argument, which is where an STT error becomes a score error.
+IDENTITY_HINT_RE = re.compile(r"[@#]|\d|\b(?:zip|email|order|dot com|at)\b", re.I)
+NEGATION_RE = re.compile(
+    r"\b(?:not|no|don'?t|doesn'?t|didn'?t|can'?t|won'?t|never)\b", re.I
+)
+# Any letter outside Latin-1: the transcript came back in a different script.
+NON_LATIN_RE = re.compile(r"[^\x00-\xff]")
+
+# Above this, the pair differs only in inflection or a filler word — real, but
+# not what anyone is hunting. Kept out of OTHER so that bucket stays meaningful.
+MINOR_SIMILARITY = 0.8
+
+# A pair at or above this normalized similarity is treated as heard correctly.
+SAME_ENOUGH = 0.95
+
+
+def _normalize(text: str) -> list[str]:
+    """Tokens for comparison: spoken digits folded, punctuation and case gone."""
+    text = EFFECT_RE.sub(" ", text)
+    text = text.replace("’", "'").lower()
+    # Hyphens are DELETED, not spaced: the gold script and the transcript
+    # disagree freely on them ("tshirt" / "t-shirt", "v-neck" / "v neck"), and
+    # spacing them splits one word into two tokens so a perfectly transcribed
+    # sentence scores as a mismatch. Deleting also folds a spelled-out
+    # "Y-U-S-U-F" straight into "yusuf".
+    text = re.sub(r"[-–—]+", "", text)
+    text = re.sub(r"[^a-z0-9']+", " ", text)
+    tokens = [NUMBER_WORDS.get(t, t) for t in text.split() if t]
+    # Join digit runs, so a spoken "1 9 1 2 2" and a transcribed "19122" are one
+    # token. Spelled letters fold the same way ("y u s u f" / "yusuf") — but only
+    # into a RUN of single letters, tracked explicitly. Folding a lone letter into
+    # whatever preceded it merges "many" + "t" from "many t-shirts" into "manyt",
+    # inventing a mismatch in a sentence that was transcribed perfectly.
+    out: list[str] = []
+    letter_run = False
+    for token in tokens:
+        single_letter = len(token) == 1 and token.isalpha()
+        if token.isdigit() and out and out[-1].isdigit():
+            out[-1] += token
+        elif single_letter and letter_run and out:
+            out[-1] += token
+        else:
+            out.append(token)
+            letter_run = single_letter
+    return out
+
+
+def _similarity(gold: str, heard: str) -> float:
+    a, b = _normalize(gold), _normalize(heard)
+    if not a and not b:
+        return 1.0
+    return difflib.SequenceMatcher(None, a, b).ratio()
+
+
+def _gold_utterances(sim: dict) -> list[str]:
+    """The exact text synthesized for the caller, in order, one per utterance."""
+    seen: dict[str, str] = {}
+    order: list[str] = []
+    for tick in sim.get("ticks") or []:
+        chunk = tick.get("user_chunk") or {}
+        gold = chunk.get("audio_script_gold")
+        ids = chunk.get("utterance_ids") or []
+        if not gold or not ids:
+            continue
+        uid = ids[0]
+        if uid in seen:
+            continue
+        pieces = GOLD_CHUNK_RE.findall(gold)
+        text = "".join(pieces).strip()
+        if not text:
+            continue
+        seen[uid] = text
+        order.append(uid)
+    return [seen[u] for u in order]
+
+
+def _heard_transcripts(log: Path) -> list[str]:
+    out = []
+    with log.open(errors="replace") as fh:
+        for line in fh:
+            m = TRANSCRIPT_RE.search(line)
+            if m:
+                out.append(m.group(1)[1:-1])
+    return out
+
+
+def _align(gold: list[str], heard: list[str]) -> list[tuple[list[str], list[str]]]:
+    """Greedy alignment over 1:1, 1:2 (split) and 2:1 (merge) pairings."""
+    pairs: list[tuple[list[str], list[str]]] = []
+    i = j = 0
+    while i < len(gold) and j < len(heard):
+        one_one = _similarity(gold[i], heard[j])
+        split = (
+            _similarity(gold[i], heard[j] + " " + heard[j + 1])
+            if j + 1 < len(heard)
+            else -1.0
+        )
+        merge = (
+            _similarity(gold[i] + " " + gold[i + 1], heard[j])
+            if i + 1 < len(gold)
+            else -1.0
+        )
+        best = max(one_one, split, merge)
+        # Require a real margin before claiming a split/merge: near-ties are
+        # 1:1, or a long correct transcript absorbs its innocent neighbour.
+        if best == split and split > one_one + 0.05:
+            pairs.append(([gold[i]], [heard[j], heard[j + 1]]))
+            i, j = i + 1, j + 2
+        elif best == merge and merge > one_one + 0.05:
+            pairs.append(([gold[i], gold[i + 1]], [heard[j]]))
+            i, j = i + 2, j + 1
+        else:
+            pairs.append(([gold[i]], [heard[j]]))
+            i, j = i + 1, j + 1
+    for k in range(i, len(gold)):
+        pairs.append(([gold[k]], []))  # said, never transcribed
+    for k in range(j, len(heard)):
+        pairs.append(([], [heard[k]]))  # heard, never said
+    return pairs
+
+
+def _classify(gold: str, heard: str, cardinality: tuple[int, int]) -> str:
+    """Name the error class, because they need different remedies.
+
+    Retrying only rescues a homophone (one candidate may be right); a digit
+    substitution is an independent coin flip per attempt, and a dropped negation
+    or a collapsed structure is not recoverable agent-side at all.
+    """
+    if not heard:
+        return "NOT_HEARD — utterance never transcribed"
+    if not gold:
+        return "PHANTOM — transcript with no matching utterance"
+    # Checked before everything else because it subsumes the rest: an English
+    # utterance returned in Devanagari or Hebrew script is a language-detection
+    # failure, and every downstream measure (truncated, substituted) is just a
+    # side effect of comparing across alphabets. Filed as TRUNCATED it looks
+    # like an audio problem.
+    if NON_LATIN_RE.search(heard):
+        return (
+            "NON_LATIN_SCRIPT — English returned in another script (language detection)"
+        )
+    if cardinality[0] == 1 and cardinality[1] > 1:
+        return "SPLIT — one utterance became several turns"
+    if cardinality[0] > 1 and cardinality[1] == 1:
+        return "MERGED — several utterances became one turn"
+
+    g_tokens, h_tokens = _normalize(gold), _normalize(heard)
+    g_set, h_set = set(g_tokens), set(h_tokens)
+    lost, gained = g_set - h_set, h_set - g_set
+
+    if bool(NEGATION_RE.search(gold)) != bool(NEGATION_RE.search(heard)):
+        return "NEGATION — polarity changed; meaning inverted"
+    if re.search(r"@|\bat\b.*\bdot\b", gold, re.I) and "@" not in heard:
+        return "EMAIL — address structure lost"
+    if any(t.isdigit() for t in lost | gained):
+        return "DIGITS — numeric substitution (zip / order id / phone)"
+    if lost and all(len(t) > 2 for t in lost) and len(lost) == len(gained):
+        return "SUBSTITUTION — words swapped (homophone or proper noun)"
+    if len(h_tokens) < len(g_tokens) * 0.6:
+        return "TRUNCATED — most of the utterance missing"
+    if difflib.SequenceMatcher(None, g_tokens, h_tokens).ratio() >= MINOR_SIMILARITY:
+        return "MINOR — inflection or filler only"
+    return "OTHER"
+
+
+def _word_diff(gold: str, heard: str) -> str:
+    """Compact token diff, on the NORMALIZED forms actually compared."""
+    a, b = _normalize(gold), _normalize(heard)
+    bits = []
+    for op, i1, i2, j1, j2 in difflib.SequenceMatcher(None, a, b).get_opcodes():
+        if op == "equal":
+            continue
+        said = " ".join(a[i1:i2]) or "∅"
+        got = " ".join(b[j1:j2]) or "∅"
+        bits.append(f"{said!r}→{got!r}")
+    return "; ".join(bits) if bits else "(normalized forms match)"
+
+
+def _latest_trials(index) -> dict[str, dict]:
+    entries = index.values() if isinstance(index, dict) else (index or [])
+    best: dict[str, dict] = {}
+    for entry in entries:
+        if entry is None:
+            continue
+        task_id = str(entry.get("task_id"))
+        current = best.get(task_id)
+        if current is None or entry.get("trial", 0) >= current.get("trial", 0):
+            best[task_id] = entry
+    return best
+
+
+def report(run: str, root: Path, include_all: bool, out) -> None:
+    run_dir = root / "data" / "simulations" / run
+    results_path = run_dir / "results.json"
+    if not results_path.exists():
+        print(f"\n## {run}\n\nNo results.json — skipped.\n", file=out)
+        return
+
+    latest = _latest_trials(
+        json.loads(results_path.read_text()).get("simulation_index")
+    )
+    logs = {
+        p.parent.name.removeprefix("sim_"): p
+        for p in run_dir.glob("artifacts/task_*/sim_*/task.log")
+    }
+
+    print(f"\n## {run}\n", file=out)
+    totals: dict[str, int] = {}
+    utterances = errors = 0
+    identity_errors: list[str] = []
+    shown = 0
+
+    for entry in sorted(latest.values(), key=lambda e: (e.get("reward") or 0)):
+        reward = entry.get("reward") or 0
+        if reward >= 1.0 and not include_all:
+            continue
+        sim_path = run_dir / "simulations" / f"{entry['id']}.json"
+        log = logs.get(entry["id"])
+        if not sim_path.exists() or not log:
+            continue
+        sim = json.loads(sim_path.read_text())
+        pairs = _align(_gold_utterances(sim), _heard_transcripts(log))
+
+        rows = []
+        for gold_group, heard_group in pairs:
+            gold = " ".join(gold_group)
+            heard = " ".join(heard_group)
+            cardinality = (len(gold_group), len(heard_group))
+            utterances += 1
+            score = _similarity(gold, heard) if gold and heard else 0.0
+            if cardinality == (1, 1) and score >= SAME_ENOUGH:
+                continue
+            kind = _classify(gold, heard, cardinality)
+            errors += 1
+            totals[kind] = totals.get(kind, 0) + 1
+            identity = bool(IDENTITY_HINT_RE.search(gold))
+            if identity:
+                identity_errors.append(f"{run} task {entry['task_id']}: {kind}")
+            rows.append((kind, gold, heard, score, identity))
+
+        if not rows:
+            continue
+        shown += 1
+        print(f"### task `{entry['task_id']}` — reward {reward}\n", file=out)
+        for kind, gold, heard, score, identity in rows:
+            flag = "  ⚠️ **feeds a tool argument**" if identity else ""
+            print(f"- **{kind}**{flag}", file=out)
+            print(f"  - said:  `{gold}`", file=out)
+            print(f"  - heard: `{heard or '(nothing)'}`", file=out)
+            print(
+                f"  - diff:  {_word_diff(gold, heard)}  (similarity {score:.2f})",
+                file=out,
+            )
+        print("", file=out)
+
+    scope = "all tasks" if include_all else "failing tasks"
+    print(f"### Summary ({scope})\n", file=out)
+    print(
+        f"- utterances compared: **{utterances}**, mis-heard: **{errors}**"
+        + (f"  ({100 * errors / utterances:.0f}%)" if utterances else ""),
+        file=out,
+    )
+    for kind, n in sorted(totals.items(), key=lambda kv: -kv[1]):
+        print(f"  - {n}x {kind}", file=out)
+    print(
+        f"- mis-hearings on utterances that feed a tool argument: "
+        f"**{len(identity_errors)}** — these are the ones that move the score",
+        file=out,
+    )
+    if not shown:
+        print("\n_No mis-hearings found in scope._", file=out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("runs", nargs="+")
+    parser.add_argument(
+        "--all", action="store_true", help="include passing tasks, not just failures"
+    )
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+
+    out = args.out.open("w") if args.out else sys.stdout
+    try:
+        print("# STT error report", file=out)
+        print(
+            "\nGold text is what the harness SYNTHESIZED (`audio_script_gold`); "
+            "heard text is the agent's `user_transcript`. Comparison is on "
+            "normalized tokens, so a ZIP spoken as words and transcribed as "
+            "digits is not an error.",
+            file=out,
+        )
+        for run in args.runs:
+            report(run, args.root, args.all, out)
+    finally:
+        if args.out:
+            out.close()
+            print(f"wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/stt_errors.py
+++ b/scripts/stt_errors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Diff what the caller SAID against what the agent HEARD, per utterance.
 
-    uv run python scripts/stt_errors.py <run> [<run> ...] [--all] [--out FILE]
+    uv run python scripts/stt_errors.py <run> [<run> ...] [--all-errors] [--out FILE]
 
 tau2 synthesizes the caller's speech from text, so ground truth exists: every
 `user_chunk` carries an `audio_script_gold` naming the exact utterance that was
@@ -9,8 +9,10 @@ spoken. The agent's side of it is the `user_transcript` wire events in the
 session log. Pairing them turns "the agent did the wrong thing" into "the agent
 was told the wrong thing", which are different bugs with different owners.
 
-Defaults to FAILING tasks only (`--all` for every task), since a mis-hearing
-that changed nothing is not what you are looking for.
+Defaults to the mis-hearings that REACHED A TOOL CALL, across every task —
+including tasks that passed, where a mis-heard argument is a near miss worth
+seeing before it costs a run. `--all-errors` widens to every mis-hearing;
+`--failing-only` narrows the tasks.
 
 ## Why the comparison needs normalization
 
@@ -91,7 +93,31 @@ def _normalize(text: str) -> list[str]:
     # spacing them splits one word into two tokens so a perfectly transcribed
     # sentence scores as a mismatch. Deleting also folds a spelled-out
     # "Y-U-S-U-F" straight into "yusuf".
+    # Collapse a spelled-out run FIRST, while its separators are still intact.
+    # The two sides punctuate spelling differently — gold `"M, E, I—D, A, V, I, S"`
+    # against heard `"M-E-I-D-A-B-I-S"` — and deleting dashes alone leaves the gold
+    # as `me | id | avis` (the em-dash fuses I+D into a two-letter token, breaking
+    # the single-letter run) versus one token for the heard side. Every argument
+    # then looked absent from what the caller said: `first_name='mei'` was reported
+    # as a mis-hearing of an utterance that spelled M, E, I aloud.
+    text = re.sub(
+        r"(?:\b[a-z]\b[^a-z0-9]*){2,}",
+        lambda m: re.sub(r"[^a-z]", "", m.group(0)) + " ",
+        text,
+    )
     text = re.sub(r"[-–—]+", "", text)
+    # Address folding. A caller spelling an email says the SEPARATORS aloud
+    # ("mia dot garcia at example dot com") and STT writes them as punctuation
+    # ("mia.garcia2723@example.com") — a correct transcription that could never
+    # match, since punctuation is stripped while the words survive. Dropping the
+    # spoken forms too makes both sides collapse to the same letters.
+    #
+    # Gated on the utterance looking address-ish (an "@", or a spoken "dot"), so
+    # an ordinary "meet me at the store" keeps its "at" and a genuinely dropped
+    # word still reads as a difference. Losing the "@" ENTIRELY is still caught:
+    # the EMAIL class is detected on the raw strings, before any of this.
+    if "@" in text or re.search(r"\bdot\b", text):
+        text = re.sub(r"\b(?:dot|at)\b", " ", text)
     text = re.sub(r"[^a-z0-9']+", " ", text)
     tokens = [NUMBER_WORDS.get(t, t) for t in text.split() if t]
     # Join digit runs, so a spoken "1 9 1 2 2" and a transcribed "19122" are one
@@ -256,68 +282,174 @@ def _blob(text: str) -> str:
     return "".join(_normalize(text))
 
 
-def _arg_values(arguments: dict) -> list[tuple[str, str]]:
-    """(argument name, normalized value) for every scalar in a tool call."""
-    out = []
+def _scalar_args(arguments: dict) -> dict[str, list[str]]:
+    """argument name -> normalized scalar value(s) of one tool call."""
+    out: dict[str, list[str]] = {}
     for name, value in (arguments or {}).items():
         items = value if isinstance(value, list) else [value]
         for item in items:
             if isinstance(item, (str, int, float)) and not isinstance(item, bool):
                 blob = _blob(str(item))
                 if blob:
-                    out.append((name, blob))
+                    out.setdefault(name, []).append(blob)
     return out
+
+
+def _failed_checks(sim: dict) -> list[tuple[str, dict[str, list[str]]]]:
+    """(tool name, expected args) for the action checks that FAILED.
+
+    Only failed checks: an argument from a check that passed cannot be evidence
+    that something went wrong.
+    """
+    out = []
+    for check in (sim.get("reward_info") or {}).get("action_checks") or []:
+        if check.get("action_match"):
+            continue
+        action = check.get("action") or {}
+        name = action.get("name")
+        if name:
+            out.append((name, _scalar_args(action.get("arguments") or {})))
+    return out
+
+
+def _calls_by_name(sim: dict) -> dict[str, list[dict[str, list[str]]]]:
+    """tool name -> each call's normalized arguments, in order."""
+    out: dict[str, list[dict[str, list[str]]]] = {}
+    for tick in sim.get("ticks") or []:
+        for call in tick.get("agent_tool_calls") or []:
+            name = call.get("name")
+            if name:
+                out.setdefault(name, []).append(
+                    _scalar_args(call.get("arguments") or {})
+                )
+    return out
+
+
+# Values shorter than this are not evidence: a two-character argument matches
+# somewhere in almost any transcript by chance.
+MIN_EVIDENCE_LEN = 3
+
+
+def _contains(value: str, text: str) -> bool:
+    """Does `text` really carry `value`, allowing for spelling and run-together?
+
+    Plain substring matching on the concatenated form is too loose and invented
+    findings: `"And when you say that"` collapses to `andwhenyousaythatthats`,
+    which contains `usa` across the `you|say` boundary, so an agent's
+    `country='usa'` was reported as a mis-hearing from an utterance that never
+    mentioned a country.
+
+    A real match is one of two shapes, both anchored to token boundaries:
+
+    - inside a SINGLE token — a spelled-out name arrives as one token
+      (`meidabis`), and `dabis` is genuinely in it;
+    - the exact concatenation of consecutive tokens — a spoken address becomes
+      `mia | garcia | 2723 | example | com`, whose join is the argument value.
+    """
+    if not value:
+        return False
+    tokens = _normalize(text)
+    if any(value in token for token in tokens):
+        return True
+    for i in range(len(tokens)):
+        joined = ""
+        for j in range(i, len(tokens)):
+            joined += tokens[j]
+            if joined == value:
+                return True
+            if len(joined) > len(value):
+                break
+    return False
 
 
 def _causal_evidence(
     gold: str,
     heard: str,
-    expected_args: list[tuple[str, str]],
-    actual_args: list[tuple[str, str]],
+    failed: list[tuple[str, dict[str, list[str]]]],
+    calls: dict[str, list[dict[str, list[str]]]],
 ) -> list[str]:
-    """Why this mis-hearing plausibly caused the failure — empty if it didn't.
+    """Why this mis-hearing reached a tool call — empty if it didn't.
 
-    Two directions, and both are needed. A value the caller SAID that is missing
-    from what was heard explains an action the agent could not perform (it was
-    never told the right thing). A value present in what was heard and absent
-    from what was said explains an action performed WRONGLY (the mis-hearing
-    became the argument). Reporting only the first would miss the wrong-account
-    class entirely, where every required datum was spoken and the agent still
-    acted on something else.
+    The primary rule needs no expected value, so it works whether the task passed
+    or failed: an argument the agent PASSED whose value appears in the transcript
+    and was never said is a mis-hearing that got as far as a tool call. A passing
+    task can contain one — the agent recovered, or the check tolerated it — and
+    those are exactly the near misses worth seeing before they cost a run.
+
+    A value that IS in what the caller said is never evidence, however unlike the
+    transcript it looks. That is what makes a correctly transcribed spelled-out
+    email (`mia.garcia2723@example.com`, said as "dot"/"at") stop being reported:
+    its normalized form is present on both sides.
+
+    When a failed check names an expected value, two things are added: the reason
+    says what the caller actually said, and a value that was spoken but never
+    reached the tool at all is reported too — an action the agent could not
+    perform because it was never told the right thing.
+
+    Expected values are compared PER CALL rather than pooled across calls. An
+    agent retrying authentication gets a different field wrong each time —
+    measured: `{first_name: mei, last_name: kobacs}` then
+    `{first_name: may, last_name: kovacs}`. Pooled, every argument was right in
+    *some* call and the task looked uncaused, when in fact no single call was ever
+    right and each wrong field traces to its own mis-hearing.
     """
-    gold_blob, heard_blob = _blob(gold), _blob(heard)
-    reasons = []
-    for name, value in expected_args:
-        if value and value in gold_blob and value not in heard_blob:
-            reasons.append(f"expected `{name}`={value!r} was spoken but not heard")
-    for name, value in actual_args:
-        if value and value in heard_blob and value not in gold_blob:
-            reasons.append(
-                f"agent used `{name}`={value!r}, which only appears in the transcript"
-            )
+    # A transcript with no matching utterance has no `said` side, so nothing
+    # can be attributed to it — every value would trivially be "not in gold".
+    if not gold.strip():
+        return []
+    reasons: list[str] = []
+    # What the failed checks (if any) expected, so a reason can name it.
+    expected_by_arg: dict[tuple[str, str], list[str]] = {}
+    for tool, expected_args in failed:
+        for name, values in expected_args.items():
+            expected_by_arg.setdefault((tool, name), []).extend(values)
+
+    seen: set[tuple[str, str, str]] = set()
+    for tool, tool_calls in calls.items():
+        for call in tool_calls:
+            for name, values in call.items():
+                for value in values:
+                    if len(value) < MIN_EVIDENCE_LEN:
+                        continue
+                    if not _contains(value, heard) or _contains(value, gold):
+                        continue
+                    key = (tool, name, value)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    said = [
+                        e
+                        for e in expected_by_arg.get((tool, name), [])
+                        if e and e != value and _contains(e, gold)
+                    ]
+                    if said:
+                        reasons.append(
+                            f"`{tool}.{name}`: agent used {value!r} from the transcript, "
+                            f"caller said {said[0]!r}"
+                        )
+                    else:
+                        reasons.append(
+                            f"`{tool}.{name}`: agent used {value!r}, which appears in the "
+                            f"transcript but not in what the caller said"
+                        )
+
+    # A value the caller said that never reached the tool. Needs an expected value,
+    # so this half applies to failed checks only.
+    for tool, expected_args in failed:
+        tool_calls = calls.get(tool, [])
+        for name, expected_values in expected_args.items():
+            for expected in expected_values:
+                if len(expected) < MIN_EVIDENCE_LEN or not _contains(expected, gold):
+                    continue
+                if _contains(expected, heard):
+                    continue  # it was heard; if it still went wrong, not here
+                if any(expected in call.get(name, []) for call in tool_calls):
+                    continue  # it did reach the tool
+                reasons.append(
+                    f"`{tool}.{name}`={expected!r} was spoken but not heard"
+                    + ("" if tool_calls else "; the tool was never called")
+                )
     return reasons
-
-
-def _failed_action_args(
-    sim: dict,
-) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
-    """Arguments of the checks that FAILED, and of the calls actually made.
-
-    Scoped to failed checks on purpose: an argument from a check that passed
-    cannot be evidence that something went wrong.
-    """
-    reward_info = sim.get("reward_info") or {}
-    expected: list[tuple[str, str]] = []
-    for check in reward_info.get("action_checks") or []:
-        if check.get("action_match"):
-            continue
-        expected += _arg_values((check.get("action") or {}).get("arguments") or {})
-
-    actual: list[tuple[str, str]] = []
-    for tick in sim.get("ticks") or []:
-        for call in tick.get("agent_tool_calls") or []:
-            actual += _arg_values(call.get("arguments") or {})
-    return expected, actual
 
 
 def _latest_trials(index) -> dict[str, dict]:
@@ -333,7 +465,7 @@ def _latest_trials(index) -> dict[str, dict]:
     return best
 
 
-def report(run: str, root: Path, include_all: bool, all_errors: bool, out) -> None:
+def report(run: str, root: Path, failing_only: bool, all_errors: bool, out) -> None:
     run_dir = root / "data" / "simulations" / run
     results_path = run_dir / "results.json"
     if not results_path.exists():
@@ -356,7 +488,10 @@ def report(run: str, root: Path, include_all: bool, all_errors: bool, out) -> No
 
     for entry in sorted(latest.values(), key=lambda e: (e.get("reward") or 0)):
         reward = entry.get("reward") or 0
-        if reward >= 1.0 and not include_all:
+        # Every task by default: a mis-heard value can reach a tool call in a
+        # task that still PASSED (the agent recovered, or the check tolerated
+        # it), and those near misses are the cheapest ones to learn from.
+        if failing_only and reward >= 1.0:
             continue
         sim_path = run_dir / "simulations" / f"{entry['id']}.json"
         log = logs.get(entry["id"])
@@ -364,10 +499,9 @@ def report(run: str, root: Path, include_all: bool, all_errors: bool, out) -> No
             continue
         sim = json.loads(sim_path.read_text())
         pairs = _align(_gold_utterances(sim), _heard_transcripts(log))
-        expected_args, actual_args = _failed_action_args(sim)
-        # A passing task has no failed action to trace to, so causal filtering
-        # cannot apply — show its mis-hearings as-is when --all asked for them.
-        filtering = not all_errors and reward < 1.0
+        failed_checks = _failed_checks(sim)
+        calls = _calls_by_name(sim)
+        filtering = not all_errors
 
         rows = []
         for gold_group, heard_group in pairs:
@@ -376,11 +510,18 @@ def report(run: str, root: Path, include_all: bool, all_errors: bool, out) -> No
             cardinality = (len(gold_group), len(heard_group))
             utterances += 1
             score = _similarity(gold, heard) if gold and heard else 0.0
-            if cardinality == (1, 1) and score >= SAME_ENOUGH:
+            # Identical collapsed forms mean the transcript differs only in where
+            # it put the boundaries — a spelled name ("Y, U, S, U, F" / "Y-U-S-U-F"),
+            # a spoken ZIP, an email whose separators were said aloud. Token
+            # similarity scores those below the threshold even though every letter
+            # and digit is right, and each one reported as an error is a
+            # false positive on exactly the utterances that matter most.
+            same_collapsed = bool(gold) and bool(heard) and _blob(gold) == _blob(heard)
+            if cardinality == (1, 1) and (score >= SAME_ENOUGH or same_collapsed):
                 continue
             kind = _classify(gold, heard, cardinality)
             errors += 1
-            reasons = _causal_evidence(gold, heard, expected_args, actual_args)
+            reasons = _causal_evidence(gold, heard, failed_checks, calls)
             if reasons:
                 causal += 1
                 # Counted per class only when causal: a breakdown over every
@@ -407,11 +548,11 @@ def report(run: str, root: Path, include_all: bool, all_errors: bool, out) -> No
                 print(f"  - **caused:** {reason}", file=out)
         print("", file=out)
 
-    scope = "all tasks" if include_all else "failing tasks"
+    scope = "failing tasks" if failing_only else "all tasks"
     lens = (
         "every mis-hearing"
         if all_errors
-        else "only mis-hearings traced to a failed action"
+        else "only mis-hearings that reached a tool call"
     )
     print(f"### Summary ({scope}; {lens})\n", file=out)
     print(
@@ -420,7 +561,7 @@ def report(run: str, root: Path, include_all: bool, all_errors: bool, out) -> No
         file=out,
     )
     print(
-        f"- of those, traced to a failed action: **{causal}**"
+        f"- of those, reached a tool call: **{causal}**"
         + (f"  ({100 * causal / errors:.0f}% of mis-hearings)" if errors else ""),
         file=out,
     )
@@ -431,13 +572,13 @@ def report(run: str, root: Path, include_all: bool, all_errors: bool, out) -> No
         # scope reads as "there were only this many", and the count is also the
         # honest measure of how much a language/endpoint fix would NOT buy.
         print(
-            f"- **{suppressed}** further mis-hearing(s) hidden as not traceable to a "
-            f"failed action — `--all-errors` to see them",
+            f"- **{suppressed}** further mis-hearing(s) hidden as never reaching a "
+            f"tool call — `--all-errors` to see them",
             file=out,
         )
     if not shown:
         print(
-            "\n_No mis-hearings traced to a failed action in scope._"
+            "\n_No mis-hearings reached a tool call in scope._"
             if not all_errors
             else "\n_No mis-hearings found in scope._",
             file=out,
@@ -448,7 +589,9 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("runs", nargs="+")
     parser.add_argument(
-        "--all", action="store_true", help="include passing tasks, not just failures"
+        "--failing-only",
+        action="store_true",
+        help="skip tasks that passed (default: every task)",
     )
     parser.add_argument(
         "--all-errors",
@@ -470,7 +613,7 @@ def main() -> int:
             file=out,
         )
         for run in args.runs:
-            report(run, args.root, args.all, args.all_errors, out)
+            report(run, args.root, args.failing_only, args.all_errors, out)
     finally:
         if args.out:
             out.close()

--- a/scripts/stt_errors.py
+++ b/scripts/stt_errors.py
@@ -244,6 +244,82 @@ def _word_diff(gold: str, heard: str) -> str:
     return "; ".join(bits) if bits else "(normalized forms match)"
 
 
+def _blob(text: str) -> str:
+    """Normalized tokens run together, for substring containment.
+
+    Argument values do not line up with token boundaries: a name spelled letter
+    by letter normalizes to one token (`yusufrossi`) while the expected argument
+    is `Yusuf`, and a ZIP spoken as words becomes `19122` mid-sentence. Matching
+    against the concatenation catches both without a word-boundary rule that
+    would miss them.
+    """
+    return "".join(_normalize(text))
+
+
+def _arg_values(arguments: dict) -> list[tuple[str, str]]:
+    """(argument name, normalized value) for every scalar in a tool call."""
+    out = []
+    for name, value in (arguments or {}).items():
+        items = value if isinstance(value, list) else [value]
+        for item in items:
+            if isinstance(item, (str, int, float)) and not isinstance(item, bool):
+                blob = _blob(str(item))
+                if blob:
+                    out.append((name, blob))
+    return out
+
+
+def _causal_evidence(
+    gold: str,
+    heard: str,
+    expected_args: list[tuple[str, str]],
+    actual_args: list[tuple[str, str]],
+) -> list[str]:
+    """Why this mis-hearing plausibly caused the failure — empty if it didn't.
+
+    Two directions, and both are needed. A value the caller SAID that is missing
+    from what was heard explains an action the agent could not perform (it was
+    never told the right thing). A value present in what was heard and absent
+    from what was said explains an action performed WRONGLY (the mis-hearing
+    became the argument). Reporting only the first would miss the wrong-account
+    class entirely, where every required datum was spoken and the agent still
+    acted on something else.
+    """
+    gold_blob, heard_blob = _blob(gold), _blob(heard)
+    reasons = []
+    for name, value in expected_args:
+        if value and value in gold_blob and value not in heard_blob:
+            reasons.append(f"expected `{name}`={value!r} was spoken but not heard")
+    for name, value in actual_args:
+        if value and value in heard_blob and value not in gold_blob:
+            reasons.append(
+                f"agent used `{name}`={value!r}, which only appears in the transcript"
+            )
+    return reasons
+
+
+def _failed_action_args(
+    sim: dict,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Arguments of the checks that FAILED, and of the calls actually made.
+
+    Scoped to failed checks on purpose: an argument from a check that passed
+    cannot be evidence that something went wrong.
+    """
+    reward_info = sim.get("reward_info") or {}
+    expected: list[tuple[str, str]] = []
+    for check in reward_info.get("action_checks") or []:
+        if check.get("action_match"):
+            continue
+        expected += _arg_values((check.get("action") or {}).get("arguments") or {})
+
+    actual: list[tuple[str, str]] = []
+    for tick in sim.get("ticks") or []:
+        for call in tick.get("agent_tool_calls") or []:
+            actual += _arg_values(call.get("arguments") or {})
+    return expected, actual
+
+
 def _latest_trials(index) -> dict[str, dict]:
     entries = index.values() if isinstance(index, dict) else (index or [])
     best: dict[str, dict] = {}
@@ -257,7 +333,7 @@ def _latest_trials(index) -> dict[str, dict]:
     return best
 
 
-def report(run: str, root: Path, include_all: bool, out) -> None:
+def report(run: str, root: Path, include_all: bool, all_errors: bool, out) -> None:
     run_dir = root / "data" / "simulations" / run
     results_path = run_dir / "results.json"
     if not results_path.exists():
@@ -274,8 +350,8 @@ def report(run: str, root: Path, include_all: bool, out) -> None:
 
     print(f"\n## {run}\n", file=out)
     totals: dict[str, int] = {}
-    utterances = errors = 0
-    identity_errors: list[str] = []
+    utterances = errors = causal = 0
+    suppressed = 0
     shown = 0
 
     for entry in sorted(latest.values(), key=lambda e: (e.get("reward") or 0)):
@@ -288,6 +364,10 @@ def report(run: str, root: Path, include_all: bool, out) -> None:
             continue
         sim = json.loads(sim_path.read_text())
         pairs = _align(_gold_utterances(sim), _heard_transcripts(log))
+        expected_args, actual_args = _failed_action_args(sim)
+        # A passing task has no failed action to trace to, so causal filtering
+        # cannot apply — show its mis-hearings as-is when --all asked for them.
+        filtering = not all_errors and reward < 1.0
 
         rows = []
         for gold_group, heard_group in pairs:
@@ -300,43 +380,68 @@ def report(run: str, root: Path, include_all: bool, out) -> None:
                 continue
             kind = _classify(gold, heard, cardinality)
             errors += 1
-            totals[kind] = totals.get(kind, 0) + 1
-            identity = bool(IDENTITY_HINT_RE.search(gold))
-            if identity:
-                identity_errors.append(f"{run} task {entry['task_id']}: {kind}")
-            rows.append((kind, gold, heard, score, identity))
+            reasons = _causal_evidence(gold, heard, expected_args, actual_args)
+            if reasons:
+                causal += 1
+                # Counted per class only when causal: a breakdown over every
+                # mis-hearing would not describe the rows actually printed.
+                totals[kind] = totals.get(kind, 0) + 1
+            elif filtering:
+                suppressed += 1
+                continue
+            rows.append((kind, gold, heard, score, reasons))
 
         if not rows:
             continue
         shown += 1
         print(f"### task `{entry['task_id']}` — reward {reward}\n", file=out)
-        for kind, gold, heard, score, identity in rows:
-            flag = "  ⚠️ **feeds a tool argument**" if identity else ""
-            print(f"- **{kind}**{flag}", file=out)
+        for kind, gold, heard, score, reasons in rows:
+            print(f"- **{kind}**", file=out)
             print(f"  - said:  `{gold}`", file=out)
             print(f"  - heard: `{heard or '(nothing)'}`", file=out)
             print(
                 f"  - diff:  {_word_diff(gold, heard)}  (similarity {score:.2f})",
                 file=out,
             )
+            for reason in reasons:
+                print(f"  - **caused:** {reason}", file=out)
         print("", file=out)
 
     scope = "all tasks" if include_all else "failing tasks"
-    print(f"### Summary ({scope})\n", file=out)
+    lens = (
+        "every mis-hearing"
+        if all_errors
+        else "only mis-hearings traced to a failed action"
+    )
+    print(f"### Summary ({scope}; {lens})\n", file=out)
     print(
         f"- utterances compared: **{utterances}**, mis-heard: **{errors}**"
         + (f"  ({100 * errors / utterances:.0f}%)" if utterances else ""),
         file=out,
     )
-    for kind, n in sorted(totals.items(), key=lambda kv: -kv[1]):
-        print(f"  - {n}x {kind}", file=out)
     print(
-        f"- mis-hearings on utterances that feed a tool argument: "
-        f"**{len(identity_errors)}** — these are the ones that move the score",
+        f"- of those, traced to a failed action: **{causal}**"
+        + (f"  ({100 * causal / errors:.0f}% of mis-hearings)" if errors else ""),
         file=out,
     )
+    for kind, n in sorted(totals.items(), key=lambda kv: -kv[1]):
+        print(f"  - {n}x {kind}", file=out)
+    if suppressed and not all_errors:
+        # Said out loud rather than silently dropped: a filter that hides its own
+        # scope reads as "there were only this many", and the count is also the
+        # honest measure of how much a language/endpoint fix would NOT buy.
+        print(
+            f"- **{suppressed}** further mis-hearing(s) hidden as not traceable to a "
+            f"failed action — `--all-errors` to see them",
+            file=out,
+        )
     if not shown:
-        print("\n_No mis-hearings found in scope._", file=out)
+        print(
+            "\n_No mis-hearings traced to a failed action in scope._"
+            if not all_errors
+            else "\n_No mis-hearings found in scope._",
+            file=out,
+        )
 
 
 def main() -> int:
@@ -344,6 +449,11 @@ def main() -> int:
     parser.add_argument("runs", nargs="+")
     parser.add_argument(
         "--all", action="store_true", help="include passing tasks, not just failures"
+    )
+    parser.add_argument(
+        "--all-errors",
+        action="store_true",
+        help="every mis-hearing, not just those traced to a failed action",
     )
     parser.add_argument("--root", type=Path, default=Path.cwd())
     parser.add_argument("--out", type=Path)
@@ -360,7 +470,7 @@ def main() -> int:
             file=out,
         )
         for run in args.runs:
-            report(run, args.root, args.all, out)
+            report(run, args.root, args.all, args.all_errors, out)
     finally:
         if args.out:
             out.close()

--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -45,6 +45,7 @@ from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union
 from loguru import logger
 
 if TYPE_CHECKING:
+    from tau2.voice.audio_native.aai.provider import AAIVADConfig
     from tau2.voice.audio_native.gemini.provider import GeminiVADConfig
     from tau2.voice.audio_native.livekit.config import CascadedConfig
     from tau2.voice.audio_native.nova.provider import NovaVADConfig
@@ -80,7 +81,7 @@ from tau2.voice.audio_native.adapter import DiscreteTimeAdapter, create_adapter
 from tau2.voice.audio_native.tick_result import TickResult
 
 # Provider type alias
-AudioNativeProvider = Literal["openai", "gemini", "xai", "nova", "qwen", "livekit"]
+AudioNativeProvider = Literal["openai", "gemini", "xai", "nova", "qwen", "aai", "livekit"]
 
 # VAD config union type (string annotations for lazy resolution)
 VADConfig = Union[
@@ -89,6 +90,7 @@ VADConfig = Union[
     "XAIVADConfig",
     "NovaVADConfig",
     "QwenVADConfig",
+    "AAIVADConfig",
 ]
 
 AUDIO_NATIVE_VOICE_INSTRUCTION = """
@@ -288,6 +290,10 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
             from tau2.voice.audio_native.qwen.provider import QwenVADConfig
 
             self.vad_config = QwenVADConfig()
+        elif provider == "aai":
+            from tau2.voice.audio_native.aai.provider import AAIVADConfig
+
+            self.vad_config = AAIVADConfig()
         elif provider == "livekit":
             from tau2.voice.audio_native.livekit.discrete_time_adapter import (
                 LiveKitVADConfig,

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -239,7 +239,7 @@ def add_run_args(parser):
     parser.add_argument(
         "--audio-native-provider",
         type=str,
-        choices=["openai", "gemini", "xai", "livekit"],
+        choices=["openai", "gemini", "xai", "nova", "qwen", "aai", "livekit"],
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
         help=f"Audio native API provider. Default is '{DEFAULT_AUDIO_NATIVE_PROVIDER}'.",
     )

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -195,6 +195,9 @@ DEFAULT_AAI_WS_URL = "ws://localhost:3000/websocket"  # overridable via AAI_WS_U
 DEFAULT_AAI_MODEL = "host"  # fixed, determined by endpoint
 DEFAULT_AAI_INPUT_SAMPLE_RATE = 16000  # PCM16 sent to aai (STT)
 DEFAULT_AAI_OUTPUT_SAMPLE_RATE = 24000  # PCM16 received from aai (TTS)
+DEFAULT_AAI_CONFIG_FRAME_TIMEOUT = (
+    10.0  # seconds to await the server config handshake frame
+)
 
 # =============================================================================
 # PROVIDER REGISTRY (derived from above)

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -208,6 +208,7 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
     "xai": DEFAULT_XAI_MODEL,
     "nova": DEFAULT_NOVA_MODEL,
     "qwen": DEFAULT_QWEN_MODEL,
+    "aai": DEFAULT_AAI_MODEL,
     "livekit": "dummy",
 }
 
@@ -217,6 +218,7 @@ DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
     "xai": None,
     "nova": None,
     "qwen": None,
+    "aai": None,
     "livekit": None,
 }
 
@@ -226,6 +228,7 @@ AUDIO_NATIVE_PROVIDER_TYPES = {
     "xai": "audio_native",
     "nova": "audio_native",
     "qwen": "audio_native",
+    "aai": "audio_native",
     "livekit": "cascaded",
 }
 

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -198,6 +198,10 @@ DEFAULT_AAI_OUTPUT_SAMPLE_RATE = 24000  # PCM16 received from aai (TTS)
 DEFAULT_AAI_CONFIG_FRAME_TIMEOUT = (
     10.0  # seconds to await the server config handshake frame
 )
+# Spoken by the host agent on session start so the call doesn't open with dead
+# air while the S2S model waits through the user's first turn. Empty string
+# disables the greeting.
+DEFAULT_AAI_GREETING = "Thank you for calling. How can I help you today?"
 
 # =============================================================================
 # PROVIDER REGISTRY (derived from above)

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -78,6 +78,22 @@ DEFAULT_VOICE_SYNTHESIS_PROVIDER = "elevenlabs"
 DEFAULT_VOICE_TRANSCRIPTION_MODEL = "nova-3"
 DEFAULT_VOICE_MODEL = "eleven_v3"
 
+# Ceiling on TTS calls in flight at once, PROCESS-WIDE (see
+# tau2.voice.synthesis.synthesize). TTS providers cap concurrency per
+# subscription and answer 429 `concurrent_limit_exceeded` over it; ElevenLabs'
+# lower tiers allow 5. Exceeding it is not merely slower — a synthesis that
+# burns its retries is a caller utterance that arrives late or not at all, and
+# `--max-concurrency` does not bound this on its own, because a single
+# simulation fans out (OutOfTurnSpeechGenerator pre-generates its inserts in a
+# thread pool).
+#
+# Default 4, one below the common cap, leaving room for an in-flight retry.
+# This is PER PROCESS: running K benchmarks in parallel against one key allows
+# K x this, so set TAU2_TTS_MAX_CONCURRENCY to floor(cap / K) for those runs
+# (the env override is read in tau2.voice.synthesis.synthesize; this module is
+# deliberately import-free).
+DEFAULT_TTS_MAX_CONCURRENCY = 4
+
 # Text streaming (legacy)
 DEFAULT_TEXT_STREAMING_CHUNK_BY = "words"
 DEFAULT_TEXT_STREAMING_CHUNK_SIZE = 1

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -189,6 +189,14 @@ DEFAULT_QWEN_INPUT_SAMPLE_RATE = 16000  # fixed, API-defined
 DEFAULT_QWEN_OUTPUT_SAMPLE_RATE = 24000  # fixed, API-defined
 
 # =============================================================================
+# AAI PROVIDER (local voice-agent host; overridable URL/rates)
+# =============================================================================
+DEFAULT_AAI_WS_URL = "ws://localhost:3000/websocket"  # overridable via AAI_WS_URL
+DEFAULT_AAI_MODEL = "host"  # fixed, determined by endpoint
+DEFAULT_AAI_INPUT_SAMPLE_RATE = 16000  # PCM16 sent to aai (STT)
+DEFAULT_AAI_OUTPUT_SAMPLE_RATE = 24000  # PCM16 received from aai (TTS)
+
+# =============================================================================
 # PROVIDER REGISTRY (derived from above)
 # =============================================================================
 DEFAULT_AUDIO_NATIVE_MODELS = {

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -70,9 +70,9 @@ class AudioNativeConfig(BaseModel):
     """
 
     # Provider selection
-    provider: Literal["openai", "gemini", "xai", "nova", "qwen", "livekit"] = Field(
+    provider: Literal["openai", "gemini", "xai", "nova", "qwen", "aai", "livekit"] = Field(
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
-        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
+        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), 'aai' (AssemblyAI voice-agent host), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
     )
 
     # Cascaded config (for livekit provider)

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -72,7 +72,7 @@ class AudioNativeConfig(BaseModel):
     # Provider selection
     provider: Literal["openai", "gemini", "xai", "nova", "qwen", "aai", "livekit"] = Field(
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
-        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), 'aai' (AssemblyAI voice-agent host), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
+        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), 'aai' (local aai voice-agent host), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
     )
 
     # Cascaded config (for livekit provider)

--- a/src/tau2/voice/README.md
+++ b/src/tau2/voice/README.md
@@ -17,6 +17,10 @@ tau2 run --domain retail --audio-native --num-tasks 1 --verbose-logs
 
 The default provider is `openai`. Use `--audio-native-model` to override the default model for a provider.
 
+The AAI provider needs an agent you run yourself and `AAI_ALLOW_HOST=1` on it —
+see [`audio_native/aai/README.md`](audio_native/aai/README.md) for setup, and for
+a worked STT-endpoint A/B (two dev servers, one agent, one variable).
+
 ## Speech Complexity
 
 The `--speech-complexity` flag controls the realism of the user simulator's speech environment:

--- a/src/tau2/voice/README.md
+++ b/src/tau2/voice/README.md
@@ -13,7 +13,7 @@ tau2 run --domain retail --audio-native --num-tasks 1 --verbose-logs
 | OpenAI Realtime | `--audio-native-provider openai` | `OPENAI_API_KEY` |
 | Google Gemini Live | `--audio-native-provider gemini` | `GOOGLE_API_KEY` |
 | xAI Grok Voice | `--audio-native-provider xai` | `XAI_API_KEY` |
-| AAI | `--audio-native-provider aai` | `AAI_WS_URL` (local host mode) |
+| AAI | `--audio-native-provider aai` | `AAI_WS_URL`; `ASSEMBLYAI_API_KEY` for a deployed agent |
 
 The default provider is `openai`. Use `--audio-native-model` to override the default model for a provider.
 
@@ -134,7 +134,8 @@ See the [Voice Persona Setup Guide](../../docs/voice-personas.md) for step-by-st
 | `OPENAI_API_KEY` | OpenAI Realtime provider |
 | `GOOGLE_API_KEY` | Gemini Live provider |
 | `XAI_API_KEY` | xAI Grok Voice provider |
-| `AAI_WS_URL` | AAI voice-agent host (local mode) |
+| `AAI_WS_URL` | AAI voice-agent host (local or deployed) |
+| `ASSEMBLYAI_API_KEY` | Owner key for host mode against a *deployed* AAI agent |
 | `ELEVENLABS_API_KEY` | User simulator TTS (synthesis) |
 | `DEEPGRAM_API_KEY` | Transcription (Deepgram nova-2, nova-3) |
 | `TAU2_VOICE_ID_*` | Custom voice ID overrides (see [Voice Persona Setup](../../docs/voice-personas.md)) |

--- a/src/tau2/voice/README.md
+++ b/src/tau2/voice/README.md
@@ -13,6 +13,7 @@ tau2 run --domain retail --audio-native --num-tasks 1 --verbose-logs
 | OpenAI Realtime | `--audio-native-provider openai` | `OPENAI_API_KEY` |
 | Google Gemini Live | `--audio-native-provider gemini` | `GOOGLE_API_KEY` |
 | xAI Grok Voice | `--audio-native-provider xai` | `XAI_API_KEY` |
+| AAI | `--audio-native-provider aai` | `AAI_WS_URL` (local host mode) |
 
 The default provider is `openai`. Use `--audio-native-model` to override the default model for a provider.
 
@@ -133,6 +134,7 @@ See the [Voice Persona Setup Guide](../../docs/voice-personas.md) for step-by-st
 | `OPENAI_API_KEY` | OpenAI Realtime provider |
 | `GOOGLE_API_KEY` | Gemini Live provider |
 | `XAI_API_KEY` | xAI Grok Voice provider |
+| `AAI_WS_URL` | AAI voice-agent host (local mode) |
 | `ELEVENLABS_API_KEY` | User simulator TTS (synthesis) |
 | `DEEPGRAM_API_KEY` | Transcription (Deepgram nova-2, nova-3) |
 | `TAU2_VOICE_ID_*` | Custom voice ID overrides (see [Voice Persona Setup](../../docs/voice-personas.md)) |

--- a/src/tau2/voice/audio_native/README.md
+++ b/src/tau2/voice/audio_native/README.md
@@ -9,6 +9,7 @@ Full-duplex voice evaluation via provider-specific realtime APIs. Each provider 
 | **openai** | Native audio | OpenAI Realtime API | gpt-realtime-1.5 |
 | **gemini** | Native audio | Google Gemini Live | gemini-3.1-flash-live-preview |
 | **xai** | Native audio | xAI Grok Voice Agent | xai-realtime |
+| **aai** | Native audio | Local AAI voice-agent host | host |
 | **nova** | Native audio | Amazon Nova Sonic | amazon.nova-2-sonic-v1:0 |
 | **qwen** | Native audio | Alibaba Qwen Omni | qwen3-omni-flash-realtime |
 | **livekit** | Cascaded (STT→LLM→TTS) | LiveKit + Deepgram + OpenAI | Configurable |

--- a/src/tau2/voice/audio_native/aai/README.md
+++ b/src/tau2/voice/audio_native/aai/README.md
@@ -196,32 +196,54 @@ noisy rather than comparable.
 ## 6. Read the results
 
 ```sh
-for r in retail-stt-default-20 retail-stt-sandbox-20; do
-  echo "== $r"
-  jq '[.simulations[].reward] | add/length' data/simulations/$r/results.json
-done
+uv run python scripts/failure_report.py retail-stt-default-20 retail-stt-sandbox-20
+
+# or, to paste into a coding agent
+uv run python scripts/failure_report.py retail-stt-default-20 --top 12 --out failures.md
 ```
 
-Four traps, in the order they bite:
+The report is ordered the way a fix needs it:
 
-1. **Wait for retries to settle.** A retry *overwrites* the earlier score, so a
-   mid-run average is not the result. Read `results.json` only after both runs
-   exit.
-2. **Result panels print in completion order**, not task order. Take task ids
-   from `results.json`'s `simulation_index`, never from the log's panel order.
-3. **A low reward with high `NL_ASSERTION` means authentication failed**, not
-   that the agent converses badly. A call that never gets past
-   `find_user_id_by_name_zip` executes zero expected actions yet still scores
-   NL 1.0 for handling it gracefully. Since this A/B is about STT, that is the
-   number that should move.
-4. **Failing calls run long.** An agent that cannot authenticate keeps retrying,
-   so any wall-clock cap kills already-doomed conversations preferentially — the
-   worse arm loses more sessions to timeouts than to scoring, which exaggerates
-   the gap.
+- **Run trust first**, before any score — caller-voice 429s, sessions that
+  produced no scored row, reconnects, `error`/`idle_timeout` counts. If these
+  are non-zero, everything below is partly measuring the harness.
+- **Wire anomalies, separately from reward** — transcripts emitted past a turn's
+  terminal `cancelled` frame, user turns that never got a `reply_done`,
+  first-word gaps over 10s, zero-duration speech windows. A 0.0 caused by a
+  provider that never connected is not evidence about agent quality, and the two
+  want different fixes.
+- **Failures worst-first**, each with a named failure mode, the expected action
+  beside the call the agent really made, and the judge's own justification for
+  every missed assertion.
 
-For per-turn detail, the wire events are in
-`data/simulations/<run>/artifacts/task_*/sim_*/task.log` (`grep 'AAI event:'`),
-and the tool-call arguments — which is where STT errors become score errors —
-are in `data/simulations/<run>/simulations/*.json` under each tick's
-`agent_tool_calls`. Note `sim["messages"]` is empty; it is not the place to
-look.
+The argument diff is usually the finding. On an STT-bound domain a wrong call is
+the mis-hearing made visible — and it is worth reading closely, because the
+failure is not always a mangled digit. One measured run returned an item on
+order `#W5490111` with `credit_card_3124723` where the task expected `#W7387996`
+with `paypal_9497703`: a different order *and* payment method, i.e. an
+STT-mangled email that resolved to **a different real user**, scored NL 1.0
+because the call itself was conducted well.
+
+The script handles three traps that produced wrong conclusions when this was
+done by hand — it collapses retries to the highest trial per task (a retry
+*overwrites* the earlier score, so counting every row mixes a superseded score
+into the mean), labels an incomplete run instead of averaging it as final, and
+keeps wire failures out of the reward numbers.
+
+Two more it cannot handle for you:
+
+- **A low reward with high `NL_ASSERTION` means the agent acted wrong, not that
+  it spoke badly** — most often that it never got past authentication, since a
+  call that fails `find_user_id_by_name_zip` executes zero expected actions and
+  still scores NL 1.0 for handling it gracefully. The report names this
+  `NEVER_AUTHENTICATED` / `WRONG_ACTIONS_GOOD_TALK`, but which one you care
+  about is a judgement about what you changed.
+- **Failing calls run long**, because an agent that cannot authenticate keeps
+  retrying. Any wall-clock cap therefore kills already-doomed conversations
+  preferentially, so the worse arm loses more sessions to timeouts than to
+  scoring and the gap looks larger than it is.
+
+For raw detail the report points at both files per failure: the wire events in
+`data/simulations/<run>/artifacts/task_*/sim_*/task.log` (`grep 'AAI event:'`)
+and the per-tick tool calls in `data/simulations/<run>/simulations/*.json`. Note
+`sim["messages"]` is empty in audio-native runs — the ticks are the only record.

--- a/src/tau2/voice/audio_native/aai/README.md
+++ b/src/tau2/voice/audio_native/aai/README.md
@@ -257,11 +257,11 @@ thing":
 ```sh
 uv run python scripts/stt_errors.py retail-stt-default-20 retail-stt-sandbox-20
 
-# every mis-hearing, including ones that changed nothing
+# every mis-hearing, including ones that never reached a tool call
 uv run python scripts/stt_errors.py retail-stt-default-20 --all-errors
 
-# include tasks that passed too
-uv run python scripts/stt_errors.py retail-stt-default-20 --all
+# skip tasks that passed
+uv run python scripts/stt_errors.py retail-stt-default-20 --failing-only
 ```
 
 Ground truth exists because tau2 *synthesizes* the caller: every `user_chunk`
@@ -269,30 +269,50 @@ carries an `audio_script_gold` naming the exact text spoken. The script pairs
 those against the agent's `user_transcript` wire events and prints
 said/heard/diff per utterance.
 
-**By default it shows only the mis-hearings it can trace to a failed action**,
-each with a `caused:` line naming the argument:
+**By default it shows only the mis-hearings that reached a tool call**, across
+every task — including tasks that PASSED, since a mis-heard argument the agent
+recovered from is a near miss worth seeing before it costs a run. Each row
+carries a `caused:` line naming the argument:
 
 ```
-- DIGITS — numeric substitution (zip / order id / phone)
-  - said:  `K, O, V, A, C, S.`
-  - heard: `K-O-B-A-C-S. Okay, so this one, people`
-  - caused: expected `last_name`='kovacs' was spoken but not heard
-  - caused: agent used `last_name`='kobacs', which only appears in the transcript
+- SUBSTITUTION — words swapped (homophone or proper noun)
+  - said:  `M, E, I—D, A, V, I, S. Zip is eight, zero, two, one, seven.`
+  - heard: `M-E-I-D-A-B-I-S. Zip is 80217.`
+  - caused: `find_user_id_by_name_zip.last_name`: agent used 'dabis', which
+            appears in the transcript but not in what the caller said
 ```
 
-The trace runs both directions, and both are needed. A value the caller *said*
-that is missing from what was heard explains an action the agent could not
-perform — it was never told the right thing. A value present in what was heard
-and absent from what was said explains an action performed *wrongly* — the
-mis-hearing became the argument. Only the second catches the wrong-account class,
-where every required datum was spoken and the agent still acted on something
-else.
+The rule needs no expected value, which is what lets it cover passing tasks: an
+argument whose value is in the transcript and was never *said* is a mis-hearing
+that got as far as a tool call. When a failed check does name an expected value,
+two things are added — the reason says what the caller actually said, and a value
+that was spoken but never reached the tool at all is reported too (an action the
+agent could not perform because it was never told the right thing). A value that
+*is* present in what the caller said is never evidence, however unlike the
+transcript it looks.
 
 This matters because most mis-hearings are harmless: on the measured runs only
-**17%** and **23%** of them could be traced to a failed action. A report listing
-all of them invites fixing the loudest rather than the costly one. The count of
-what was hidden is still printed, since that number is also the honest ceiling
-on what a language or endpoint fix would buy.
+**~10%** of them reached a tool call. A report listing all of them invites fixing
+the loudest rather than the costly one. The hidden count is still printed, since
+that number is also the honest ceiling on what a language or endpoint fix would
+buy.
+
+Three false-positive sources were found by reading its own output, and all three
+are worth knowing about if you extend it:
+
+- **Spelled-out separators.** A caller spelling an email says `dot` and `at`
+  aloud; STT writes punctuation. Both are folded, gated on the utterance looking
+  address-ish, so `mia.garcia2723@example.com` stops reading as an error — it is a
+  *correct* transcription.
+- **Cross-word substring matches.** Comparing against a space-less form made
+  `"And when you say that"` contain `usa`, so an agent's `country='usa'` was
+  blamed on an utterance that never mentioned a country. Matching is now anchored
+  to token boundaries (inside one token, or an exact run of consecutive ones).
+- **Asymmetric spelling punctuation.** Gold `"M, E, I—D, A, V, I, S"` against
+  heard `"M-E-I-D-A-B-I-S"`: deleting dashes alone left the gold as
+  `me | id | avis` versus one token for the transcript, so *every* argument looked
+  absent from what the caller said. Spelled runs are collapsed before any
+  dash handling.
 
 Errors are classed because the classes need different remedies, and only one of
 them is fixable agent-side:

--- a/src/tau2/voice/audio_native/aai/README.md
+++ b/src/tau2/voice/audio_native/aai/README.md
@@ -247,3 +247,53 @@ For raw detail the report points at both files per failure: the wire events in
 `data/simulations/<run>/artifacts/task_*/sim_*/task.log` (`grep 'AAI event:'`)
 and the per-tick tool calls in `data/simulations/<run>/simulations/*.json`. Note
 `sim["messages"]` is empty in audio-native runs — the ticks are the only record.
+
+## 7. Find the STT errors behind a failure
+
+For an STT A/B this is the report that matters, because it is the only one that
+distinguishes "the agent did the wrong thing" from "the agent was told the wrong
+thing":
+
+```sh
+uv run python scripts/stt_errors.py retail-stt-default-20 retail-stt-sandbox-20
+
+# include tasks that passed too
+uv run python scripts/stt_errors.py retail-stt-default-20 --all
+```
+
+Ground truth exists because tau2 *synthesizes* the caller: every `user_chunk`
+carries an `audio_script_gold` naming the exact text spoken. The script pairs
+those against the agent's `user_transcript` wire events and prints said/heard/diff
+per utterance, flagging the ones whose content reaches a tool argument (`⚠️`) —
+names, ZIPs, emails, order ids — since those are where a mis-hearing becomes a
+score.
+
+Errors are classed because the classes need different remedies, and only one of
+them is fixable agent-side:
+
+| class | meaning | agent-side retry helps? |
+| --- | --- | --- |
+| `NON_LATIN_SCRIPT` | English came back in Devanagari/Hebrew/etc. | no — language detection |
+| `NEGATION` | polarity flipped; meaning inverted | no |
+| `EMAIL` | address structure lost (`@` gone) | no |
+| `DIGITS` | ZIP / order id substitution | each retry is an independent coin flip |
+| `SUBSTITUTION` | homophone or proper noun swapped | sometimes — one candidate may be right |
+| `SPLIT` / `MERGED` | utterance boundaries disagree with the simulator's | no — endpointing |
+| `TRUNCATED` / `NOT_HEARD` | most or all of it missing | no |
+| `MINOR` | inflection or filler only | n/a, not worth chasing |
+
+Two things it is careful about, both of which produced false findings in the
+first draft:
+
+- **The comparison is normalized.** A ZIP spoken `"one, nine, one, two, two"`
+  and transcribed `"19122"` is *correct*; so is `"Y-U-S-U-F"` for
+  `"Y, U, S, U, F"`. Raw diffing flags nearly every authentication utterance,
+  which buries the real errors. Digit words fold to digits, digit runs join,
+  hyphens are deleted (not spaced — otherwise `t-shirt` splits into two tokens
+  and a perfect transcript scores as a mismatch), and only what remains counts.
+- **Alignment is not positional.** STT decides utterance boundaries and the
+  simulator decides utterances, and they disagree — a pause or a `[sneeze]`
+  splits one into two. Index pairing shifts every later row after the first
+  split, so the whole rest of the call reads as errors. The script aligns
+  greedily over 1:1, 1:2 and 2:1 and reports the cardinality, because a split is
+  itself a finding: the agent answered half a sentence.

--- a/src/tau2/voice/audio_native/aai/README.md
+++ b/src/tau2/voice/audio_native/aai/README.md
@@ -50,10 +50,14 @@ assumes a local agent.
   dev server falls back to for `ASSEMBLYAI_API_KEY`, so without it the agent
   boots and then fails at STT connect.
 - An SDK build containing `assemblyAIStt({ streamingUrl })`
-  ([agent#976](https://github.com/alexkroman/agent/pull/976)). Without it the
-  descriptor can only select a host via `region: "us" | "eu"`, and arm B below
+  ([agent#976](https://github.com/alexkroman/agent/pull/976), merged). Without it
+  the descriptor can only select a host via `region: "us" | "eu"`, and arm B below
   silently runs on the default endpoint — i.e. you measure nothing and it looks
   like a null result.
+- For `assemblyAIStt({ languages })`, also
+  [agent#978](https://github.com/alexkroman/agent/pull/978). Without it, drop that
+  line from the `agent.ts` below; the run still works, with the language caveat
+  described in "Settings that matter".
 
 ## 2. The agent project
 
@@ -85,8 +89,16 @@ export default agent({
   greeting: "",
   // No sttPrompt on purpose: the harness sends its own via the host config
   // block, keeping the benchmark's STT biasing with the benchmark.
-  stt: assemblyAIStt(streamingUrl ? { streamingUrl } : {}),
-  llm: assemblyAILlm({ model: "gpt-5.5" }),
+  // languages: ["en"] — an unset language is NOT English. Universal-3.5 Pro
+  // code-switches across 18 languages, and unpinned it returned English
+  // utterances transliterated into Devanagari and Hebrew script, authentication
+  // turns included. See "Settings that matter" below.
+  stt: assemblyAIStt({
+    languages: ["en"],
+    ...(streamingUrl ? { streamingUrl } : {}),
+  }),
+  // reasoningEffort: "none" — time-to-first-token IS the voice quality here.
+  llm: assemblyAILlm({ model: "gpt-5.5", reasoningEffort: "none" }),
   tts: assemblyAITts(),
 });
 ```
@@ -343,3 +355,73 @@ first draft:
   split, so the whole rest of the call reads as errors. The script aligns
   greedily over 1:1, 1:2 and 2:1 and reports the cardinality, because a split is
   itself a finding: the agent answered half a sentence.
+
+# Settings that matter (measured, not guessed)
+
+Every number here comes from reading a real run's artifacts. Where a setting was
+left alone, the measurement is the reason.
+
+## Change: `reasoningEffort: "none"` on the LLM
+
+The dominant voice defect is **dead air before the agent's first word**, not
+turn-taking. Measured on a 5-task retail run: 12 of 53 turns waited over 5s for
+the first agent word, median 1.62s, worst **19.1s**. Decomposing all ten gaps
+over 8s, every single one had a real content word first (`Got`, `One`, `Thanks`)
+and **no tool call yet in that turn** — so the gap is the model thinking.
+
+Nothing in the pipeline covers that window. `holdPhrase` fires when a turn
+*opens with a tool call*; the dead-air cover measures *tool execution*. Both are
+downstream of the first token, which is why one of those gaps was the hold phrase
+itself (`One moment.`) arriving 10.9s late. Covering time-to-first-token would
+need a timer armed at turn commit, independent of the model stream — a code
+change, not a setting.
+
+## Change: `languages: ["en"]` on the STT
+
+An unset language is *not* English — Universal-3.5 Pro code-switches across 18
+languages, deciding per turn. Unpinned, English utterances came back
+transliterated: `Hello? Any update?` as `हेलो एनी अपडेट`, and an authentication
+turn as `यूसुफ रॉसी, ज़िप कोड 19122।`, so the tool call built from it was garbage.
+
+Caveat on expectations: on the 20-task runs, **none** of the causal mis-hearings
+(the ones that reached a tool call) were in that class. Pinning the language is
+still right — an auth turn *did* come back in Devanagari, and that is luck rather
+than safety — but do not expect it to move the score much on its own.
+
+## Leave alone: `minBargeInWords` (2), `interruptionMinDurationMs` (500)
+
+**17 of 18 barge-ins were followed by a genuine committed user turn** — one false
+positive in the run. These are correctly tuned for this workload.
+
+`speech_started` → barge-in is median 2.09s, which looks like it wants
+`minBargeInWords: 1`. It does not: that delay is STT partial cadence, not the
+gate. What you would buy is the simulated caller's `"Okay."` and `"Uh-huh."`
+backchannels cutting the agent off mid-sentence.
+
+## Leave alone: `falseInterruptionTimeoutMs` (2000)
+
+The server log looks alarming — `false-interruption resume` followed by
+`resume mooted by committed user turn`, repeatedly — and cancel→commit really
+does straddle the timer (median 1.72s, p75 2.33s, max 4.35s), so a 2000ms window
+fires mid-distribution.
+
+It is nonetheless handled by design: the mooting path aborts the resume **while
+it is still silent** (`!hasTurnSpoken()`), so nothing is played over the caller.
+In the measured log 3 of 4 resumes were mooted and the 4th was the one genuinely
+false interruption. The residual cost is a wasted LLM turn, not audible damage.
+Raising the window would trade that for slower recovery on real false alarms.
+
+## Leave alone: `minTurnSilenceMs` (2000)
+
+It adds ~2s to every turn, so it is the obvious latency target. But the STT
+report finds **SPLIT** errors on this domain — one utterance becoming two turns —
+which means it is sometimes too *short*. Retail authentication is spelled-out
+names and digits with deliberate pauses, so if anything it wants raising here,
+paying latency you are better off recovering from the model.
+
+## Not a setting
+
+Two defects in this list are SDK-side ordering bugs, visible in the wire log and
+unaffected by any constant: `agent_transcript` emitted after a turn's terminal
+`cancelled` frame, and user turns that never receive a `reply_done`. Both are
+reported by `scripts/failure_report.py` under "Wire anomalies".

--- a/src/tau2/voice/audio_native/aai/README.md
+++ b/src/tau2/voice/audio_native/aai/README.md
@@ -1,0 +1,227 @@
+# AAI audio-native provider
+
+Runs tau2-bench against an [AAI](https://github.com/alexkroman/agent) voice
+agent over its WebSocket session protocol.
+
+**"AAI" here is the `@alexkroman1/aai` agent framework, not AssemblyAI the
+transcription service.** The framework happens to default to AssemblyAI
+providers for STT/LLM/TTS, but the thing under test is an agent you run
+yourself — locally via `aai dev`, or deployed to the AAI platform.
+
+The provider always connects in **host mode** (`?host=1`): tau2 supplies the
+system prompt and the domain's tool schemas, and the agent contributes only its
+provider triple (STT + LLM + TTS). That is what makes this harness useful for
+comparing *speech* pipelines — the reasoning half of the agent is tau2's, held
+constant, so a score difference is attributable to the voice stack.
+
+## Quick start (local agent)
+
+```sh
+# terminal 1 — the agent
+cd ~/Code/agent/<your-project> && AAI_ALLOW_HOST=1 npx aai dev
+
+# terminal 2 — the benchmark
+AAI_WS_URL=ws://localhost:3000/websocket uv run tau2 run \
+  --domain retail --audio-native --audio-native-provider aai \
+  --num-tasks 5 --max-concurrency 1 --save-to my-run --verbose-logs
+```
+
+`AAI_ALLOW_HOST=1` is required and easy to miss. Host mode lets the *client*
+supply the agent definition while the session spends the operator's provider
+credentials, so the AAI dev server refuses it unless explicitly enabled — the
+symptom otherwise is a rejected upgrade, not a helpful error.
+
+`AAI_WS_URL` defaults to `ws://localhost:3000/websocket`, which matches
+`aai dev`'s default port, so the local case needs no override. A **deployed**
+agent uses `wss://<host>/<slug>/websocket` and also needs `ASSEMBLYAI_API_KEY`.
+
+---
+
+# Reproducing the STT endpoint A/B
+
+This is the comparison the provider was built for: the same agent, run twice,
+differing **only** in which STT streaming endpoint it dials. Everything below
+assumes a local agent.
+
+## 1. Prerequisites
+
+- The [agent repo](https://github.com/alexkroman/agent) cloned, with
+  `pnpm install` run and `npx aai login` completed. The login key is what the
+  dev server falls back to for `ASSEMBLYAI_API_KEY`, so without it the agent
+  boots and then fails at STT connect.
+- An SDK build containing `assemblyAIStt({ streamingUrl })`
+  ([agent#976](https://github.com/alexkroman/agent/pull/976)). Without it the
+  descriptor can only select a host via `region: "us" | "eu"`, and arm B below
+  silently runs on the default endpoint — i.e. you measure nothing and it looks
+  like a null result.
+
+## 2. The agent project
+
+Both arms must run **byte-identical agent code**, or a score difference could
+be a source drift between two copies rather than the endpoint. So: one project,
+one `agent.ts`, and the endpoint comes from the environment.
+
+Create a project directory (this lives outside both repos — it is your local
+harness, not a checked-in fixture) whose `node_modules/@alexkroman1/*` link to
+the agent repo's `packages/*`, then write:
+
+```ts
+// agent.ts
+import { agent } from "@alexkroman1/aai";
+import { assemblyAILlm } from "@alexkroman1/aai/llm";
+import { assemblyAIStt } from "@alexkroman1/aai/stt";
+import { assemblyAITts } from "@alexkroman1/aai/tts";
+
+// tau2 connects with ?host=1 and injects its own system prompt + tool schemas,
+// so only this provider triple is inherited — which is what makes this file the
+// right place to A/B an STT endpoint.
+//
+// AAI_STT_URL unset (arm A) leaves the SDK's own default endpoint in place;
+// set (arm B) points the socket at that URL instead.
+const streamingUrl = process.env.AAI_STT_URL;
+
+export default agent({
+  name: "tau2-pipeline",
+  greeting: "",
+  // No sttPrompt on purpose: the harness sends its own via the host config
+  // block, keeping the benchmark's STT biasing with the benchmark.
+  stt: assemblyAIStt(streamingUrl ? { streamingUrl } : {}),
+  llm: assemblyAILlm({ model: "gpt-5.5" }),
+  tts: assemblyAITts(),
+});
+```
+
+`process.env` works here because `aai dev` evaluates the bundle **in the CLI's
+own process** and the bundler sets no Vite `define`. This is a dev-only
+affordance: after `aai deploy` the same code runs in a guest sandbox whose env
+comes from `.env` / `aai secret`, not your shell.
+
+## 3. Start both dev servers
+
+```sh
+# terminal 1 — arm A, default STT host
+cd <project> && AAI_ALLOW_HOST=1 npx aai dev --port 3000
+
+# terminal 2 — arm B, sandbox STT host
+cd <project> && AAI_ALLOW_HOST=1 \
+  AAI_STT_URL=wss://streaming.sandbox000.assemblyai-labs.com/v3/ws \
+  npx aai dev --port 3001
+```
+
+Two servers can share one project directory: with no `client.tsx`, `aai dev`
+starts no Vite server and binds the requested port directly, and it keeps no
+on-disk state.
+
+Wait for each to log `Session mode resolved … mode: 'pipeline'`, then:
+
+```sh
+curl -s -o /dev/null -w "3000:%{http_code} " http://localhost:3000/health
+curl -s -o /dev/null -w "3001:%{http_code}\n" http://localhost:3001/health
+```
+
+The `streamingUrl` must include the versioned path (`/v3/ws`) — the SDK
+supplies that only for its own default host, so a bare origin connects to the
+wrong route.
+
+## 4. Verify arm B before spending a full run on it
+
+Do not skip this. If the cluster rejects the key or the path, every arm-B
+session dies at STT connect and the arm scores 0.0 — which is indistinguishable
+from a quality result in `results.json`.
+
+```sh
+AAI_WS_URL=ws://localhost:3001/websocket uv run tau2 run \
+  --domain retail --audio-native --audio-native-provider aai \
+  --num-tasks 1 --max-concurrency 1 --save-to smoke-sandbox --verbose-logs
+```
+
+Then check terminal 2 for `stt_connect_failed` / `stt_auth_failed`. If the
+cluster needs its own key, restart **only** arm B with it prefixed — a shell
+value beats the login-key fallback, and arm A is untouched:
+
+```sh
+ASSEMBLYAI_API_KEY=<sandbox-key> AAI_ALLOW_HOST=1 \
+  AAI_STT_URL=wss://streaming.sandbox000.assemblyai-labs.com/v3/ws \
+  npx aai dev --port 3001
+```
+
+`AAI_DEBUG=1` on either server logs each STT turn, which is the fastest way to
+confirm words are arriving.
+
+## 5. Run both arms
+
+```sh
+# terminal 3
+AAI_WS_URL=ws://localhost:3000/websocket uv run tau2 run \
+  --domain retail --audio-native --audio-native-provider aai \
+  --num-tasks 20 --max-concurrency 1 --save-to retail-stt-default-20 --verbose-logs
+
+# terminal 4
+AAI_WS_URL=ws://localhost:3001/websocket uv run tau2 run \
+  --domain retail --audio-native --audio-native-provider aai \
+  --num-tasks 20 --max-concurrency 1 --save-to retail-stt-sandbox-20 --verbose-logs
+```
+
+### Concurrency: the TTS cap binds across BOTH runs
+
+The user simulator's voice is ElevenLabs, and its subscription caps concurrent
+requests (5 on lower tiers), answering `429 concurrent_limit_exceeded` over it.
+A synthesis that burns its retries is a **caller utterance that arrives late or
+not at all**, and on retail the delayed ones are disproportionately the
+spelled-out names and ZIPs that authentication depends on — so exceeding the cap
+corrupts the variable this A/B measures.
+
+`--max-concurrency` does not bound it on its own: a single simulation fans out
+(`OutOfTurnSpeechGenerator` pre-generates its inserts in a thread pool).
+`DEFAULT_TTS_MAX_CONCURRENCY` (4) is the real ceiling, enforced by a semaphore
+in `tau2.voice.synthesis.synthesize`.
+
+**That ceiling is per PROCESS.** Two arms in parallel means two semaphores, so
+set each to half the cap:
+
+```sh
+TAU2_TTS_MAX_CONCURRENCY=2 AAI_WS_URL=... uv run tau2 run ...
+```
+
+Or run the arms sequentially and leave it at the default. To confirm afterwards
+that the cap held:
+
+```sh
+grep -c "synthesize_voice failed" data/simulations/<run>/artifacts/task_*/*/task.log
+```
+
+Anything above zero means some caller speech was delayed; treat the run as
+noisy rather than comparable.
+
+## 6. Read the results
+
+```sh
+for r in retail-stt-default-20 retail-stt-sandbox-20; do
+  echo "== $r"
+  jq '[.simulations[].reward] | add/length' data/simulations/$r/results.json
+done
+```
+
+Four traps, in the order they bite:
+
+1. **Wait for retries to settle.** A retry *overwrites* the earlier score, so a
+   mid-run average is not the result. Read `results.json` only after both runs
+   exit.
+2. **Result panels print in completion order**, not task order. Take task ids
+   from `results.json`'s `simulation_index`, never from the log's panel order.
+3. **A low reward with high `NL_ASSERTION` means authentication failed**, not
+   that the agent converses badly. A call that never gets past
+   `find_user_id_by_name_zip` executes zero expected actions yet still scores
+   NL 1.0 for handling it gracefully. Since this A/B is about STT, that is the
+   number that should move.
+4. **Failing calls run long.** An agent that cannot authenticate keeps retrying,
+   so any wall-clock cap kills already-doomed conversations preferentially — the
+   worse arm loses more sessions to timeouts than to scoring, which exaggerates
+   the gap.
+
+For per-turn detail, the wire events are in
+`data/simulations/<run>/artifacts/task_*/sim_*/task.log` (`grep 'AAI event:'`),
+and the tool-call arguments — which is where STT errors become score errors —
+are in `data/simulations/<run>/simulations/*.json` under each tick's
+`agent_tool_calls`. Note `sim["messages"]` is empty; it is not the place to
+look.

--- a/src/tau2/voice/audio_native/aai/README.md
+++ b/src/tau2/voice/audio_native/aai/README.md
@@ -257,16 +257,42 @@ thing":
 ```sh
 uv run python scripts/stt_errors.py retail-stt-default-20 retail-stt-sandbox-20
 
+# every mis-hearing, including ones that changed nothing
+uv run python scripts/stt_errors.py retail-stt-default-20 --all-errors
+
 # include tasks that passed too
 uv run python scripts/stt_errors.py retail-stt-default-20 --all
 ```
 
 Ground truth exists because tau2 *synthesizes* the caller: every `user_chunk`
 carries an `audio_script_gold` naming the exact text spoken. The script pairs
-those against the agent's `user_transcript` wire events and prints said/heard/diff
-per utterance, flagging the ones whose content reaches a tool argument (`⚠️`) —
-names, ZIPs, emails, order ids — since those are where a mis-hearing becomes a
-score.
+those against the agent's `user_transcript` wire events and prints
+said/heard/diff per utterance.
+
+**By default it shows only the mis-hearings it can trace to a failed action**,
+each with a `caused:` line naming the argument:
+
+```
+- DIGITS — numeric substitution (zip / order id / phone)
+  - said:  `K, O, V, A, C, S.`
+  - heard: `K-O-B-A-C-S. Okay, so this one, people`
+  - caused: expected `last_name`='kovacs' was spoken but not heard
+  - caused: agent used `last_name`='kobacs', which only appears in the transcript
+```
+
+The trace runs both directions, and both are needed. A value the caller *said*
+that is missing from what was heard explains an action the agent could not
+perform — it was never told the right thing. A value present in what was heard
+and absent from what was said explains an action performed *wrongly* — the
+mis-hearing became the argument. Only the second catches the wrong-account class,
+where every required datum was spoken and the agent still acted on something
+else.
+
+This matters because most mis-hearings are harmless: on the measured runs only
+**17%** and **23%** of them could be traced to a failed action. A report listing
+all of them invites fixing the loudest rather than the costly one. The count of
+what was hidden is still printed, since that number is also the honest ceiling
+on what a language or endpoint fix would buy.
 
 Errors are classed because the classes need different remedies, and only one of
 them is fixable agent-side:

--- a/src/tau2/voice/audio_native/aai/__init__.py
+++ b/src/tau2/voice/audio_native/aai/__init__.py
@@ -1,7 +1,8 @@
-"""AssemblyAI audio-native integration.
+"""aai audio-native integration.
 
-AAI provides speech-to-speech capabilities through a local WebSocket-based
-voice-agent host. The host communicates via bidirectional WebSocket with
+aai (the @alexkroman1/aai voice-agent framework) provides speech-to-speech
+capabilities through a local WebSocket-based voice-agent host — distinct from
+the separate `assemblyai` provider. The host communicates via bidirectional WebSocket with
 speech transcription, agent responses, and tool/function calling support.
 
 Key features:

--- a/src/tau2/voice/audio_native/aai/__init__.py
+++ b/src/tau2/voice/audio_native/aai/__init__.py
@@ -1,0 +1,1 @@
+"""AAI audio-native voice provider for tau2."""

--- a/src/tau2/voice/audio_native/aai/__init__.py
+++ b/src/tau2/voice/audio_native/aai/__init__.py
@@ -1,1 +1,37 @@
-"""AAI audio-native voice provider for tau2."""
+"""AssemblyAI audio-native integration.
+
+AAI provides speech-to-speech capabilities through a local WebSocket-based
+voice-agent host. The host communicates via bidirectional WebSocket with
+speech transcription, agent responses, and tool/function calling support.
+
+Key features:
+- Input: PCM16 16kHz audio
+- Output: PCM16 24kHz audio
+- Server-side VAD and turn-taking
+- Tool/function calling support
+- Local execution for privacy and latency
+
+Reference: AssemblyAI documentation
+https://www.assemblyai.com/docs/
+"""
+
+from tau2.voice.audio_native.aai.discrete_time_adapter import DiscreteTimeAAIAdapter
+from tau2.voice.audio_native.aai.events import (
+    AAIAudioChunkEvent,
+    AAIErrorEvent,
+    AAIToolCallEvent,
+    AAIUserTranscriptEvent,
+    parse_aai_event,
+)
+from tau2.voice.audio_native.aai.provider import AAIVADConfig, AAIVoiceAgentProvider
+
+__all__ = [
+    "AAIAudioChunkEvent",
+    "AAIErrorEvent",
+    "AAIToolCallEvent",
+    "AAIUserTranscriptEvent",
+    "AAIVADConfig",
+    "AAIVoiceAgentProvider",
+    "DiscreteTimeAAIAdapter",
+    "parse_aai_event",
+]

--- a/src/tau2/voice/audio_native/aai/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/aai/discrete_time_adapter.py
@@ -1,0 +1,300 @@
+"""Discrete-time adapter for the AAI (AssemblyAI voice-agent host) provider.
+
+Mirrors the AssemblyAI adapter's lifecycle/tick structure, with one key
+difference: the aai host speaks PCM16 over its WebSocket (16kHz in, 24kHz
+out), while the adapter's external interface stays tau2 telephony mu-law/8k.
+Audio conversion therefore happens at this boundary:
+
+- Send path: mu-law 8k (external) -> PCM16 -> resample to 16kHz -> provider.
+- Receive path: PCM16 24k (from provider) -> resample to 8kHz -> mu-law.
+
+aai events don't carry a reply/turn id, so a synthetic running turn id
+(``turn-N``) is maintained locally and incremented on ``reply_done``.
+"""
+
+import asyncio
+from typing import Any, List, Optional
+
+from loguru import logger
+
+from tau2.config import (
+    DEFAULT_AUDIO_NATIVE_CONNECT_TIMEOUT,
+    DEFAULT_AUDIO_NATIVE_DISCONNECT_TIMEOUT,
+    DEFAULT_AUDIO_NATIVE_TICK_TIMEOUT_BUFFER,
+)
+from tau2.data_model.audio import (
+    TELEPHONY_AUDIO_FORMAT,
+    AudioData,
+    AudioEncoding,
+    AudioFormat,
+)
+from tau2.data_model.message import ToolCall
+from tau2.environment.tool import Tool
+from tau2.voice.audio_native.aai.events import (
+    AAIAgentTranscriptEvent,
+    AAIAudioChunkEvent,
+    AAIAudioDoneEvent,
+    AAIErrorEvent,
+    AAIReplyDoneEvent,
+    AAISpeechStartedEvent,
+    AAISpeechStoppedEvent,
+    AAITimeoutEvent,
+    AAIToolCallEvent,
+)
+from tau2.voice.audio_native.aai.provider import AAIVoiceAgentProvider
+from tau2.voice.audio_native.adapter import DiscreteTimeAdapter
+from tau2.voice.audio_native.async_loop import BackgroundAsyncLoop
+from tau2.voice.audio_native.tick_result import TickResult, UtteranceTranscript
+from tau2.voice.utils.audio_preprocessing import (
+    convert_to_pcm16,
+    convert_to_ulaw,
+    resample_audio,
+)
+
+# aai host WebSocket audio rates (see AAIVoiceAgentProvider defaults).
+AAI_SEND_SAMPLE_RATE = 16000
+AAI_RECEIVE_SAMPLE_RATE = 24000
+AAI_RECEIVE_AUDIO_FORMAT = AudioFormat(
+    encoding=AudioEncoding.PCM_S16LE,
+    sample_rate=AAI_RECEIVE_SAMPLE_RATE,
+    channels=1,
+)
+
+
+class DiscreteTimeAAIAdapter(DiscreteTimeAdapter):
+    """Discrete-time adapter for the aai voice-agent host provider."""
+
+    def __init__(
+        self,
+        tick_duration_ms: int,
+        send_audio_instant: bool = True,
+        reasoning_effort: Optional[str] = None,
+        provider: Optional[AAIVoiceAgentProvider] = None,
+        system_prompt: str = "",
+        tools: tuple = (),
+    ):
+        if reasoning_effort is not None:
+            raise ValueError(
+                f"aai provider does not support reasoning_effort "
+                f"(got '{reasoning_effort}')"
+            )
+        # External interface stays tau2 telephony mu-law/8k (base default);
+        # PCM16 conversion happens at the WebSocket boundary, not here.
+        super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
+        self._chunk_size = int(AAI_SEND_SAMPLE_RATE * 2 * self._voip_interval_ms / 1000)
+        self.system_prompt = system_prompt
+        self.tools = tools
+        self._provider = provider
+        self._owns_provider = provider is None
+        self._bg_loop = BackgroundAsyncLoop()
+        self._connected = False
+        self._turn_index = 0
+
+    @property
+    def provider(self) -> AAIVoiceAgentProvider:
+        if self._provider is None:
+            self._provider = AAIVoiceAgentProvider(
+                system_prompt=self.system_prompt,
+                tools=self.tools,
+            )
+        return self._provider
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected and self._bg_loop.is_running
+
+    def connect(
+        self,
+        system_prompt: str,
+        tools: List[Tool],
+        vad_config: Any = None,
+        modality: str = "audio",
+    ) -> None:
+        if self._connected:
+            logger.warning("Already connected, disconnecting first")
+            self.disconnect()
+        self.system_prompt = system_prompt
+        self.tools = tuple(tools)
+        self._bg_loop.start()
+        try:
+            self._bg_loop.run_coroutine(
+                self.provider.connect(),
+                timeout=DEFAULT_AUDIO_NATIVE_CONNECT_TIMEOUT,
+            )
+            self._connected = True
+            logger.info(
+                f"DiscreteTimeAAIAdapter connected "
+                f"(tick={self.tick_duration_ms}ms, bytes_per_tick={self.bytes_per_tick})"
+            )
+        except Exception as e:
+            logger.error(f"DiscreteTimeAAIAdapter failed to connect: {e}")
+            self._bg_loop.stop()
+            raise RuntimeError(f"Failed to connect to aai host: {e}") from e
+
+    def disconnect(self) -> None:
+        if not self._connected:
+            return
+        if self._bg_loop.is_running:
+            try:
+                self._bg_loop.run_coroutine(
+                    self._async_disconnect(),
+                    timeout=DEFAULT_AUDIO_NATIVE_DISCONNECT_TIMEOUT,
+                )
+            except Exception as e:
+                logger.warning(f"Error during disconnect: {e}")
+        self._bg_loop.stop()
+        self._connected = False
+        self._tick_count = 0
+        self._cumulative_user_audio_ms = 0
+        self.clear_buffers()
+        logger.info("DiscreteTimeAAIAdapter disconnected")
+
+    async def _async_disconnect(self) -> None:
+        if self._owns_provider and self._provider is not None:
+            await self.provider.disconnect()
+
+    def run_tick(
+        self, user_audio: bytes, tick_number: Optional[int] = None
+    ) -> TickResult:
+        if not self.is_connected:
+            raise RuntimeError("Not connected to aai host. Call connect() first.")
+        if tick_number is None:
+            tick_number = self._tick_count
+        self._tick_count = tick_number + 1
+        try:
+            return self._bg_loop.run_coroutine(
+                self._async_run_tick(user_audio, tick_number),
+                timeout=self.tick_duration_ms / 1000
+                + DEFAULT_AUDIO_NATIVE_TICK_TIMEOUT_BUFFER,
+            )
+        except Exception as e:
+            logger.error(f"Error in run_tick (tick={tick_number}): {e}")
+            raise
+
+    async def _flush_pending_tool_results(self) -> None:
+        # aai's tool_result auto-fires the next reply; no follow-up message.
+        for (
+            call_id,
+            result_str,
+            _request_response,
+            _is_error,
+        ) in self._pending_tool_results:
+            await self.provider.send_tool_result(call_id, result_str)
+        self._pending_tool_results.clear()
+
+    async def _execute_tick(
+        self,
+        user_audio: bytes,
+        tick_number: int,
+        result: TickResult,
+        tick_start: float,
+    ) -> None:
+        pcm16_16k = self._convert_ulaw_to_pcm16_16k(user_audio)
+
+        async def receive_events():
+            elapsed = asyncio.get_running_loop().time() - tick_start
+            remaining = max(0.01, (self.tick_duration_ms / 1000) - elapsed)
+            return await self.provider.receive_events_for_duration(remaining)
+
+        _, events = await asyncio.gather(
+            self._send_audio_chunked(
+                pcm16_16k, self.provider.send_audio, self._chunk_size
+            ),
+            receive_events(),
+        )
+        for event in events:
+            self._process_event(result, event)
+
+    @staticmethod
+    def _convert_ulaw_to_pcm16_16k(ulaw_8k: bytes) -> bytes:
+        """Convert mu-law 8k user audio to PCM16 16k for the aai host."""
+        audio = AudioData(data=ulaw_8k, format=TELEPHONY_AUDIO_FORMAT)
+        pcm16 = convert_to_pcm16(audio)
+        resampled = resample_audio(pcm16, AAI_SEND_SAMPLE_RATE)
+        return resampled.data
+
+    @staticmethod
+    def _convert_pcm16_24k_to_ulaw_8k(pcm16_24k: bytes) -> bytes:
+        """Convert PCM16 24k agent audio (from the aai host) to mu-law 8k."""
+        audio = AudioData(data=pcm16_24k, format=AAI_RECEIVE_AUDIO_FORMAT)
+        resampled = resample_audio(audio, 8000)
+        ulaw = convert_to_ulaw(resampled)
+        return ulaw.data
+
+    def _process_event(self, result: TickResult, event: Any) -> None:
+        result.events.append(event)
+
+        if isinstance(event, AAIAgentTranscriptEvent):
+            item_id = self._ensure_current_item_id()
+            ut = self._utterance_transcripts.setdefault(
+                item_id, UtteranceTranscript(item_id=item_id)
+            )
+            # aai sends the full transcript each time (not deltas); overwrite.
+            ut.transcript_received = event.text
+
+        elif isinstance(event, AAIAudioChunkEvent):
+            item_id = self._ensure_current_item_id()
+            ulaw_bytes = self._convert_pcm16_24k_to_ulaw_8k(event.pcm16)
+            if result.skip_item_id is not None and item_id == result.skip_item_id:
+                result.truncated_audio_bytes += len(ulaw_bytes)
+                return
+            if ulaw_bytes:
+                result.agent_audio_chunks.append((ulaw_bytes, item_id))
+            ut = self._utterance_transcripts.setdefault(
+                item_id, UtteranceTranscript(item_id=item_id)
+            )
+            ut.add_audio(len(ulaw_bytes))
+
+        elif isinstance(event, AAIToolCallEvent):
+            result.tool_calls.append(
+                ToolCall(
+                    id=event.tool_call_id,
+                    name=event.tool_name,
+                    arguments=event.args,
+                )
+            )
+            logger.debug(f"Tool call detected: {event.tool_name}({event.tool_call_id})")
+
+        elif isinstance(event, AAISpeechStartedEvent):
+            logger.debug("Speech started - interruption detected")
+            result.vad_events.append("speech_started")
+            if self._buffered_agent_audio:
+                buffered = sum(len(c[0]) for c in self._buffered_agent_audio)
+                result.truncated_audio_bytes += buffered
+                self._buffered_agent_audio.clear()
+            result.was_truncated = True
+            result.skip_item_id = self._current_item_id
+
+        elif isinstance(event, AAISpeechStoppedEvent):
+            result.vad_events.append("speech_stopped")
+
+        elif isinstance(event, (AAIReplyDoneEvent, AAIAudioDoneEvent)):
+            if isinstance(event, AAIReplyDoneEvent):
+                item_id = self._current_item_id
+                ut = self._utterance_transcripts.get(item_id) if item_id else None
+                if ut is not None:
+                    if ut.audio_bytes_received == 0:
+                        logger.warning(f"Reply {item_id} completed with no audio")
+                    if ut.transcript_received == "":
+                        logger.warning(
+                            f"Reply {item_id} completed with no transcript — "
+                            "possible event schema mismatch"
+                        )
+                self._turn_index += 1
+                self._current_item_id = None
+
+        elif isinstance(event, AAIErrorEvent):
+            logger.error(f"aai host error: {event.code} {event.message}")
+
+        elif isinstance(event, AAITimeoutEvent):
+            pass
+
+        else:
+            logger.debug(f"Event {type(event).__name__} received")
+
+    def _ensure_current_item_id(self) -> str:
+        """Return the synthetic turn id for the in-progress turn, creating it
+        if this is the first audio/transcript event of the turn."""
+        if self._current_item_id is None:
+            self._current_item_id = f"turn-{self._turn_index}"
+        return self._current_item_id

--- a/src/tau2/voice/audio_native/aai/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/aai/discrete_time_adapter.py
@@ -18,6 +18,8 @@ from typing import Any, List, Optional
 from loguru import logger
 
 from tau2.config import (
+    DEFAULT_AAI_INPUT_SAMPLE_RATE,
+    DEFAULT_AAI_OUTPUT_SAMPLE_RATE,
     DEFAULT_AUDIO_NATIVE_CONNECT_TIMEOUT,
     DEFAULT_AUDIO_NATIVE_DISCONNECT_TIMEOUT,
     DEFAULT_AUDIO_NATIVE_TICK_TIMEOUT_BUFFER,
@@ -51,9 +53,10 @@ from tau2.voice.utils.audio_preprocessing import (
     resample_audio,
 )
 
-# aai host WebSocket audio rates (see AAIVoiceAgentProvider defaults).
-AAI_SEND_SAMPLE_RATE = 16000
-AAI_RECEIVE_SAMPLE_RATE = 24000
+# aai host WebSocket audio rates (shared with AAIVoiceAgentProvider via
+# tau2.config so the two sides can't drift).
+AAI_SEND_SAMPLE_RATE = DEFAULT_AAI_INPUT_SAMPLE_RATE
+AAI_RECEIVE_SAMPLE_RATE = DEFAULT_AAI_OUTPUT_SAMPLE_RATE
 AAI_RECEIVE_AUDIO_FORMAT = AudioFormat(
     encoding=AudioEncoding.PCM_S16LE,
     sample_rate=AAI_RECEIVE_SAMPLE_RATE,
@@ -89,6 +92,10 @@ class DiscreteTimeAAIAdapter(DiscreteTimeAdapter):
         self._bg_loop = BackgroundAsyncLoop()
         self._connected = False
         self._turn_index = 0
+        # Turn ids interrupted by a barge-in (AAISpeechStartedEvent); their
+        # reply_done is expected to carry zero audio/transcript, so the
+        # loud-failure guard in _process_event skips them.
+        self._interrupted_turn_ids: set[str] = set()
 
     @property
     def provider(self) -> AAIVoiceAgentProvider:
@@ -264,24 +271,30 @@ class DiscreteTimeAAIAdapter(DiscreteTimeAdapter):
                 self._buffered_agent_audio.clear()
             result.was_truncated = True
             result.skip_item_id = self._current_item_id
+            if self._current_item_id is not None:
+                self._interrupted_turn_ids.add(self._current_item_id)
 
         elif isinstance(event, AAISpeechStoppedEvent):
             result.vad_events.append("speech_stopped")
 
-        elif isinstance(event, (AAIReplyDoneEvent, AAIAudioDoneEvent)):
-            if isinstance(event, AAIReplyDoneEvent):
-                item_id = self._current_item_id
-                ut = self._utterance_transcripts.get(item_id) if item_id else None
-                if ut is not None:
-                    if ut.audio_bytes_received == 0:
-                        logger.warning(f"Reply {item_id} completed with no audio")
-                    if ut.transcript_received == "":
-                        logger.warning(
-                            f"Reply {item_id} completed with no transcript — "
-                            "possible event schema mismatch"
-                        )
-                self._turn_index += 1
-                self._current_item_id = None
+        elif isinstance(event, AAIReplyDoneEvent):
+            item_id = self._current_item_id
+            was_interrupted = item_id in self._interrupted_turn_ids
+            ut = self._utterance_transcripts.get(item_id) if item_id else None
+            if ut is not None and not was_interrupted:
+                if ut.audio_bytes_received == 0:
+                    logger.warning(f"Reply {item_id} completed with no audio")
+                if ut.transcript_received == "":
+                    logger.warning(
+                        f"Reply {item_id} completed with no transcript — "
+                        "possible event schema mismatch"
+                    )
+            self._interrupted_turn_ids.discard(item_id)
+            self._turn_index += 1
+            self._current_item_id = None
+
+        elif isinstance(event, AAIAudioDoneEvent):
+            logger.debug("Audio playback done")
 
         elif isinstance(event, AAIErrorEvent):
             logger.error(f"aai host error: {event.code} {event.message}")

--- a/src/tau2/voice/audio_native/aai/events.py
+++ b/src/tau2/voice/audio_native/aai/events.py
@@ -1,0 +1,250 @@
+"""Pydantic models for AAI voice agent events.
+
+AAI server sends camelCase JSON messages that are parsed into typed event models.
+All events inherit from BaseAAIEvent with configurable extra field handling.
+"""
+
+from typing import Any, Literal, Optional
+
+from loguru import logger
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BaseAAIEvent(BaseModel):
+    """Base class for all AAI events."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    type: str
+
+
+# =============================================================================
+# Configuration Events
+# =============================================================================
+
+
+class AAIConfigEvent(BaseAAIEvent):
+    """Server configuration acknowledgment."""
+
+    type: Literal["config"] = "config"
+
+
+# =============================================================================
+# Speech Detection Events
+# =============================================================================
+
+
+class AAISpeechStartedEvent(BaseAAIEvent):
+    """User speech detection started."""
+
+    type: Literal["speech_started"] = "speech_started"
+
+
+class AAISpeechStoppedEvent(BaseAAIEvent):
+    """User speech detection stopped."""
+
+    type: Literal["speech_stopped"] = "speech_stopped"
+
+
+# =============================================================================
+# Transcript Events
+# =============================================================================
+
+
+class AAIUserTranscriptEvent(BaseAAIEvent):
+    """User speech transcript from the voice agent."""
+
+    type: Literal["user_transcript"] = "user_transcript"
+    text: str
+    turn_order: Optional[int] = Field(default=None, alias="turnOrder")
+
+
+class AAIAgentTranscriptEvent(BaseAAIEvent):
+    """Agent response transcript."""
+
+    type: Literal["agent_transcript"] = "agent_transcript"
+    text: str
+
+
+# =============================================================================
+# Tool Events
+# =============================================================================
+
+
+class AAIToolCallEvent(BaseAAIEvent):
+    """Agent is requesting to call a tool."""
+
+    type: Literal["tool_call"] = "tool_call"
+    tool_call_id: str = Field(alias="toolCallId")
+    tool_name: str = Field(alias="toolName")
+    args: dict = Field(default_factory=dict)
+
+
+class AAIToolCallDoneEvent(BaseAAIEvent):
+    """Tool execution has completed."""
+
+    type: Literal["tool_call_done"] = "tool_call_done"
+    tool_call_id: str = Field(alias="toolCallId")
+    result: str = ""
+
+
+# =============================================================================
+# Response Events
+# =============================================================================
+
+
+class AAIReplyDoneEvent(BaseAAIEvent):
+    """Agent response is complete."""
+
+    type: Literal["reply_done"] = "reply_done"
+
+
+class AAIAudioDoneEvent(BaseAAIEvent):
+    """Audio output is complete."""
+
+    type: Literal["audio_done"] = "audio_done"
+
+
+# =============================================================================
+# Session Control Events
+# =============================================================================
+
+
+class AAICancelledEvent(BaseAAIEvent):
+    """Session was cancelled."""
+
+    type: Literal["cancelled"] = "cancelled"
+
+
+class AAIResetEvent(BaseAAIEvent):
+    """Session was reset."""
+
+    type: Literal["reset"] = "reset"
+
+
+class AAIIdleTimeoutEvent(BaseAAIEvent):
+    """Session idle timeout occurred."""
+
+    type: Literal["idle_timeout"] = "idle_timeout"
+
+
+# =============================================================================
+# Error and Custom Events
+# =============================================================================
+
+
+class AAIErrorEvent(BaseAAIEvent):
+    """Error from the AAI server."""
+
+    type: Literal["error"] = "error"
+    code: Optional[str] = None
+    message: Optional[str] = None
+
+
+class AAICustomEvent(BaseAAIEvent):
+    """Custom application-defined event."""
+
+    type: Literal["custom_event"] = "custom_event"
+    event: str
+    data: Optional[Any] = None
+
+
+# =============================================================================
+# Internal/Helper Events
+# =============================================================================
+
+
+class AAITimeoutEvent(BaseAAIEvent):
+    """Timeout waiting for events (used internally, not from server)."""
+
+    type: Literal["timeout"] = "timeout"
+
+
+class AAIUnknownEvent(BaseAAIEvent):
+    """Unknown or unrecognized event type."""
+
+    type: str
+    raw: Optional[dict] = None
+
+
+class AAIAudioChunkEvent(BaseAAIEvent):
+    """Audio frame chunk (constructed directly by provider, not parsed).
+
+    pcm16 field is excluded from serialization due to binary size.
+    """
+
+    type: Literal["audio_chunk"] = "audio_chunk"
+    pcm16: bytes = Field(default=b"", exclude=True)
+
+
+# =============================================================================
+# Event Type Mapping
+# =============================================================================
+
+_EVENT_TYPE_MAP: dict[str, type[BaseAAIEvent]] = {
+    "config": AAIConfigEvent,
+    "speech_started": AAISpeechStartedEvent,
+    "speech_stopped": AAISpeechStoppedEvent,
+    "user_transcript": AAIUserTranscriptEvent,
+    "agent_transcript": AAIAgentTranscriptEvent,
+    "tool_call": AAIToolCallEvent,
+    "tool_call_done": AAIToolCallDoneEvent,
+    "reply_done": AAIReplyDoneEvent,
+    "audio_done": AAIAudioDoneEvent,
+    "cancelled": AAICancelledEvent,
+    "reset": AAIResetEvent,
+    "idle_timeout": AAIIdleTimeoutEvent,
+    "error": AAIErrorEvent,
+    "custom_event": AAICustomEvent,
+    "timeout": AAITimeoutEvent,
+}
+
+
+# =============================================================================
+# Event Parsing
+# =============================================================================
+
+
+def parse_aai_event(data: dict) -> BaseAAIEvent:
+    """Parse raw AAI event data into a typed event model.
+
+    Args:
+        data: Raw event dictionary from AAI server.
+
+    Returns:
+        Typed event instance. Unknown types return AAIUnknownEvent.
+        Parse failures return AAIUnknownEvent with warning logged.
+    """
+    event_type = data.get("type", "unknown")
+    event_class = _EVENT_TYPE_MAP.get(event_type)
+
+    if event_class is None:
+        return AAIUnknownEvent(type=event_type, raw=data)
+
+    # Log event, redacting large binary/base64 fields
+    log_data = _prepare_log_data(data)
+    logger.debug(f"AAI event: {event_type} - {log_data}")
+
+    try:
+        return event_class.model_validate(data)
+    except Exception as e:
+        logger.warning(f"Failed to parse AAI event {event_type}: {e}")
+        return AAIUnknownEvent(type=event_type, raw=data)
+
+
+def _prepare_log_data(data: dict) -> dict:
+    """Prepare event data for logging, eliding large fields like base64.
+
+    Args:
+        data: Raw event data.
+
+    Returns:
+        Copy of data with large fields redacted for logging.
+    """
+    log_data = data.copy()
+    # Redact any large base64 or binary fields if present
+    for key in list(log_data.keys()):
+        if key in ("audio", "data", "content") and isinstance(log_data[key], str):
+            if len(log_data[key]) > 100:
+                log_data[key] = f"<{len(log_data[key])} chars>"
+    return log_data

--- a/src/tau2/voice/audio_native/aai/provider.py
+++ b/src/tau2/voice/audio_native/aai/provider.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 
 from tau2.config import (
     DEFAULT_AAI_CONFIG_FRAME_TIMEOUT,
+    DEFAULT_AAI_GREETING,
     DEFAULT_AAI_INPUT_SAMPLE_RATE,
     DEFAULT_AAI_MODEL,
     DEFAULT_AAI_OUTPUT_SAMPLE_RATE,
@@ -111,6 +112,7 @@ class AAIVoiceAgentProvider:
         tts_sample_rate: int = DEFAULT_AAI_OUTPUT_SAMPLE_RATE,
         system_prompt: str = "",
         tools: tuple = (),
+        greeting: str = DEFAULT_AAI_GREETING,
     ):
         """Initialize the AAI voice agent provider.
 
@@ -121,12 +123,15 @@ class AAIVoiceAgentProvider:
             tts_sample_rate: Sample rate for audio received from AAI (default: 24000).
             system_prompt: System instructions for the agent.
             tools: Tools available to the agent.
+            greeting: Spoken by the host agent on session start so the call does
+                not open with dead air. Empty string disables it.
         """
         self.ws_url = ws_url or os.environ.get("AAI_WS_URL") or DEFAULT_AAI_WS_URL
         self.input_sample_rate = input_sample_rate
         self.tts_sample_rate = tts_sample_rate
         self.system_prompt = system_prompt
         self.tools = tools
+        self.greeting = greeting
         self.ws: Optional[websockets.WebSocketClientProtocol] = None
         self._buffered_events: List[BaseAAIEvent] = []
 
@@ -202,15 +207,18 @@ class AAIVoiceAgentProvider:
         Returns:
             Configuration message dict with proper AAI host format.
         """
+        host: Dict = {
+            "systemPrompt": system_prompt,
+            "tools": self._format_tools_for_api(tools),
+        }
+        if self.greeting:
+            host["greeting"] = self.greeting
         return {
             "type": "config",
             "audioFormat": "pcm16",
             "sampleRate": self.input_sample_rate,
             "ttsSampleRate": self.tts_sample_rate,
-            "host": {
-                "systemPrompt": system_prompt,
-                "tools": self._format_tools_for_api(tools),
-            },
+            "host": host,
         }
 
     @websocket_retry

--- a/src/tau2/voice/audio_native/aai/provider.py
+++ b/src/tau2/voice/audio_native/aai/provider.py
@@ -113,6 +113,7 @@ class AAIVoiceAgentProvider:
         system_prompt: str = "",
         tools: tuple = (),
         greeting: str = DEFAULT_AAI_GREETING,
+        api_key: Optional[str] = None,
     ):
         """Initialize the AAI voice agent provider.
 
@@ -125,8 +126,17 @@ class AAIVoiceAgentProvider:
             tools: Tools available to the agent.
             greeting: Spoken by the host agent on session start so the call does
                 not open with dead air. Empty string disables it.
+            api_key: Platform API key, sent as a bearer token on the upgrade.
+                Defaults to ASSEMBLYAI_API_KEY. Required only when pointing at
+                a deployed agent on the AAI platform: host mode there lets this
+                client replace the agent's prompt and tools while spending the
+                owner's credentials, so the platform demands proof of slug
+                ownership. A local `aai dev` host gates on AAI_ALLOW_HOST
+                instead and ignores the header, so leaving this unset keeps the
+                usual local workflow working.
         """
         self.ws_url = ws_url or os.environ.get("AAI_WS_URL") or DEFAULT_AAI_WS_URL
+        self.api_key = api_key or os.environ.get("ASSEMBLYAI_API_KEY") or ""
         self.input_sample_rate = input_sample_rate
         self.tts_sample_rate = tts_sample_rate
         self.system_prompt = system_prompt
@@ -238,9 +248,14 @@ class AAIVoiceAgentProvider:
         # Build the URL with host=1 flag
         url = self._with_host_flag(self.ws_url)
 
+        # Header, not a query parameter: a URL travels through proxy logs,
+        # shell history, and Referer headers, and this token is the whole
+        # platform credential.
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+
         try:
             logger.info(f"AAI Provider: Connecting to {url}")
-            self.ws = await websockets.connect(url)
+            self.ws = await websockets.connect(url, additional_headers=headers)
 
             # Build and send config message
             config_msg = self._build_config_message(self.system_prompt, self.tools)

--- a/src/tau2/voice/audio_native/aai/provider.py
+++ b/src/tau2/voice/audio_native/aai/provider.py
@@ -1,0 +1,399 @@
+"""
+AAI voice agent provider for local WebSocket-based voice processing.
+
+Communicates with a local AAI voice agent host via WebSocket, sending PCM16 audio
+and receiving transcripts, audio responses, and tool calls.
+
+The protocol uses:
+- Binary frames for PCM16 audio chunks (16kHz in, 24kHz out)
+- JSON frames for control messages and events
+- Server-side VAD (voice activity detection) and turn-taking
+"""
+
+import asyncio
+import json
+import os
+from typing import AsyncGenerator, Dict, List, Optional
+from urllib.parse import urlencode, urlparse, urlunparse
+
+import websockets
+from dotenv import load_dotenv
+from loguru import logger
+from pydantic import BaseModel
+
+from tau2.config import (
+    DEFAULT_AAI_INPUT_SAMPLE_RATE,
+    DEFAULT_AAI_MODEL,
+    DEFAULT_AAI_OUTPUT_SAMPLE_RATE,
+    DEFAULT_AAI_WS_URL,
+)
+from tau2.utils.retry import websocket_retry
+from tau2.voice.audio_native.aai.events import (
+    AAIAudioChunkEvent,
+    AAITimeoutEvent,
+    BaseAAIEvent,
+    parse_aai_event,
+)
+
+load_dotenv()
+
+# Audio format constants (from config)
+AAI_INPUT_SAMPLE_RATE = DEFAULT_AAI_INPUT_SAMPLE_RATE
+AAI_INPUT_BYTES_PER_SECOND = AAI_INPUT_SAMPLE_RATE * 2  # 16-bit = 2 bytes
+
+AAI_OUTPUT_SAMPLE_RATE = DEFAULT_AAI_OUTPUT_SAMPLE_RATE
+AAI_OUTPUT_BYTES_PER_SECOND = AAI_OUTPUT_SAMPLE_RATE * 2  # 16-bit samples
+
+
+class AAIVADConfig(BaseModel):
+    """Configuration for AAI's Voice Activity Detection.
+
+    AAI handles VAD server-side; this config is empty for interface parity
+    with other providers.
+    """
+
+    pass
+
+
+class AAIVoiceAgentProvider:
+    """AAI voice agent provider with WebSocket-based communication.
+
+    This provider manages a persistent WebSocket connection to a local AAI
+    voice agent host, enabling real-time bidirectional voice processing.
+
+    The connection uses:
+    - Binary frames (bytes) for PCM16 audio chunks
+    - Text frames (JSON) for control messages and events
+    - Server-side VAD and turn-taking
+
+    Attributes:
+        ws_url: WebSocket endpoint URL (from AAI_WS_URL env var or DEFAULT_AAI_WS_URL).
+        input_sample_rate: Sample rate for audio sent to AAI (16000 Hz).
+        tts_sample_rate: Sample rate for audio received from AAI (24000 Hz).
+        system_prompt: System instructions for the voice agent.
+        tools: Tools available to the voice agent.
+        ws: Active WebSocket connection.
+
+    Example:
+        ```python
+        provider = AAIVoiceAgentProvider(
+            system_prompt="You are a helpful assistant.",
+            tools=[],
+        )
+
+        await provider.connect()
+
+        # Send audio
+        await provider.send_audio(pcm16_audio_bytes)
+
+        # Receive events for a tick duration
+        events = await provider.receive_events_for_duration(0.2)
+        for event in events:
+            if isinstance(event, AAIAudioChunkEvent):
+                play_audio(event.pcm16)
+            elif isinstance(event, AAIToolCallEvent):
+                result = await execute_tool(event.tool_name, event.args)
+                await provider.send_tool_result(event.tool_call_id, result)
+
+        await provider.disconnect()
+        ```
+    """
+
+    DEFAULT_MODEL = DEFAULT_AAI_MODEL
+
+    def __init__(
+        self,
+        ws_url: Optional[str] = None,
+        input_sample_rate: int = DEFAULT_AAI_INPUT_SAMPLE_RATE,
+        tts_sample_rate: int = DEFAULT_AAI_OUTPUT_SAMPLE_RATE,
+        system_prompt: str = "",
+        tools: tuple = (),
+    ):
+        """Initialize the AAI voice agent provider.
+
+        Args:
+            ws_url: WebSocket URL for AAI host. If not provided, reads from
+                AAI_WS_URL environment variable, falling back to DEFAULT_AAI_WS_URL.
+            input_sample_rate: Sample rate for audio sent to AAI (default: 16000).
+            tts_sample_rate: Sample rate for audio received from AAI (default: 24000).
+            system_prompt: System instructions for the agent.
+            tools: Tools available to the agent.
+        """
+        self.ws_url = ws_url or os.environ.get("AAI_WS_URL") or DEFAULT_AAI_WS_URL
+        self.input_sample_rate = input_sample_rate
+        self.tts_sample_rate = tts_sample_rate
+        self.system_prompt = system_prompt
+        self.tools = tools
+        self.ws: Optional[websockets.WebSocketClientProtocol] = None
+        self._buffered_events: List[BaseAAIEvent] = []
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if the WebSocket connection is active."""
+        if self.ws is None:
+            return False
+        from websockets.protocol import State
+
+        return self.ws.state == State.OPEN
+
+    @staticmethod
+    def _with_host_flag(url: str) -> str:
+        """Append ?host=1 to the WebSocket URL to activate host mode.
+
+        Args:
+            url: The WebSocket URL.
+
+        Returns:
+            The URL with ?host=1 appended (or merged with existing query params).
+        """
+        parsed = urlparse(url)
+        # Parse existing query parameters
+        query_params = {}
+        if parsed.query:
+            for param in parsed.query.split("&"):
+                if "=" in param:
+                    key, value = param.split("=", 1)
+                    query_params[key] = value
+                else:
+                    query_params[param] = ""
+        # Add host=1
+        query_params["host"] = "1"
+        # Rebuild URL with new query string
+        new_query = urlencode(query_params)
+        new_parsed = parsed._replace(query=new_query)
+        return urlunparse(new_parsed)
+
+    def _format_tools_for_api(self, tools: tuple) -> List[Dict]:
+        """Format tools for the AAI API.
+
+        Converts Tool objects to flat function schema (not nested under "function").
+
+        Args:
+            tools: Tuple of Tool objects.
+
+        Returns:
+            List of flat function declarations.
+        """
+        formatted_tools = []
+        for tool in tools:
+            schema = tool.openai_schema
+            # Extract the nested function schema and flatten it
+            func_schema = schema["function"]
+            formatted_tools.append(
+                {
+                    "type": "function",
+                    "name": func_schema["name"],
+                    "description": func_schema["description"],
+                    "parameters": func_schema["parameters"],
+                }
+            )
+        return formatted_tools
+
+    def _build_config_message(self, system_prompt: str, tools: tuple) -> Dict:
+        """Build the configuration message for the AAI host.
+
+        Args:
+            system_prompt: System instructions for the agent.
+            tools: Tools available to the agent.
+
+        Returns:
+            Configuration message dict with proper AAI host format.
+        """
+        return {
+            "type": "config",
+            "audioFormat": "pcm16",
+            "sampleRate": self.input_sample_rate,
+            "ttsSampleRate": self.tts_sample_rate,
+            "host": {
+                "systemPrompt": system_prompt,
+                "tools": self._format_tools_for_api(tools),
+            },
+        }
+
+    @websocket_retry
+    async def connect(self) -> None:
+        """Connect to the AAI voice agent host.
+
+        Opens a WebSocket connection, appends the ?host=1 query parameter,
+        sends the configuration message, and waits for acknowledgment.
+
+        Raises:
+            RuntimeError: If connection fails or handshake is incomplete.
+        """
+        if self.is_connected:
+            logger.warning("Already connected, disconnecting first")
+            await self.disconnect()
+
+        # Build the URL with host=1 flag
+        url = self._with_host_flag(self.ws_url)
+
+        try:
+            logger.info(f"AAI Provider: Connecting to {url}")
+            self.ws = await websockets.connect(url)
+
+            # Build and send config message
+            config_msg = self._build_config_message(self.system_prompt, self.tools)
+            await self.ws.send(json.dumps(config_msg))
+
+            # Wait for config acknowledgment with per-frame timeout
+            while True:
+                try:
+                    frame = await asyncio.wait_for(self.ws.recv(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    # Timeout waiting for config ack; buffer other frames
+                    continue
+
+                # Check if it's a config ack
+                if isinstance(frame, str):
+                    try:
+                        data = json.loads(frame)
+                        event = parse_aai_event(data)
+                        if event.type == "config":
+                            logger.info("AAI Provider: Config acknowledged")
+                            break
+                        else:
+                            # Buffer non-config events for later retrieval
+                            self._buffered_events.append(event)
+                    except json.JSONDecodeError:
+                        logger.warning(f"Failed to parse JSON frame: {frame}")
+                else:
+                    # Binary frame (audio); buffer as audio chunk event
+                    self._buffered_events.append(AAIAudioChunkEvent(pcm16=frame))
+
+            logger.info("AAI Provider: Connected and configured")
+
+        except Exception as e:
+            logger.error(f"Failed to connect to AAI host: {e}")
+            raise RuntimeError(f"Failed to connect to AAI host: {e}") from e
+
+    async def disconnect(self) -> None:
+        """Close the WebSocket connection.
+
+        Gracefully closes the connection if one exists.
+        Safe to call even if not connected.
+        """
+        if self.ws:
+            logger.info("AAI Provider: Disconnecting")
+            try:
+                await self.ws.close()
+            except Exception as e:
+                logger.warning(f"Error during disconnect: {e}")
+            self.ws = None
+            logger.info("AAI Provider: Disconnected")
+
+    async def send_audio(self, pcm16: bytes) -> None:
+        """Send audio data to the AAI host.
+
+        Audio should be PCM16 at 16kHz.
+
+        Args:
+            pcm16: Raw PCM16 audio bytes.
+
+        Raises:
+            RuntimeError: If not connected.
+        """
+        if not self.is_connected:
+            raise RuntimeError("Not connected to AAI host")
+
+        await self.ws.send(pcm16)
+
+    async def send_tool_result(self, tool_call_id: str, result: str) -> None:
+        """Send the result of a tool call back to the AAI host.
+
+        Args:
+            tool_call_id: The unique identifier of the tool call.
+            result: The string result of the tool execution.
+
+        Raises:
+            RuntimeError: If not connected.
+        """
+        if not self.is_connected:
+            raise RuntimeError("Not connected to AAI host")
+
+        message = {
+            "type": "tool_result",
+            "toolCallId": tool_call_id,
+            "result": result,
+        }
+        await self.ws.send(json.dumps(message))
+
+    async def receive_events(self) -> AsyncGenerator[BaseAAIEvent, None]:
+        """Receive and yield events from the AAI WebSocket connection.
+
+        Handles both binary frames (audio chunks) and text frames (JSON events).
+        Uses per-frame timeouts to allow interleaved reception of multiple events.
+
+        Yields:
+            BaseAAIEvent: Parsed event objects or audio chunks.
+
+        Raises:
+            RuntimeError: If connection closes unexpectedly.
+        """
+        if not self.is_connected:
+            raise RuntimeError("Not connected to AAI host")
+
+        while self.is_connected:
+            try:
+                frame = await asyncio.wait_for(self.ws.recv(), timeout=0.01)
+
+                if isinstance(frame, bytes):
+                    # Binary frame: audio chunk
+                    yield AAIAudioChunkEvent(pcm16=frame)
+                else:
+                    # Text frame: JSON event
+                    data = json.loads(frame)
+                    event = parse_aai_event(data)
+                    yield event
+
+            except asyncio.TimeoutError:
+                yield AAITimeoutEvent(type="timeout")
+            except websockets.ConnectionClosed as e:
+                logger.error(
+                    f"AAI Provider: Connection closed "
+                    f"(code={e.code}, reason='{e.reason or 'no reason'}')"
+                )
+                raise RuntimeError(
+                    f"WebSocket connection closed unexpectedly "
+                    f"(code={e.code}, reason='{e.reason or 'no reason'}')"
+                ) from e
+            except websockets.ConnectionClosedError as e:
+                logger.error(
+                    f"AAI Provider: Connection error "
+                    f"(code={e.code}, reason='{e.reason or 'no reason'}')"
+                )
+                raise RuntimeError(
+                    f"WebSocket connection closed unexpectedly "
+                    f"(code={e.code}, reason='{e.reason or 'no reason'}')"
+                ) from e
+            except json.JSONDecodeError as e:
+                logger.warning(f"Failed to parse JSON frame: {e}")
+            except Exception as e:
+                logger.error(f"AAI Provider: Error receiving event: {e}")
+
+    async def receive_events_for_duration(
+        self, duration_seconds: float
+    ) -> List[BaseAAIEvent]:
+        """Receive events for a specified duration.
+
+        Prepends and clears buffered events from the handshake before
+        collecting new events.
+
+        Args:
+            duration_seconds: How long to collect events (in seconds).
+
+        Returns:
+            List of events received during the duration.
+        """
+        events = self._buffered_events.copy()
+        self._buffered_events.clear()
+
+        end_time = asyncio.get_event_loop().time() + duration_seconds
+
+        async for event in self.receive_events():
+            if not isinstance(event, AAITimeoutEvent):
+                events.append(event)
+
+            if asyncio.get_event_loop().time() >= end_time:
+                break
+
+        return events

--- a/src/tau2/voice/audio_native/aai/provider.py
+++ b/src/tau2/voice/audio_native/aai/provider.py
@@ -22,6 +22,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from tau2.config import (
+    DEFAULT_AAI_CONFIG_FRAME_TIMEOUT,
     DEFAULT_AAI_INPUT_SAMPLE_RATE,
     DEFAULT_AAI_MODEL,
     DEFAULT_AAI_OUTPUT_SAMPLE_RATE,
@@ -30,6 +31,8 @@ from tau2.config import (
 from tau2.utils.retry import websocket_retry
 from tau2.voice.audio_native.aai.events import (
     AAIAudioChunkEvent,
+    AAIConfigEvent,
+    AAIErrorEvent,
     AAITimeoutEvent,
     BaseAAIEvent,
     parse_aai_event,
@@ -235,30 +238,45 @@ class AAIVoiceAgentProvider:
             config_msg = self._build_config_message(self.system_prompt, self.tools)
             await self.ws.send(json.dumps(config_msg))
 
-            # Wait for config acknowledgment with per-frame timeout
+            # Wait for the config handshake frame, bounded by a timeout so we
+            # never hang forever if the host accepts the socket but never
+            # initializes the agent. Each recv is individually bounded; any
+            # non-config frame received in the meantime is buffered (not
+            # dropped) so it can be surfaced by the next
+            # receive_events_for_duration() call.
             while True:
                 try:
-                    frame = await asyncio.wait_for(self.ws.recv(), timeout=0.1)
-                except asyncio.TimeoutError:
-                    # Timeout waiting for config ack; buffer other frames
-                    continue
+                    frame = await asyncio.wait_for(
+                        self.ws.recv(), timeout=DEFAULT_AAI_CONFIG_FRAME_TIMEOUT
+                    )
+                except asyncio.TimeoutError as e:
+                    raise RuntimeError(
+                        f"aai host did not send a config frame within "
+                        f"{DEFAULT_AAI_CONFIG_FRAME_TIMEOUT}s; the agent did not "
+                        "initialize"
+                    ) from e
 
-                # Check if it's a config ack
-                if isinstance(frame, str):
-                    try:
-                        data = json.loads(frame)
-                        event = parse_aai_event(data)
-                        if event.type == "config":
-                            logger.info("AAI Provider: Config acknowledged")
-                            break
-                        else:
-                            # Buffer non-config events for later retrieval
-                            self._buffered_events.append(event)
-                    except json.JSONDecodeError:
-                        logger.warning(f"Failed to parse JSON frame: {frame}")
-                else:
+                if isinstance(frame, bytes):
                     # Binary frame (audio); buffer as audio chunk event
                     self._buffered_events.append(AAIAudioChunkEvent(pcm16=frame))
+                    continue
+
+                try:
+                    data = json.loads(frame)
+                except json.JSONDecodeError:
+                    logger.warning(f"Failed to parse JSON frame: {frame}")
+                    continue
+
+                event = parse_aai_event(data)
+                if isinstance(event, AAIConfigEvent):
+                    logger.info("AAI Provider: Config acknowledged")
+                    break
+                if isinstance(event, AAIErrorEvent):
+                    raise RuntimeError(
+                        f"aai host returned an error during handshake: {event.message}"
+                    )
+                # Buffer any other event for later retrieval
+                self._buffered_events.append(event)
 
             logger.info("AAI Provider: Connected and configured")
 
@@ -347,18 +365,9 @@ class AAIVoiceAgentProvider:
 
             except asyncio.TimeoutError:
                 yield AAITimeoutEvent(type="timeout")
-            except websockets.ConnectionClosed as e:
+            except (websockets.ConnectionClosed, websockets.ConnectionClosedError) as e:
                 logger.error(
                     f"AAI Provider: Connection closed "
-                    f"(code={e.code}, reason='{e.reason or 'no reason'}')"
-                )
-                raise RuntimeError(
-                    f"WebSocket connection closed unexpectedly "
-                    f"(code={e.code}, reason='{e.reason or 'no reason'}')"
-                ) from e
-            except websockets.ConnectionClosedError as e:
-                logger.error(
-                    f"AAI Provider: Connection error "
                     f"(code={e.code}, reason='{e.reason or 'no reason'}')"
                 )
                 raise RuntimeError(

--- a/src/tau2/voice/audio_native/aai/test_provider_standalone.py
+++ b/src/tau2/voice/audio_native/aai/test_provider_standalone.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Standalone script to test AAI voice agent provider.
+
+This script connects to a local AAI voice-agent host via WebSocket,
+sends test audio, and receives events.
+
+Usage:
+    AAI_WS_URL=ws://localhost:3100/websocket python src/tau2/voice/audio_native/aai/test_provider_standalone.py
+"""
+
+import asyncio
+import os
+import signal
+import sys
+from typing import List
+
+# Add src to path
+sys.path.insert(0, "src")
+
+
+async def main():
+    from tau2.data_model.audio import AudioData, AudioEncoding, AudioFormat
+    from tau2.voice.audio_native.aai.events import BaseAAIEvent
+    from tau2.voice.audio_native.aai.provider import AAIVoiceAgentProvider
+    from tau2.voice.utils.audio_preprocessing import convert_to_pcm16, resample_audio
+
+    print("=" * 60)
+    print("AAI Voice Agent Provider Test Script")
+    print("=" * 60)
+
+    # Read AAI_WS_URL from environment
+    aai_ws_url = os.environ.get("AAI_WS_URL", "ws://localhost:3000/websocket")
+    print(f"\nConnecting to: {aai_ws_url}")
+
+    provider = AAIVoiceAgentProvider(
+        ws_url=aai_ws_url,
+        system_prompt="You are a helpful assistant. Keep replies to one short sentence.",
+        tools=[],
+    )
+
+    received_events: List[BaseAAIEvent] = []
+
+    try:
+        # 1. Connect
+        print("\n1. Connecting to AAI host...")
+        try:
+            await asyncio.wait_for(provider.connect(), timeout=5)
+        except asyncio.TimeoutError:
+            print(f"SKIP: aai host not reachable at {aai_ws_url}")
+            return
+        except Exception as e:
+            if "refused" in str(e).lower() or "connection" in str(e).lower():
+                print(f"SKIP: aai host not reachable at {aai_ws_url}")
+                return
+            raise
+
+        print("   ✅ Connected!")
+
+        # 2. Load and convert test audio
+        print("\n2. Loading test audio...")
+        audio_path = "tests/test_voice/test_audio_native/testdata/hello.ulaw"
+        if not os.path.exists(audio_path):
+            print(f"   ⚠️ Audio file not found: {audio_path}")
+            return
+
+        with open(audio_path, "rb") as f:
+            ulaw_data = f.read()
+
+        # Create AudioData object for hello.ulaw (μ-law at 8kHz)
+        audio = AudioData(
+            data=ulaw_data,
+            format=AudioFormat(
+                encoding=AudioEncoding.ULAW,
+                sample_rate=8000,
+                channels=1,
+            ),
+            audio_path=None,
+        )
+
+        # Convert μ-law-8k → PCM16-8k → PCM16-16k
+        print(f"   Loaded: {len(ulaw_data)} bytes of μ-law audio at 8kHz")
+        pcm16_8k = convert_to_pcm16(audio)
+        print(f"   Converted to PCM16-8k: {len(pcm16_8k.data)} bytes")
+        pcm16_16k = resample_audio(pcm16_8k, 16000)
+        print(f"   Resampled to PCM16-16k: {len(pcm16_16k.data)} bytes")
+
+        # 3. Send audio and receive events concurrently
+        print("\n3. Sending test audio and receiving events...")
+
+        async def send_audio_with_chunks():
+            """Send audio in chunks with delays, then silence."""
+            chunk_size = 16000 * 2 * 50 // 1000  # ~50ms chunks at 16kHz 16-bit
+            # Send speech audio in chunks
+            for i in range(0, len(pcm16_16k.data), chunk_size):
+                chunk = pcm16_16k.data[i : i + chunk_size]
+                await provider.send_audio(chunk)
+                await asyncio.sleep(0.05)  # ~50ms between chunks
+
+            print("   ✅ Speech audio sent!")
+
+            # Send ~2s of silence for VAD
+            silence_1s = b"\x00" * 32000  # 1 second at 16kHz 16-bit
+            for _ in range(2):
+                await provider.send_audio(silence_1s)
+                await asyncio.sleep(0.1)
+
+            print("   ✅ Silence sent!")
+
+        # 4. Send audio and collect events concurrently
+        _, events = await asyncio.gather(
+            send_audio_with_chunks(),
+            provider.receive_events_for_duration(25.0),
+        )
+        received_events.extend(events)
+        print(f"   Received {len(received_events)} events")
+
+        # 5. Show results
+        print("\n" + "=" * 60)
+        print("RESULTS")
+        print("=" * 60)
+
+        # Note: Config event is received during connect() and consumed as part of
+        # the handshake, so it doesn't appear in the events list. Success = connected
+        # to the host and receiving the config acknowledgment (which happened during connect).
+        print(f"Connected and received config: ✅")
+        print(f"Additional events received after connect: {len(received_events)}")
+
+        # Collect event types for diagnostic purposes
+        if received_events:
+            event_types = {}
+            for e in received_events:
+                event_type = type(e).__name__
+                event_types[event_type] = event_types.get(event_type, 0) + 1
+
+            print("\nEvent types received:")
+            for t, count in sorted(event_types.items()):
+                print(f"  - {t}: {count}")
+        else:
+            print("\nNo additional events received (this is OK for a simple ping)")
+
+        print("\n✅ SUCCESS - AAI provider connected and ready!")
+        return 0
+
+    except asyncio.TimeoutError:
+        print(f"SKIP: aai host not reachable at {aai_ws_url}")
+        return 0
+    except Exception as e:
+        error_str = str(e).lower()
+        if (
+            "refused" in error_str
+            or "connection" in error_str
+            or "timeout" in error_str
+        ):
+            print(f"SKIP: aai host not reachable at {aai_ws_url}")
+            return 0
+        print(f"\n❌ Error: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return 1
+
+    finally:
+        # 6. Disconnect
+        print("\n6. Disconnecting...")
+        await provider.disconnect()
+        print("   ✅ Disconnected!")
+
+
+if __name__ == "__main__":
+    # Set up timeout
+    def timeout_handler(signum, frame):
+        print("\n\n❌ SCRIPT TIMEOUT (60s)")
+        sys.exit(1)
+
+    signal.signal(signal.SIGALRM, timeout_handler)
+    signal.alarm(60)
+
+    # Run
+    exit_code = asyncio.run(main())
+    sys.exit(exit_code)

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -326,7 +326,7 @@ class DiscreteTimeAdapter(ABC):
 # ---------------------------------------------------------------------------
 
 # Providers where the model is determined by the endpoint, not a parameter
-_PROVIDERS_WITH_ENDPOINT_DETERMINED_MODEL = ("xai",)
+_PROVIDERS_WITH_ENDPOINT_DETERMINED_MODEL = ("xai", "aai")
 
 
 def create_adapter(
@@ -345,7 +345,7 @@ def create_adapter(
     and the resolved model name.
 
     Args:
-        provider: Provider identifier (openai, gemini, xai, nova, qwen,
+        provider: Provider identifier (openai, gemini, xai, nova, qwen, aai,
             livekit).
         tick_duration_ms: Duration of each tick in milliseconds.
         send_audio_instant: If True, send audio in one call per tick.
@@ -437,6 +437,16 @@ def create_adapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
             model=model,
+            reasoning_effort=reasoning_effort,
+        )
+    elif provider == "aai":
+        from tau2.voice.audio_native.aai.discrete_time_adapter import (
+            DiscreteTimeAAIAdapter,
+        )
+
+        adapter = DiscreteTimeAAIAdapter(
+            tick_duration_ms=tick_duration_ms,
+            send_audio_instant=send_audio_instant,
             reasoning_effort=reasoning_effort,
         )
     elif provider == "livekit":

--- a/src/tau2/voice/synthesis/synthesize.py
+++ b/src/tau2/voice/synthesis/synthesize.py
@@ -1,7 +1,11 @@
 """Core voice synthesis (TTS) functions."""
 
+import os
+import threading
+
 from dotenv import load_dotenv
 
+from tau2.config import DEFAULT_TTS_MAX_CONCURRENCY
 from tau2.data_model.audio import AudioData
 from tau2.data_model.voice import ElevenLabsTTSConfig
 from tau2.utils.retry import tts_retry
@@ -12,17 +16,54 @@ load_dotenv()
 ProviderConfig = ElevenLabsTTSConfig
 
 
+def _tts_concurrency_limit() -> int:
+    """Process-wide TTS concurrency ceiling; see DEFAULT_TTS_MAX_CONCURRENCY."""
+    raw = os.environ.get("TAU2_TTS_MAX_CONCURRENCY")
+    if raw is None:
+        return DEFAULT_TTS_MAX_CONCURRENCY
+    try:
+        value = int(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"TAU2_TTS_MAX_CONCURRENCY must be an integer, got {raw!r}"
+        ) from e
+    if value < 1:
+        raise ValueError(f"TAU2_TTS_MAX_CONCURRENCY must be >= 1, got {value}")
+    return value
+
+
+# Bounds provider calls in flight across EVERY synthesis path in the process —
+# the streaming user simulator, the legacy half-duplex simulator, the CLI, and
+# OutOfTurnSpeechGenerator's thread pool. This module is the one choke point all
+# four pass through, which is why the limit lives here rather than at each fan-out
+# site: capping a single thread pool would leave the other three unbounded.
+#
+# Read once at import so every caller shares one semaphore.
+_TTS_SEMAPHORE = threading.BoundedSemaphore(_tts_concurrency_limit())
+
+
 @tts_retry
 def synthesize_voice(
     text: str,
     provider: str,
     provider_config: ProviderConfig,
 ) -> AudioData:
-    """Synthesize voice from text using the specified configuration."""
-    if provider == "elevenlabs":
-        audio_data = tts_elevenlabs(text=text, config=provider_config)
-    else:
+    """Synthesize voice from text using the specified configuration.
+
+    Serialized against DEFAULT_TTS_MAX_CONCURRENCY: providers cap concurrent
+    requests per subscription and answer 429 over it, which costs a caller
+    utterance rather than just time.
+    """
+    if provider != "elevenlabs":
+        # Raised before acquiring: an unsupported provider is a config error,
+        # not work, and must not queue behind in-flight synthesis.
         raise ValueError(f"Unsupported synthesis provider: {provider}")
+
+    # Acquired INSIDE the retried function, so a backing-off attempt releases
+    # its slot while it sleeps. Holding across the retry would let a few
+    # rate-limited calls idle the whole allowance and stall every other caller.
+    with _TTS_SEMAPHORE:
+        audio_data = tts_elevenlabs(text=text, config=provider_config)
 
     if not audio_data.format.is_pcm16:
         raise ValueError(

--- a/tests/test_voice/test_audio_native/test_aai_adapter.py
+++ b/tests/test_voice/test_audio_native/test_aai_adapter.py
@@ -1,0 +1,125 @@
+"""Tests for the AAI discrete-time adapter (PCM16 <-> mu-law conversion).
+
+Unlike AssemblyAI's native G.711 mu-law transport, the aai voice-agent host
+speaks PCM16 over its WebSocket (16kHz in, 24kHz out). The adapter's external
+interface stays tau2 telephony mu-law/8k, so conversion happens at this
+boundary: send path (mu-law 8k -> PCM16 16k) and receive path
+(PCM16 24k -> mu-law 8k).
+"""
+
+import pytest
+
+from tau2.voice.audio_native.aai.discrete_time_adapter import DiscreteTimeAAIAdapter
+from tau2.voice.audio_native.aai.events import (
+    AAIAgentTranscriptEvent,
+    AAIAudioChunkEvent,
+    AAISpeechStartedEvent,
+    AAISpeechStoppedEvent,
+    AAIToolCallEvent,
+)
+from tau2.voice.audio_native.tick_result import TickResult
+
+
+def _adapter() -> DiscreteTimeAAIAdapter:
+    return DiscreteTimeAAIAdapter(tick_duration_ms=200, send_audio_instant=True)
+
+
+def _result() -> TickResult:
+    return TickResult(
+        tick_number=1,
+        audio_sent_bytes=0,
+        audio_sent_duration_ms=0.0,
+        bytes_per_tick=1600,
+        bytes_per_second=8000,
+    )
+
+
+def test_reasoning_effort_rejected() -> None:
+    with pytest.raises(ValueError):
+        DiscreteTimeAAIAdapter(tick_duration_ms=200, reasoning_effort="high")
+
+
+def test_audio_chunk_converted_from_pcm16_24k_to_ulaw_8k() -> None:
+    a = _adapter()
+    r = _result()
+    # ~20ms of PCM16 audio at 24kHz (480 samples, 2 bytes/sample).
+    pcm16_24k = (b"\x10\x00") * 480
+    a._process_event(r, AAIAudioChunkEvent(pcm16=pcm16_24k))
+
+    assert r.agent_audio_bytes > 0
+    assert len(r.agent_audio_chunks) == 1
+    ulaw_bytes, item_id = r.agent_audio_chunks[0]
+    # mu-law is 1 byte/sample; 24k->8k resample should yield ~1/3 the samples.
+    assert len(ulaw_bytes) == pytest.approx(160, abs=5)
+    assert item_id == a._current_item_id
+
+
+def test_agent_transcript_overwrites_not_appends() -> None:
+    a = _adapter()
+    r = _result()
+    a._process_event(r, AAIAgentTranscriptEvent(text="first text"))
+    a._process_event(r, AAIAgentTranscriptEvent(text="second text"))
+
+    turn_id = a._current_item_id
+    assert turn_id is not None
+    assert a._utterance_transcripts[turn_id].transcript_received == "second text"
+
+
+def test_tool_call_recorded_with_id_name_arguments() -> None:
+    a = _adapter()
+    r = _result()
+    a._process_event(
+        r,
+        AAIToolCallEvent(tool_call_id="c-1", tool_name="lookup", args={"x": 1}),
+    )
+
+    assert len(r.tool_calls) == 1
+    assert r.tool_calls[0].id == "c-1"
+    assert r.tool_calls[0].name == "lookup"
+    assert r.tool_calls[0].arguments == {"x": 1}
+
+
+def test_speech_started_sets_truncation_and_vad_event() -> None:
+    a = _adapter()
+    r = _result()
+    a._process_event(r, AAIAgentTranscriptEvent(text="hi there"))
+    current_item_id = a._current_item_id
+
+    a._process_event(r, AAISpeechStartedEvent())
+
+    assert r.was_truncated is True
+    assert "speech_started" in r.vad_events
+    assert r.skip_item_id == current_item_id
+
+
+def test_speech_started_discards_buffered_agent_audio() -> None:
+    a = _adapter()
+    r = _result()
+    a._buffered_agent_audio = [(b"\xff" * 10, "turn-0")]
+
+    a._process_event(r, AAISpeechStartedEvent())
+
+    assert a._buffered_agent_audio == []
+    assert r.truncated_audio_bytes == 10
+
+
+def test_speech_stopped_adds_vad_event() -> None:
+    a = _adapter()
+    r = _result()
+    a._process_event(r, AAISpeechStoppedEvent())
+
+    assert "speech_stopped" in r.vad_events
+
+
+def test_barge_in_skip_discards_subsequent_audio_chunk() -> None:
+    a = _adapter()
+    r = _result()
+    a._process_event(r, AAIAgentTranscriptEvent(text="hi"))
+    current_item_id = a._current_item_id
+    r.skip_item_id = current_item_id
+
+    pcm16_24k = (b"\x10\x00") * 480
+    a._process_event(r, AAIAudioChunkEvent(pcm16=pcm16_24k))
+
+    assert r.agent_audio_chunks == []
+    assert r.truncated_audio_bytes > 0

--- a/tests/test_voice/test_audio_native/test_aai_adapter.py
+++ b/tests/test_voice/test_audio_native/test_aai_adapter.py
@@ -7,17 +7,37 @@ boundary: send path (mu-law 8k -> PCM16 16k) and receive path
 (PCM16 24k -> mu-law 8k).
 """
 
+import asyncio
+import logging
+
 import pytest
+from loguru import logger
 
 from tau2.voice.audio_native.aai.discrete_time_adapter import DiscreteTimeAAIAdapter
 from tau2.voice.audio_native.aai.events import (
     AAIAgentTranscriptEvent,
     AAIAudioChunkEvent,
+    AAIReplyDoneEvent,
     AAISpeechStartedEvent,
     AAISpeechStoppedEvent,
     AAIToolCallEvent,
 )
 from tau2.voice.audio_native.tick_result import TickResult
+
+
+class _PropagateHandler(logging.Handler):
+    """Forward loguru records into stdlib logging so pytest's ``caplog``
+    fixture (which only listens on stdlib logging) can capture them."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        logging.getLogger(record.name).handle(record)
+
+
+@pytest.fixture
+def caplog(caplog: pytest.LogCaptureFixture):
+    handler_id = logger.add(_PropagateHandler(), format="{message}")
+    yield caplog
+    logger.remove(handler_id)
 
 
 def _adapter() -> DiscreteTimeAAIAdapter:
@@ -123,3 +143,82 @@ def test_barge_in_skip_discards_subsequent_audio_chunk() -> None:
 
     assert r.agent_audio_chunks == []
     assert r.truncated_audio_bytes > 0
+
+
+def test_reply_done_on_non_interrupted_empty_turn_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A genuinely empty, non-interrupted turn is a real schema-drift
+    signal and should still trigger the loud-failure warning."""
+    a = _adapter()
+    r = _result()
+    # Starts the turn (via transcript-less ensure) with zero audio and no
+    # transcript ever recorded for it.
+    item_id = a._ensure_current_item_id()
+    from tau2.voice.audio_native.tick_result import UtteranceTranscript
+
+    a._utterance_transcripts[item_id] = UtteranceTranscript(item_id=item_id)
+
+    with caplog.at_level("WARNING"):
+        a._process_event(r, AAIReplyDoneEvent())
+
+    assert any("no audio" in msg for msg in caplog.messages)
+    assert any("no transcript" in msg for msg in caplog.messages)
+
+
+def test_reply_done_on_interrupted_turn_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """On a normal barge-in, the interrupted turn legitimately has zero
+    audio (chunks were discarded via skip_item_id); the loud-failure guard
+    must not fire a spurious warning for it."""
+    a = _adapter()
+    r = _result()
+    item_id = a._ensure_current_item_id()
+
+    # Barge-in: marks the current turn as interrupted and sets skip_item_id.
+    a._process_event(r, AAISpeechStartedEvent())
+    assert item_id in a._interrupted_turn_ids
+    caplog.clear()
+
+    with caplog.at_level("WARNING"):
+        a._process_event(r, AAIReplyDoneEvent())
+
+    assert caplog.messages == []
+    # Turn state should still advance normally and the id should be
+    # discarded to avoid unbounded growth of the interrupted-turn set.
+    assert a._current_item_id is None
+    assert item_id not in a._interrupted_turn_ids
+
+
+def test_flush_pending_tool_results_sends_tool_result_only() -> None:
+    """_flush_pending_tool_results should forward queued tool results to
+    the provider's send_tool_result and send nothing else."""
+
+    class _FakeProvider:
+        def __init__(self) -> None:
+            self.tool_results: list[tuple[str, str]] = []
+            self.other_calls: list[str] = []
+
+        async def send_tool_result(self, call_id: str, result: str) -> None:
+            self.tool_results.append((call_id, result))
+
+    fake_provider = _FakeProvider()
+    a = DiscreteTimeAAIAdapter(tick_duration_ms=200, provider=fake_provider)
+    a.send_tool_result("call-1", "42")
+
+    asyncio.run(a._flush_pending_tool_results())
+
+    assert fake_provider.tool_results == [("call-1", "42")]
+    assert fake_provider.other_calls == []
+    assert a._pending_tool_results == []
+
+
+def test_convert_ulaw_8k_silence_to_pcm16_16k_grows_by_4x() -> None:
+    """mu-law is 1 byte/sample at 8kHz; PCM16 is 2 bytes/sample at 16kHz,
+    so converting silence should roughly quadruple the byte count."""
+    ulaw_silence_8k = b"\xff" * 160  # 20ms of mu-law silence at 8kHz.
+
+    pcm16_16k = DiscreteTimeAAIAdapter._convert_ulaw_to_pcm16_16k(ulaw_silence_8k)
+
+    assert len(pcm16_16k) == pytest.approx(160 * 4, abs=8)

--- a/tests/test_voice/test_audio_native/test_aai_events.py
+++ b/tests/test_voice/test_audio_native/test_aai_events.py
@@ -1,0 +1,247 @@
+"""Tests for AAI event parsing and models."""
+
+from tau2.voice.audio_native.aai.events import (
+    AAIAgentTranscriptEvent,
+    AAIAudioChunkEvent,
+    AAIAudioDoneEvent,
+    AAICancelledEvent,
+    AAIConfigEvent,
+    AAICustomEvent,
+    AAIErrorEvent,
+    AAIIdleTimeoutEvent,
+    AAIReplyDoneEvent,
+    AAIResetEvent,
+    AAISpeechStartedEvent,
+    AAISpeechStoppedEvent,
+    AAIToolCallDoneEvent,
+    AAIToolCallEvent,
+    AAIUnknownEvent,
+    AAIUserTranscriptEvent,
+    parse_aai_event,
+)
+
+
+class TestAAIEventModels:
+    """Test individual event model creation and field mapping."""
+
+    def test_agent_transcript_event_parses_text(self) -> None:
+        """Test that agent_transcript event parses text field."""
+        data = {
+            "type": "agent_transcript",
+            "text": "Hello, how can I help?",
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIAgentTranscriptEvent)
+        assert event.text == "Hello, how can I help?"
+        assert event.type == "agent_transcript"
+
+    def test_tool_call_maps_camel_case_to_snake_case(self) -> None:
+        """Test that toolCallId and toolName are mapped to tool_call_id and tool_name."""
+        data = {
+            "type": "tool_call",
+            "toolCallId": "call_123",
+            "toolName": "get_weather",
+            "args": {"location": "NYC"},
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIToolCallEvent)
+        assert event.tool_call_id == "call_123"
+        assert event.tool_name == "get_weather"
+        assert event.args == {"location": "NYC"}
+
+    def test_user_transcript_maps_turn_order(self) -> None:
+        """Test that turnOrder alias maps to turn_order field."""
+        data = {
+            "type": "user_transcript",
+            "text": "What's the weather?",
+            "turnOrder": 2,
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIUserTranscriptEvent)
+        assert event.text == "What's the weather?"
+        assert event.turn_order == 2
+
+    def test_error_parses_code_and_message(self) -> None:
+        """Test that error event parses code and message."""
+        data = {
+            "type": "error",
+            "code": "INVALID_REQUEST",
+            "message": "Missing required field",
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIErrorEvent)
+        assert event.code == "INVALID_REQUEST"
+        assert event.message == "Missing required field"
+
+    def test_unknown_type_returns_unknown_event(self) -> None:
+        """Test that unknown event type returns AAIUnknownEvent."""
+        data = {
+            "type": "some_future_event",
+            "foo": "bar",
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIUnknownEvent)
+        assert event.type == "some_future_event"
+        assert event.raw == data
+
+    def test_config_event(self) -> None:
+        """Test config event parsing."""
+        data = {
+            "type": "config",
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIConfigEvent)
+        assert event.type == "config"
+
+    def test_speech_started_event(self) -> None:
+        """Test speech_started event."""
+        data = {"type": "speech_started"}
+        event = parse_aai_event(data)
+        assert isinstance(event, AAISpeechStartedEvent)
+        assert event.type == "speech_started"
+
+    def test_speech_stopped_event(self) -> None:
+        """Test speech_stopped event."""
+        data = {"type": "speech_stopped"}
+        event = parse_aai_event(data)
+        assert isinstance(event, AAISpeechStoppedEvent)
+        assert event.type == "speech_stopped"
+
+    def test_tool_call_done_event(self) -> None:
+        """Test tool_call_done event with result field."""
+        data = {
+            "type": "tool_call_done",
+            "toolCallId": "call_123",
+            "result": '{"temp": 72}',
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIToolCallDoneEvent)
+        assert event.tool_call_id == "call_123"
+        assert event.result == '{"temp": 72}'
+
+    def test_reply_done_event(self) -> None:
+        """Test reply_done event."""
+        data = {"type": "reply_done"}
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIReplyDoneEvent)
+        assert event.type == "reply_done"
+
+    def test_audio_done_event(self) -> None:
+        """Test audio_done event."""
+        data = {"type": "audio_done"}
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIAudioDoneEvent)
+        assert event.type == "audio_done"
+
+    def test_cancelled_event(self) -> None:
+        """Test cancelled event."""
+        data = {"type": "cancelled"}
+        event = parse_aai_event(data)
+        assert isinstance(event, AAICancelledEvent)
+        assert event.type == "cancelled"
+
+    def test_reset_event(self) -> None:
+        """Test reset event."""
+        data = {"type": "reset"}
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIResetEvent)
+        assert event.type == "reset"
+
+    def test_idle_timeout_event(self) -> None:
+        """Test idle_timeout event."""
+        data = {"type": "idle_timeout"}
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIIdleTimeoutEvent)
+        assert event.type == "idle_timeout"
+
+    def test_custom_event(self) -> None:
+        """Test custom_event parsing."""
+        data = {
+            "type": "custom_event",
+            "event": "my_custom",
+            "data": {"key": "value"},
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAICustomEvent)
+        assert event.event == "my_custom"
+        assert event.data == {"key": "value"}
+
+    def test_tool_call_args_defaults_to_empty_dict(self) -> None:
+        """Test that tool_call args defaults to empty dict."""
+        data = {
+            "type": "tool_call",
+            "toolCallId": "call_456",
+            "toolName": "list_items",
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIToolCallEvent)
+        assert event.args == {}
+
+    def test_tool_call_done_result_defaults_to_empty_string(self) -> None:
+        """Test that tool_call_done result defaults to empty string."""
+        data = {
+            "type": "tool_call_done",
+            "toolCallId": "call_456",
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIToolCallDoneEvent)
+        assert event.result == ""
+
+    def test_extra_fields_ignored(self) -> None:
+        """Test that extra fields are ignored due to ConfigDict."""
+        data = {
+            "type": "agent_transcript",
+            "text": "Response",
+            "extra_field": "should_be_ignored",
+            "another_extra": 123,
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIAgentTranscriptEvent)
+        assert event.text == "Response"
+        assert not hasattr(event, "extra_field")
+
+    def test_audio_chunk_event_construction(self) -> None:
+        """Test AAIAudioChunkEvent can be constructed directly (not from parse_aai_event)."""
+        # AAIAudioChunkEvent is not produced by parse_aai_event, but constructed directly
+        event = AAIAudioChunkEvent(pcm16=b"\x00\x01\x02\x03")
+        assert event.pcm16 == b"\x00\x01\x02\x03"
+        assert event.type == "audio_chunk"
+
+    def test_user_transcript_turn_order_optional(self) -> None:
+        """Test that turn_order is optional in user_transcript."""
+        data = {
+            "type": "user_transcript",
+            "text": "Hello",
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIUserTranscriptEvent)
+        assert event.turn_order is None
+
+    def test_error_code_and_message_optional(self) -> None:
+        """Test that error code and message are optional."""
+        data = {"type": "error"}
+        event = parse_aai_event(data)
+        assert isinstance(event, AAIErrorEvent)
+        assert event.code is None
+        assert event.message is None
+
+    def test_custom_event_data_optional(self) -> None:
+        """Test that custom_event data is optional."""
+        data = {
+            "type": "custom_event",
+            "event": "my_event",
+        }
+        event = parse_aai_event(data)
+        assert isinstance(event, AAICustomEvent)
+        assert event.data is None
+
+    def test_parse_failure_returns_unknown_event(self) -> None:
+        """Test that parse failures return AAIUnknownEvent with warning."""
+        # Force a validation error by passing invalid type for a required field
+        data = {
+            "type": "tool_call",
+            # Missing required fields, should fail validation
+        }
+        event = parse_aai_event(data)
+        # Should gracefully return UnknownEvent
+        assert isinstance(event, AAIUnknownEvent)

--- a/tests/test_voice/test_audio_native/test_aai_provider.py
+++ b/tests/test_voice/test_audio_native/test_aai_provider.py
@@ -1,0 +1,163 @@
+"""Tests for AAI voice agent provider client."""
+
+from unittest.mock import MagicMock
+
+from tau2.environment.tool import Tool
+from tau2.voice.audio_native.aai.provider import (
+    AAIVADConfig,
+    AAIVoiceAgentProvider,
+)
+
+
+class TestAAIVADConfig:
+    """Test AAIVADConfig model."""
+
+    def test_aai_vad_config_empty(self) -> None:
+        """Test that AAIVADConfig can be instantiated (empty for interface parity)."""
+        config = AAIVADConfig()
+        assert config is not None
+
+
+class TestAAIVoiceAgentProvider:
+    """Test AAIVoiceAgentProvider initialization and configuration."""
+
+    def test_provider_initialization_defaults(self) -> None:
+        """Test provider initializes with default values."""
+        provider = AAIVoiceAgentProvider()
+        assert provider.input_sample_rate == 16000
+        assert provider.tts_sample_rate == 24000
+        assert provider.system_prompt == ""
+        assert provider.tools == ()
+
+    def test_provider_initialization_custom(self) -> None:
+        """Test provider initializes with custom values."""
+        provider = AAIVoiceAgentProvider(
+            ws_url="ws://custom:8000/ws",
+            input_sample_rate=8000,
+            tts_sample_rate=16000,
+            system_prompt="Custom prompt",
+            tools=(),
+        )
+        assert provider.ws_url == "ws://custom:8000/ws"
+        assert provider.input_sample_rate == 8000
+        assert provider.tts_sample_rate == 16000
+        assert provider.system_prompt == "Custom prompt"
+
+    def test_build_config_message_basic(self) -> None:
+        """Test _build_config_message returns correct structure."""
+        provider = AAIVoiceAgentProvider(
+            input_sample_rate=16000,
+            tts_sample_rate=24000,
+        )
+        config = provider._build_config_message("Test prompt", [])
+
+        assert config["type"] == "config"
+        assert config["audioFormat"] == "pcm16"
+        assert config["sampleRate"] == 16000
+        assert config["ttsSampleRate"] == 24000
+        assert config["host"]["systemPrompt"] == "Test prompt"
+        assert config["host"]["tools"] == []
+
+    def test_build_config_message_with_tools(self) -> None:
+        """Test _build_config_message includes tools with correct structure."""
+        # Create a simple mock tool
+        mock_tool = MagicMock(spec=Tool)
+        mock_tool.openai_schema = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather for a location",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"},
+                    },
+                },
+            },
+        }
+
+        provider = AAIVoiceAgentProvider()
+        config = provider._build_config_message("Test prompt", [mock_tool])
+
+        assert len(config["host"]["tools"]) == 1
+        tool = config["host"]["tools"][0]
+
+        # Check flat structure (no "function" key)
+        assert tool["type"] == "function"
+        assert tool["name"] == "get_weather"
+        assert tool["description"] == "Get weather for a location"
+        assert "function" not in tool
+        assert tool["parameters"]["type"] == "object"
+
+    def test_format_tools_for_api(self) -> None:
+        """Test _format_tools_for_api flattens tool schema."""
+        mock_tool = MagicMock(spec=Tool)
+        mock_tool.openai_schema = {
+            "type": "function",
+            "function": {
+                "name": "test_func",
+                "description": "Test function",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                },
+            },
+        }
+
+        provider = AAIVoiceAgentProvider()
+        formatted = provider._format_tools_for_api([mock_tool])
+
+        assert len(formatted) == 1
+        tool = formatted[0]
+        assert tool["type"] == "function"
+        assert tool["name"] == "test_func"
+        assert tool["description"] == "Test function"
+        assert "function" not in tool
+
+    def test_with_host_flag_appends_query_param(self) -> None:
+        """Test _with_host_flag appends ?host=1 to URL."""
+        result = AAIVoiceAgentProvider._with_host_flag("ws://localhost:3000/websocket")
+        assert result == "ws://localhost:3000/websocket?host=1"
+
+    def test_with_host_flag_preserves_existing_query(self) -> None:
+        """Test _with_host_flag preserves existing query parameters."""
+        result = AAIVoiceAgentProvider._with_host_flag(
+            "ws://localhost:3000/websocket?token=abc"
+        )
+        assert "host=1" in result
+        assert "token=abc" in result
+
+    def test_with_host_flag_idempotent(self) -> None:
+        """Test _with_host_flag doesn't duplicate host=1 parameter."""
+        url = "ws://localhost:3000/websocket?host=1"
+        result = AAIVoiceAgentProvider._with_host_flag(url)
+        # Should handle gracefully (or keep as is)
+        assert result.count("host=1") >= 1
+
+    def test_is_connected_property_initial_state(self) -> None:
+        """Test is_connected returns False when not connected."""
+        provider = AAIVoiceAgentProvider()
+        assert provider.is_connected is False
+
+    def test_is_connected_property_after_connect(self) -> None:
+        """Test is_connected returns True when ws is open."""
+        provider = AAIVoiceAgentProvider()
+        # Mock the ws to be in OPEN state
+        from websockets.protocol import State
+
+        mock_ws = MagicMock()
+        mock_ws.state = State.OPEN
+        provider.ws = mock_ws
+
+        assert provider.is_connected is True
+
+    def test_is_connected_property_when_closed(self) -> None:
+        """Test is_connected returns False when ws is closed."""
+        provider = AAIVoiceAgentProvider()
+        from websockets.protocol import State
+
+        mock_ws = MagicMock()
+        mock_ws.state = State.CLOSED
+        provider.ws = mock_ws
+
+        assert provider.is_connected is False

--- a/tests/test_voice/test_audio_native/test_aai_provider.py
+++ b/tests/test_voice/test_audio_native/test_aai_provider.py
@@ -57,6 +57,17 @@ class TestAAIVoiceAgentProvider:
         assert config["ttsSampleRate"] == 24000
         assert config["host"]["systemPrompt"] == "Test prompt"
         assert config["host"]["tools"] == []
+        # A default greeting is sent so the call doesn't open with dead air.
+        assert config["host"]["greeting"]
+
+    def test_build_config_message_greeting(self) -> None:
+        """A custom greeting is forwarded; an empty greeting is omitted."""
+        with_greeting = AAIVoiceAgentProvider(greeting="Hi there.")
+        assert with_greeting._build_config_message("p", [])["host"]["greeting"] == (
+            "Hi there."
+        )
+        without = AAIVoiceAgentProvider(greeting="")
+        assert "greeting" not in without._build_config_message("p", [])["host"]
 
     def test_build_config_message_with_tools(self) -> None:
         """Test _build_config_message includes tools with correct structure."""

--- a/tests/test_voice/test_audio_native/test_aai_provider_session.py
+++ b/tests/test_voice/test_audio_native/test_aai_provider_session.py
@@ -1,0 +1,147 @@
+"""Tests for AAIVoiceAgentProvider.connect() handshake and async I/O.
+
+The AAI host accepts the socket immediately but only signals "agent
+initialized" via a `config`-type frame sent after the client's config
+message. connect() must not hang forever if that frame never arrives, and
+must not silently drop other frames (events or audio) that show up while
+it's waiting.
+
+Covers: (a) a completed handshake marks the provider connected and records
+the sent config message; (b) an early non-config frame is buffered (not
+dropped) and surfaced by the next receive_events_for_duration(); (c) a
+stalled connection with no config frame raises a clear error rather than
+hanging; (d) send_audio/send_tool_result send the expected raw/JSON frames;
+(e) receive_events_for_duration() maps a binary frame to AAIAudioChunkEvent.
+"""
+
+import asyncio
+import json
+
+import pytest
+from websockets.protocol import State
+
+from tau2.voice.audio_native.aai.events import AAIAudioChunkEvent
+from tau2.voice.audio_native.aai.provider import AAIVoiceAgentProvider
+
+
+class FakeWebSocket:
+    """Minimal async fake matching the websockets client surface we rely on."""
+
+    def __init__(self, frames):
+        self.state = State.OPEN
+        self._frames = list(frames)
+        self.sent = []
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def recv(self):
+        if not self._frames:
+            # Simulate a stalled connection: nothing to hand back before the
+            # caller's own per-frame timeout should fire.
+            await asyncio.sleep(10)
+        return self._frames.pop(0)
+
+    async def close(self):
+        self.state = State.CLOSED
+
+
+def _provider():
+    return AAIVoiceAgentProvider(ws_url="ws://localhost:3000/websocket")
+
+
+def _patch_connect(monkeypatch, fake_ws):
+    """Make `websockets.connect(url)` (awaited directly, not as a context
+    manager) resolve to the given fake websocket."""
+
+    async def fake_connect(url, *args, **kwargs):
+        return fake_ws
+
+    monkeypatch.setattr(
+        "tau2.voice.audio_native.aai.provider.websockets.connect", fake_connect
+    )
+
+
+def test_connect_completes_on_config_frame(monkeypatch):
+    provider = _provider()
+    config_frame = json.dumps({"type": "config"})
+    fake_ws = FakeWebSocket(frames=[config_frame])
+    _patch_connect(monkeypatch, fake_ws)
+
+    asyncio.run(provider.connect())
+
+    assert provider.is_connected
+    assert len(fake_ws.sent) == 1
+    sent = json.loads(fake_ws.sent[0])
+    assert sent["type"] == "config"
+    assert provider._buffered_events == []
+
+
+def test_connect_buffers_early_frame_for_next_receive(monkeypatch):
+    provider = _provider()
+    early_frame = json.dumps({"type": "agent_transcript", "text": "hello"})
+    config_frame = json.dumps({"type": "config"})
+    fake_ws = FakeWebSocket(frames=[early_frame, config_frame])
+    _patch_connect(monkeypatch, fake_ws)
+
+    asyncio.run(provider.connect())
+
+    # The early agent_transcript frame was parsed and buffered, not dropped.
+    assert len(provider._buffered_events) == 1
+    assert provider._buffered_events[0].type == "agent_transcript"
+
+    # The next receive_events_for_duration() surfaces it first, then clears.
+    provider.ws = FakeWebSocket(frames=[])
+    events = asyncio.run(provider.receive_events_for_duration(0.02))
+    assert len(events) == 1
+    assert events[0].type == "agent_transcript"
+    assert provider._buffered_events == []
+
+
+def test_connect_raises_when_host_never_sends_config(monkeypatch):
+    # Shrink the timeout so the test doesn't actually wait 10s.
+    monkeypatch.setattr(
+        "tau2.voice.audio_native.aai.provider.DEFAULT_AAI_CONFIG_FRAME_TIMEOUT",
+        0.05,
+    )
+    provider = _provider()
+    fake_ws = FakeWebSocket(frames=[])  # host never sends a config frame
+    _patch_connect(monkeypatch, fake_ws)
+
+    # No config frame arrives -> clear error, not a silent hang.
+    with pytest.raises(RuntimeError, match="did not initialize"):
+        asyncio.run(provider.connect())
+
+
+def test_send_audio_sends_raw_bytes_frame():
+    provider = _provider()
+    fake_ws = FakeWebSocket(frames=[])
+    provider.ws = fake_ws
+
+    asyncio.run(provider.send_audio(b"\x00\x01\x02\x03"))
+
+    assert fake_ws.sent[-1] == b"\x00\x01\x02\x03"
+    assert isinstance(fake_ws.sent[-1], bytes)
+
+
+def test_send_tool_result_sends_expected_json():
+    provider = _provider()
+    fake_ws = FakeWebSocket(frames=[])
+    provider.ws = fake_ws
+
+    asyncio.run(provider.send_tool_result("c1", "{}"))
+
+    sent = json.loads(fake_ws.sent[-1])
+    assert sent == {"type": "tool_result", "toolCallId": "c1", "result": "{}"}
+
+
+def test_receive_events_for_duration_maps_binary_frame_to_audio_chunk():
+    provider = _provider()
+    fake_ws = FakeWebSocket(frames=[b"\x01\x02\x03\x04"])
+    provider.ws = fake_ws
+
+    events = asyncio.run(provider.receive_events_for_duration(0.02))
+
+    assert len(events) == 1
+    assert isinstance(events[0], AAIAudioChunkEvent)
+    assert events[0].pcm16 == b"\x01\x02\x03\x04"

--- a/tests/test_voice/test_audio_native/test_aai_provider_session.py
+++ b/tests/test_voice/test_audio_native/test_aai_provider_session.py
@@ -145,3 +145,58 @@ def test_receive_events_for_duration_maps_binary_frame_to_audio_chunk():
     assert len(events) == 1
     assert isinstance(events[0], AAIAudioChunkEvent)
     assert events[0].pcm16 == b"\x01\x02\x03\x04"
+
+
+def _capture_connect(monkeypatch, fake_ws):
+    """Like `_patch_connect`, but records the kwargs the provider passed."""
+    captured = {}
+
+    async def fake_connect(url, *args, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return fake_ws
+
+    monkeypatch.setattr(
+        "tau2.voice.audio_native.aai.provider.websockets.connect", fake_connect
+    )
+    return captured
+
+
+def test_connect_sends_bearer_token_when_configured(monkeypatch):
+    """A deployed agent gates host mode on the owner's API key, since host mode
+    replaces its prompt and tools while spending the owner's credentials."""
+    fake_ws = FakeWebSocket([json.dumps({"type": "config", "config": {}})])
+    captured = _capture_connect(monkeypatch, fake_ws)
+    provider = AAIVoiceAgentProvider(
+        ws_url="ws://localhost:3000/websocket", api_key="secret-key"
+    )
+
+    asyncio.run(provider.connect())
+
+    assert captured["additional_headers"] == {"Authorization": "Bearer secret-key"}
+    # Never in the URL: that leaks through proxy logs, history, and Referer.
+    assert "secret-key" not in captured["url"]
+
+
+def test_connect_reads_the_key_from_the_environment(monkeypatch):
+    monkeypatch.setenv("ASSEMBLYAI_API_KEY", "env-key")
+    fake_ws = FakeWebSocket([json.dumps({"type": "config", "config": {}})])
+    captured = _capture_connect(monkeypatch, fake_ws)
+    provider = AAIVoiceAgentProvider(ws_url="ws://localhost:3000/websocket")
+
+    asyncio.run(provider.connect())
+
+    assert captured["additional_headers"] == {"Authorization": "Bearer env-key"}
+
+
+def test_connect_omits_the_header_without_a_key(monkeypatch):
+    """A local `aai dev` host gates on AAI_ALLOW_HOST and wants no header, so
+    the usual local workflow keeps working with nothing configured."""
+    monkeypatch.delenv("ASSEMBLYAI_API_KEY", raising=False)
+    fake_ws = FakeWebSocket([json.dumps({"type": "config", "config": {}})])
+    captured = _capture_connect(monkeypatch, fake_ws)
+    provider = AAIVoiceAgentProvider(ws_url="ws://localhost:3000/websocket")
+
+    asyncio.run(provider.connect())
+
+    assert captured["additional_headers"] == {}

--- a/tests/test_voice/test_audio_native/test_aai_registration.py
+++ b/tests/test_voice/test_audio_native/test_aai_registration.py
@@ -1,0 +1,144 @@
+"""Tests for AAI provider registration in tau2.
+
+Asserts that the aai provider is properly registered in:
+- config.py (model, reasoning_effort, provider_type registries)
+- data_model/simulation.py (AudioNativeConfig.provider Literal)
+- adapter.py (create_adapter factory)
+- agent/discrete_time_audio_native_agent.py (VAD config branch)
+- cli.py (CLI choices)
+"""
+
+import pytest
+
+from tau2.agent.discrete_time_audio_native_agent import DiscreteTimeAudioNativeAgent
+from tau2.config import (
+    DEFAULT_AUDIO_NATIVE_MODELS,
+    DEFAULT_AUDIO_NATIVE_REASONING_EFFORT,
+    AUDIO_NATIVE_PROVIDER_TYPES,
+)
+from tau2.data_model.simulation import AudioNativeConfig
+from tau2.voice.audio_native.adapter import create_adapter
+from tau2.voice.audio_native.aai.provider import AAIVADConfig
+
+
+class TestAAIConfigRegistration:
+    """Test aai provider registration in config.py."""
+
+    def test_aai_default_model(self):
+        """Test that aai has the default model 'host' in registry."""
+        assert "aai" in DEFAULT_AUDIO_NATIVE_MODELS
+        assert DEFAULT_AUDIO_NATIVE_MODELS["aai"] == "host"
+
+    def test_aai_reasoning_effort(self):
+        """Test that aai reasoning_effort is None in registry."""
+        assert "aai" in DEFAULT_AUDIO_NATIVE_REASONING_EFFORT
+        assert DEFAULT_AUDIO_NATIVE_REASONING_EFFORT["aai"] is None
+
+    def test_aai_provider_type(self):
+        """Test that aai provider type is 'audio_native' in registry."""
+        assert "aai" in AUDIO_NATIVE_PROVIDER_TYPES
+        assert AUDIO_NATIVE_PROVIDER_TYPES["aai"] == "audio_native"
+
+
+class TestAudioNativeConfigRegistration:
+    """Test aai provider registration in data_model/simulation.py."""
+
+    def test_audio_native_config_accepts_aai_provider(self):
+        """Test that AudioNativeConfig accepts provider='aai'."""
+        config = AudioNativeConfig(provider="aai")
+        assert config.provider == "aai"
+
+    def test_audio_native_config_default_model_for_aai(self):
+        """Test that AudioNativeConfig uses the aai default model."""
+        # When created with provider="aai" and no model specified,
+        # it should use the default from config
+        config = AudioNativeConfig(provider="aai")
+        # model field should default to DEFAULT_AUDIO_NATIVE_MODELS[DEFAULT_AUDIO_NATIVE_PROVIDER]
+        # but we're testing that the config can be created with aai provider
+        assert config.provider == "aai"
+
+
+class TestAdapterFactoryRegistration:
+    """Test aai provider registration in adapter.py."""
+
+    def test_create_adapter_for_aai(self):
+        """Test that create_adapter() works for aai provider."""
+        adapter, model = create_adapter(
+            provider="aai",
+            tick_duration_ms=200,
+            model=None,
+        )
+
+        # Should return the default model 'host'
+        assert model == "host"
+
+        # Should return a DiscreteTimeAAIAdapter
+        from tau2.voice.audio_native.aai.discrete_time_adapter import (
+            DiscreteTimeAAIAdapter,
+        )
+
+        assert isinstance(adapter, DiscreteTimeAAIAdapter)
+
+    def test_create_adapter_aai_not_connected(self):
+        """Test that newly created aai adapter is not connected."""
+        adapter, _ = create_adapter(
+            provider="aai",
+            tick_duration_ms=200,
+        )
+        assert adapter.is_connected is False
+
+
+class TestDiscreteTimeAgentVADConfigRegistration:
+    """Test aai VAD config registration in discrete_time_audio_native_agent.py."""
+
+    def test_agent_creates_aai_vad_config(self):
+        """Test that DiscreteTimeAudioNativeAgent builds AAIVADConfig for aai provider."""
+        # Create a minimal agent with aai provider
+        agent = DiscreteTimeAudioNativeAgent(
+            tools=[],
+            domain_policy="Test policy",
+            tick_duration_ms=200,
+            provider="aai",
+        )
+
+        # Should have AAIVADConfig set
+        assert isinstance(agent.vad_config, AAIVADConfig)
+
+    def test_agent_provider_literal_includes_aai(self):
+        """Test that AudioNativeProvider Literal includes 'aai'."""
+        # This is a compile-time check via type hints, but we can check
+        # that the agent accepts it without error
+        agent = DiscreteTimeAudioNativeAgent(
+            tools=[],
+            domain_policy="Test policy",
+            tick_duration_ms=200,
+            provider="aai",
+        )
+        assert agent.provider == "aai"
+
+
+class TestAAIExports:
+    """Test that aai/__init__.py exports the necessary classes and functions."""
+
+    def test_aai_module_exports(self):
+        """Test that aai module properly exports all required symbols."""
+        from tau2.voice.audio_native.aai import (
+            AAIAudioChunkEvent,
+            AAIErrorEvent,
+            AAIToolCallEvent,
+            AAIUserTranscriptEvent,
+            AAIVADConfig,
+            AAIVoiceAgentProvider,
+            DiscreteTimeAAIAdapter,
+            parse_aai_event,
+        )
+
+        # All imports should succeed
+        assert AAIVADConfig is not None
+        assert AAIVoiceAgentProvider is not None
+        assert DiscreteTimeAAIAdapter is not None
+        assert parse_aai_event is not None
+        assert AAIToolCallEvent is not None
+        assert AAIUserTranscriptEvent is not None
+        assert AAIErrorEvent is not None
+        assert AAIAudioChunkEvent is not None

--- a/tests/test_voice/test_synthesis_concurrency.py
+++ b/tests/test_voice/test_synthesis_concurrency.py
@@ -1,0 +1,114 @@
+"""TTS concurrency ceiling (see tau2.voice.synthesis.synthesize).
+
+Providers cap concurrent requests per subscription and answer 429
+`concurrent_limit_exceeded` over it. A synthesis that burns its retries is a
+caller utterance that arrives late or not at all, so the ceiling is a
+correctness property of a run, not a politeness setting.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tau2.voice.synthesis import synthesize as synth_module
+from tau2.voice.synthesis.synthesize import synthesize_voice
+
+
+def _pcm16_audio():
+    """Minimal stand-in accepted by synthesize_voice's format check."""
+    return SimpleNamespace(format=SimpleNamespace(is_pcm16=True, encoding="pcm_s16le"))
+
+
+def test_concurrent_synthesis_is_bounded_by_the_semaphore():
+    """The ceiling must hold across threads, not just per call site.
+
+    Driven with more threads than the limit: OutOfTurnSpeechGenerator fans out
+    into a thread pool, so a single simulation can exceed the cap on its own.
+    """
+    limit = synth_module._TTS_SEMAPHORE._initial_value
+    live = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def fake_tts(text, config):
+        nonlocal live, peak
+        with lock:
+            live += 1
+            peak = max(peak, live)
+        time.sleep(0.02)
+        with lock:
+            live -= 1
+        return _pcm16_audio()
+
+    with patch.object(synth_module, "tts_elevenlabs", fake_tts):
+        threads = [
+            threading.Thread(
+                target=synthesize_voice,
+                kwargs={
+                    "text": "hello",
+                    "provider": "elevenlabs",
+                    "provider_config": None,
+                },
+            )
+            for _ in range(limit * 4)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert peak <= limit, f"{peak} concurrent TTS calls exceeded the limit of {limit}"
+    # Guards against a semaphore so tight it serializes everything, which would
+    # make a run needlessly slow rather than merely correct.
+    assert peak > 1, "expected real parallelism up to the limit"
+
+
+def test_unsupported_provider_raises_without_consuming_a_slot():
+    """A config error must not queue behind in-flight synthesis."""
+    before = synth_module._TTS_SEMAPHORE._value
+    with pytest.raises(ValueError, match="Unsupported synthesis provider"):
+        synthesize_voice(text="hello", provider="nope", provider_config=None)
+    assert synth_module._TTS_SEMAPHORE._value == before
+
+
+def test_slot_is_released_when_the_provider_raises():
+    """A failing call must not leak its slot, or the allowance bleeds away.
+
+    Without release-on-exception the limit degrades run-long: each provider
+    error permanently costs one slot until synthesis stops entirely.
+    """
+    before = synth_module._TTS_SEMAPHORE._value
+
+    def boom(text, config):
+        raise ConnectionError("provider down")
+
+    # tts_retry re-raises after exhausting attempts; every attempt must release.
+    with patch.object(synth_module, "tts_elevenlabs", boom):
+        with pytest.raises(ConnectionError):
+            synthesize_voice(text="hello", provider="elevenlabs", provider_config=None)
+
+    assert synth_module._TTS_SEMAPHORE._value == before
+
+
+@pytest.mark.parametrize("bad", ["abc", "0", "-1"])
+def test_invalid_env_override_is_rejected(bad, monkeypatch):
+    """A typo'd override must fail loudly, not silently pick a default.
+
+    Falling back would reintroduce the 429s the ceiling exists to prevent, and
+    the run would look merely flaky.
+    """
+    monkeypatch.setenv("TAU2_TTS_MAX_CONCURRENCY", bad)
+    with pytest.raises(ValueError, match="TAU2_TTS_MAX_CONCURRENCY"):
+        synth_module._tts_concurrency_limit()
+
+
+def test_env_override_is_honored(monkeypatch):
+    monkeypatch.setenv("TAU2_TTS_MAX_CONCURRENCY", "2")
+    assert synth_module._tts_concurrency_limit() == 2
+    monkeypatch.delenv("TAU2_TTS_MAX_CONCURRENCY")
+    from tau2.config import DEFAULT_TTS_MAX_CONCURRENCY
+
+    assert synth_module._tts_concurrency_limit() == DEFAULT_TTS_MAX_CONCURRENCY


### PR DESCRIPTION
Tooling and docs around driving tau2-bench against an [AAI](https://github.com/alexkroman/agent) voice agent. No changes to scoring, domains, or any existing provider.

## `synthesize_voice` is now concurrency-bounded

Two parallel retail runs produced **24 `429 concurrent_limit_exceeded`** from ElevenLabs' 5-concurrent subscription cap. That is not merely slow: a synthesis that burns its retries is a caller utterance arriving late or not at all, and on retail those are disproportionately the spelled-out names and ZIPs authentication turns on. It corrupts the variable a voice benchmark exists to measure, while looking like flakiness.

`--max-concurrency` cannot bound it — `OutOfTurnSpeechGenerator` pre-generates its inserts in a thread pool, so one simulation fans out to 10 calls on its own. The semaphore therefore lives in `synthesize_voice`, the single choke point all four synthesis paths pass through; capping the pool would leave the other three unbounded. Acquired *inside* the retried function so a backing-off attempt releases its slot. `DEFAULT_TTS_MAX_CONCURRENCY` = 4, `TAU2_TTS_MAX_CONCURRENCY` overrides, ceiling is per process.

7 new tests; the existing voice suite passes unchanged (179 passed / 69 skipped).

## Two report scripts

`scripts/failure_report.py` — which tasks failed and why, in the order a fix needs: run trust first (429s, unscored sessions, reconnects), then wire anomalies reported *apart* from reward, then failures worst-first with the expected action beside the call actually made and the judge's own justification. Retries collapse to the highest trial per task, because a retry overwrites the earlier score and counting every row mixes a superseded one into the mean.

`scripts/stt_errors.py` — tau2 *synthesizes* the caller, so ground truth exists (`audio_script_gold`). Diffing it against the agent's `user_transcript` separates "the agent did the wrong thing" from "the agent was told the wrong thing". Shows only mis-hearings that **reached a tool call**, across every task including passing ones (a mis-heard argument the agent recovered from is a near miss). On the measured runs that is ~10% of all mis-hearings — the other 90% would have invited fixing the loudest rather than the costly one.

Three false-positive sources were found by reading its own output and are fixed: spoken `dot`/`at` separators vs written punctuation (a *correct* email read as an error), cross-word substring matches (`"you say"` contains `usa`), and asymmetric spelling punctuation (`M, E, I—D…` vs `M-E-I-D…` left every argument looking unsaid).

## Runbook + measured settings

`voice/audio_native/aai/README.md`: local-agent setup (including the easily-missed `AAI_ALLOW_HOST=1`, whose absence surfaces only as a rejected upgrade), a step-by-step STT-endpoint A/B, and a "Settings that matter" section where every entry cites a number from a real run — including two decisions *not* to change anything (`minBargeInWords`/`interruptionMinDurationMs`, with 17 of 18 barge-ins genuine; and `falseInterruptionTimeoutMs`, whose alarming log pair is handled by design since the moot aborts the resume while still silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)