### PR TITLE
Add grok-voice-think-fast-2.0 voice leaderboard submission

### DIFF
--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -162,11 +162,15 @@ DEFAULT_GEMINI_INPUT_SAMPLE_RATE = 16000  # fixed, API-defined
 DEFAULT_GEMINI_OUTPUT_SAMPLE_RATE = 24000  # fixed, API-defined
 
 # =============================================================================
-# XAI PROVIDER (overridable voice, fixed API constants)
+# XAI PROVIDER (overridable model/voice, fixed API constants)
 # =============================================================================
 DEFAULT_XAI_REALTIME_BASE_URL = "wss://api.x.ai/v1/realtime"  # fixed
-DEFAULT_XAI_VOICE = "Ara"  # overridable: Ara, Rex, Sal, Eve, Leo
-DEFAULT_XAI_MODEL = "xai-realtime"  # fixed, determined by endpoint
+DEFAULT_XAI_VOICE = "ara"  # overridable; lowercase voice IDs (ara, rex, sal, eve, leo)
+# Model is selected via ?model= query param on the WebSocket URL.
+# Aliases: grok-voice-latest -> grok-voice-think-fast-2.0 (since 2026-08-05).
+# Reasoning: session.update reasoning.effort accepts "high" | "none"
+# (API default "high").
+DEFAULT_XAI_MODEL = "grok-voice-think-fast-2.0"  # overridable
 
 # =============================================================================
 # NOVA PROVIDER (overridable model/voice, fixed API constants)
@@ -186,6 +190,9 @@ DEFAULT_QWEN_REALTIME_URL = (
 # Qwen3.5-Omni realtime models support tool calling over WebSocket
 # (the older qwen3-omni-flash-realtime accepted tool configs but never
 # invoked them). Flash variant: qwen3.5-omni-flash-realtime.
+# Rate limits:
+# qwen3.5-omni-plus-realtime; 60 (requests per minute); 100,000 (tokens per minute)
+# qwen3.5-omni-plus-realtime-2026-03-15; 60 (requests per minute); 100,000 (tokens per minute)
 DEFAULT_QWEN_MODEL = "qwen3.5-omni-plus-realtime"  # overridable
 DEFAULT_QWEN_VOICE = "Tina"  # overridable; Qwen3.5-Omni-Realtime default voice
 DEFAULT_QWEN_INPUT_SAMPLE_RATE = 16000  # fixed, API-defined
@@ -206,7 +213,7 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
 DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
     "openai": None,
     "gemini": "high",
-    "xai": None,
+    "xai": "high",
     "nova": None,
     "qwen": None,
     "livekit": None,

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -366,7 +366,7 @@ class DiscreteTimeAdapter(ABC):
 # ---------------------------------------------------------------------------
 
 # Providers where the model is determined by the endpoint, not a parameter
-_PROVIDERS_WITH_ENDPOINT_DETERMINED_MODEL = ("xai",)
+_PROVIDERS_WITH_ENDPOINT_DETERMINED_MODEL: tuple[str, ...] = ()
 
 
 def create_adapter(
@@ -455,6 +455,7 @@ def create_adapter(
         adapter = DiscreteTimeXAIAdapter(
             tick_duration_ms=tick_duration_ms,
             send_audio_instant=send_audio_instant,
+            model=model,
             reasoning_effort=reasoning_effort,
         )
     elif provider == "nova":

--- a/src/tau2/voice/audio_native/xai/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/xai/discrete_time_adapter.py
@@ -41,6 +41,7 @@ from tau2.config import (
     DEFAULT_AUDIO_NATIVE_DISCONNECT_TIMEOUT,
     DEFAULT_AUDIO_NATIVE_TICK_TIMEOUT_BUFFER,
     DEFAULT_XAI_MODEL,
+    DEFAULT_XAI_VOICE,
 )
 from tau2.data_model.message import ToolCall
 from tau2.data_model.usage import UsageRecord
@@ -95,28 +96,35 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
         self,
         tick_duration_ms: int,
         send_audio_instant: bool = True,
+        model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         provider: Optional[XAIRealtimeProvider] = None,
-        voice: str = "Ara",
+        voice: str = DEFAULT_XAI_VOICE,
     ):
         """Initialize the discrete-time xAI adapter.
 
         Args:
             tick_duration_ms: Duration of each tick in milliseconds. Must be > 0.
             send_audio_instant: If True, send audio in one call (discrete-time mode).
-            reasoning_effort: Not supported by xAI. Must be None.
+            model: Model to use (e.g. grok-voice-think-fast-2.0). Defaults to
+                DEFAULT_XAI_MODEL.
+            reasoning_effort: "high" or "none". If None, the API default
+                ("high") applies.
             provider: Optional provider instance. Created lazily if not provided.
-            voice: Voice to use. One of: Ara, Rex, Sal, Eve, Leo. Default: Ara.
+            voice: Voice to use (lowercase voice ID). Default: ara.
         """
-        if reasoning_effort is not None:
+        if reasoning_effort is not None and reasoning_effort not in ("high", "none"):
             raise ValueError(
-                f"xAI provider does not support reasoning_effort (got '{reasoning_effort}')"
+                f"xAI reasoning_effort must be 'high' or 'none' "
+                f"(got '{reasoning_effort}')"
             )
         super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
 
         self._chunk_size = int(
             self.audio_format.bytes_per_second * self._voip_interval_ms / 1000
         )
+        self.model = model or DEFAULT_XAI_MODEL
+        self.reasoning_effort = reasoning_effort
         self.voice = voice
 
         # Provider - created lazily if not provided
@@ -135,6 +143,7 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
         """Get the provider, creating it if needed."""
         if self._provider is None:
             self._provider = XAIRealtimeProvider(
+                model=self.model,
                 voice=self.voice,
                 audio_format=XAIAudioFormat.PCMU,  # G.711 μ-law
             )
@@ -198,6 +207,7 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
             system_prompt=system_prompt,
             tools=tools,
             vad_config=vad_config,
+            reasoning_effort=self.reasoning_effort,
         )
 
     def _make_audio_usage_record(self) -> Optional[UsageRecord]:
@@ -212,7 +222,7 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
             return None
         return UsageRecord(
             provider="xai",
-            model=DEFAULT_XAI_MODEL,
+            model=self.model,
             component="realtime",
             semantics="cumulative",
             scope_id=f"audio-session-{self._session_counter}",
@@ -395,7 +405,7 @@ class DiscreteTimeXAIAdapter(DiscreteTimeAdapter):
                 record = UsageRecord.from_openai_realtime_usage(
                     usage,
                     provider="xai",
-                    model=DEFAULT_XAI_MODEL,
+                    model=self.model,
                     scope_id=(event.response or {}).get("id"),
                 )
                 record.billable = False

--- a/src/tau2/voice/audio_native/xai/provider.py
+++ b/src/tau2/voice/audio_native/xai/provider.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 
 from tau2.config import (
     DEFAULT_TELEPHONY_RATE,
+    DEFAULT_XAI_MODEL,
     DEFAULT_XAI_REALTIME_BASE_URL,
     DEFAULT_XAI_VOICE,
 )
@@ -106,6 +107,7 @@ class XAIRealtimeProvider:
     def __init__(
         self,
         api_key: Optional[str] = None,
+        model: Optional[str] = None,
         voice: Optional[str] = None,
         audio_format: XAIAudioFormat = XAIAudioFormat.PCMU,
         sample_rate: int = DEFAULT_TELEPHONY_RATE,
@@ -115,7 +117,10 @@ class XAIRealtimeProvider:
         Args:
             api_key: xAI API key. If not provided, reads from XAI_API_KEY
                 environment variable.
-            voice: Voice to use. One of: Ara, Rex, Sal, Eve, Leo. Defaults to Ara.
+            model: Model to use, passed as ?model= on the WebSocket URL
+                (e.g. grok-voice-think-fast-2.0). Defaults to DEFAULT_XAI_MODEL.
+            voice: Voice to use (lowercase voice ID, e.g. ara, rex, sal, eve,
+                leo). Defaults to ara.
             audio_format: Audio format for input/output. Defaults to PCMU (G.711 μ-law)
                 which is optimal for telephony (no conversion needed).
             sample_rate: Sample rate for PCM format (ignored for PCMU/PCMA).
@@ -128,6 +133,7 @@ class XAIRealtimeProvider:
         if not self.api_key:
             raise ValueError("xAI API key not provided. Set XAI_API_KEY env var.")
 
+        self.model = model or DEFAULT_XAI_MODEL
         self.voice = voice or self.DEFAULT_VOICE
         self.audio_format = audio_format
         self.sample_rate = sample_rate
@@ -162,8 +168,9 @@ class XAIRealtimeProvider:
             "Content-Type": "application/json",
         }
 
-        logger.info(f"xAI Realtime API: Connecting to {self.BASE_URL}")
-        self.ws = await websockets.connect(self.BASE_URL, additional_headers=headers)
+        url = f"{self.BASE_URL}?model={self.model}"
+        logger.info(f"xAI Realtime API: Connecting to {url}")
+        self.ws = await websockets.connect(url, additional_headers=headers)
 
         # Wait for the connection-established event. Older xAI endpoints sent
         # conversation.created; newer ones send session.created (OpenAI-style).
@@ -241,6 +248,7 @@ class XAIRealtimeProvider:
         system_prompt: str,
         tools: List[Tool],
         vad_config: XAIVADConfig,
+        reasoning_effort: Optional[str] = None,
     ) -> None:
         """Configure the realtime session with instructions, tools, and settings.
 
@@ -248,6 +256,8 @@ class XAIRealtimeProvider:
             system_prompt: The system instructions for the assistant.
             tools: List of tools available for the assistant to use.
             vad_config: Voice Activity Detection configuration.
+            reasoning_effort: Reasoning effort, "high" or "none". If None, the
+                API default ("high") applies.
 
         Raises:
             RuntimeError: If not connected or if session configuration fails.
@@ -265,6 +275,8 @@ class XAIRealtimeProvider:
                 "tools": self._format_tools_for_api(tools),
             },
         }
+        if reasoning_effort is not None:
+            session_config["session"]["reasoning"] = {"effort": reasoning_effort}
 
         logger.debug(f"xAI session config: {json.dumps(session_config, indent=2)}")
         await self.ws.send(json.dumps(session_config))

--- a/web/leaderboard/public/submissions/grok-voice-think-fast-2-0_xai_2026-08-06/submission.json
+++ b/web/leaderboard/public/submissions/grok-voice-think-fast-2-0_xai_2026-08-06/submission.json
@@ -1,0 +1,146 @@
+{
+  "model_name": "grok-voice-think-fast-2.0",
+  "model_organization": "xAI",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-08-06",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "keshav@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 59.64912280701754,
+      "cost": 0.23825263157894733
+    },
+    "airline": {
+      "pass_1": 56.00000000000001,
+      "cost": 0.20933333333333337
+    },
+    "telecom": {
+      "pass_1": 71.9298245614035,
+      "cost": 0.38721871345029246
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_regular_xai",
+    "retail": "retail_regular_xai",
+    "telecom": "telecom_regular_xai"
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-06",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "v1.0",
+    "notes": "Full-duplex audio-native evaluation using regular speech complexity (realistic audio conditions). 1 trial per task.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "xai",
+    "model": "grok-voice-think-fast-2.0",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "interaction_metrics": {
+    "version": "1.0",
+    "config": {
+      "tick_duration_sec": 0.2,
+      "no_yield_window_sec": 2.0,
+      "backchannel_yield_window_sec": 1.0,
+      "vocal_tic_yield_window_sec": 1.0,
+      "non_directed_yield_window_sec": 1.0,
+      "vocal_tic_response_window_sec": 2.0,
+      "non_directed_response_window_sec": 2.0
+    },
+    "domains": {
+      "airline": {
+        "response_latency_mean": 1.6867924528301874,
+        "yield_latency_mean": 0.9123076923076923,
+        "response_rate": 1.0,
+        "yield_rate": 0.959409594095941,
+        "agent_interruption_rate": 0.13746630727762804,
+        "selectivity_backchannel": 0.5483870967741935,
+        "selectivity_vocal_tic": 0.33333333333333337,
+        "selectivity_non_directed": 0.2682926829268293,
+        "counts": {
+          "n_simulations": 50,
+          "response_total": 371,
+          "yield_total": 271,
+          "backchannel_total": 31,
+          "vocal_tic_total": 30,
+          "non_directed_total": 41,
+          "agent_interrupts_count": 51
+        }
+      },
+      "retail": {
+        "response_latency_mean": 1.778121546961324,
+        "yield_latency_mean": 0.9117088607594938,
+        "response_rate": 1.0,
+        "yield_rate": 0.9678407350689127,
+        "agent_interruption_rate": 0.11602209944751381,
+        "selectivity_backchannel": 0.5217391304347826,
+        "selectivity_vocal_tic": 0.36986301369863017,
+        "selectivity_non_directed": 0.28,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 905,
+          "yield_total": 653,
+          "backchannel_total": 92,
+          "vocal_tic_total": 73,
+          "non_directed_total": 75,
+          "agent_interrupts_count": 105
+        }
+      },
+      "telecom": {
+        "response_latency_mean": 1.6603235014272104,
+        "yield_latency_mean": 0.9883244882486734,
+        "response_rate": 0.9990494296577946,
+        "yield_rate": 0.9821295606850335,
+        "agent_interruption_rate": 0.06701520912547529,
+        "selectivity_backchannel": 0.34523809523809523,
+        "selectivity_vocal_tic": 0.28402366863905326,
+        "selectivity_non_directed": 0.28301886792452835,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 2104,
+          "yield_total": 1343,
+          "backchannel_total": 84,
+          "vocal_tic_total": 169,
+          "non_directed_total": 106,
+          "agent_interrupts_count": 141
+        }
+      }
+    },
+    "overall": {
+      "response_latency_mean": 1.7084125004062407,
+      "yield_latency_mean": 0.937447013771953,
+      "response_rate": 0.9996831432192649,
+      "yield_rate": 0.969793296616629,
+      "agent_interruption_rate": 0.10683453861687238,
+      "selectivity_backchannel": 0.4717881074823571,
+      "selectivity_vocal_tic": 0.3290733385570056,
+      "selectivity_non_directed": 0.27710385028378587,
+      "counts": {
+        "n_simulations": 278,
+        "response_total": 3380,
+        "yield_total": 2267,
+        "backchannel_total": 207,
+        "vocal_tic_total": 272,
+        "non_directed_total": 222,
+        "agent_interrupts_count": 297
+      }
+    }
+  },
+  "model_release": {
+    "release_date": "2026-07-29",
+    "announcement_url": "https://x.ai/news/grok-voice-think-fast-2",
+    "announcement_title": "Introducing Grok Voice Think Fast 2.0"
+  },
+  "reasoning_effort": "high"
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -46,7 +46,8 @@
     "gpt-realtime-2-banking_openai_2026-07-12",
     "gemini-3-1-flash-live-preview-thinking-high-banking_google_2026-07-13",
     "xai-realtime-banking_xai_2026-07-13",
-    "qwen3-5-omni-plus-realtime_qwen_2026-08-06"
+    "qwen3-5-omni-plus-realtime_qwen_2026-08-06",
+    "grok-voice-think-fast-2-0_xai_2026-08-06"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",


### PR DESCRIPTION
## Summary
- Update the xAI audio-native provider to `grok-voice-think-fast-2.0` (model selected via WebSocket `?model=` query param, reasoning effort `high`/`none` via `session.update`; old endpoint-determined model support removed)
- Add voice leaderboard submission for `grok-voice-think-fast-2.0` (reasoning effort high): retail 59.6 / airline 56.0 / telecom 71.9 — unweighted average **62.5**
- Full-duplex audio-native evaluation, regular speech complexity, 1 trial per task, user simulator v1.0

## Details
- 278/278 tasks completed; total agent cost $81.77 (~$0.29/conversation at $0.08/min)
- Trajectories (3.1 GB incl. audio) uploaded to `s3://sierra-tau-bench-public/submissions/grok-voice-think-fast-2-0_xai_2026-08-06/`
- `tau2 submit validate` passes (2 known benign warnings: provider-prefixed model name, user sim recorded as underlying LLM)
- Sanity check: reran `grok-voice-think-fast-1.0` on the same harness — scored 62.5 unweighted vs. its existing 67.3 leaderboard entry, so the 1.0/2.0 parity here is consistent

## Test plan
- [x] `tau2 submit validate` on the prepared submission
- [x] Provider test suite + 1-task e2e smoke test on retail (reward 1.0, correct usage attribution)

Made with [Cursor](https://cursor.com)