### PR TITLE
Fix go_away reconnection when the server goes silent

### DIFF
--- a/src/tau2/voice/audio_native/gemini/provider.py
+++ b/src/tau2/voice/audio_native/gemini/provider.py
@@ -610,6 +610,24 @@ class GeminiLiveProvider:
             logger.error(f"Session resumption failed: {e}")
             return False
 
+    def _goaway_deadline_elapsed(self) -> bool:
+        """Whether a GoAway deadline has passed without the receive loop acting.
+
+        The receive loop only re-checks `_reconnect_deadline` when a response
+        arrives (it is otherwise blocked in `async for response in turn`). If
+        the server goes silent after sending GoAway, that check never runs and
+        the reconnection window is missed entirely. The adapter polls this from
+        its own tick loop, which keeps running independently of the receive
+        task, so the deadline is honored either way.
+        """
+        if not self._reconnect_at_turn_boundary or self._reconnect_deadline is None:
+            return False
+        try:
+            now = asyncio.get_running_loop().time()
+        except RuntimeError:  # no running loop (called from sync context)
+            return False
+        return now >= self._reconnect_deadline
+
     @property
     def needs_reconnection(self) -> bool:
         """Whether a GoAway reconnection is pending.
@@ -617,7 +635,7 @@ class GeminiLiveProvider:
         The adapter should check this at the start of each tick and call
         perform_pending_reconnection() before any session I/O.
         """
-        return self._pending_reconnection
+        return self._pending_reconnection or self._goaway_deadline_elapsed()
 
     async def perform_pending_reconnection(self) -> bool:
         """Perform a pending GoAway reconnection.
@@ -630,7 +648,17 @@ class GeminiLiveProvider:
             True if reconnection succeeded, False otherwise.
         """
         if not self._pending_reconnection:
-            return True
+            if not self._goaway_deadline_elapsed():
+                return True
+            # GoAway deadline expired while the receive loop sat blocked on a
+            # silent server. Take over the reconnection here.
+            logger.warning(
+                "GoAway deadline elapsed without the receive loop reacting "
+                "(server silent); forcing reconnection at tick boundary"
+            )
+            self._reconnect_at_turn_boundary = False
+            self._reconnect_deadline = None
+            self._pending_reconnection = True
 
         self._pending_reconnection = False
 


### PR DESCRIPTION
## Description

TLDR: `GeminiLiveProvider` can silently miss its `GoAway` reconnection window. When the Gemini Live server sends a `GoAway` and then stops emitting responses, the session gets dropped mid-simulation instead of being resumed, losing the rest of the conversation for that task. This has caused unnecessary tasks when we benchmark gemini models on telecom domain where the voice conversation needs to be longer than the default 10-min max session length of Gemini API or Gemini on vertex(https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/live-api/start-manage-session#session-lifetime). For some difficult cases, the conversation has to be 20-30 minutes to address all tasks in a single use case. 

The details are below: The gemini provider records a `_reconnect_deadline` when it sees `GoAway`
(`provider.py`), but the only place that deadline is re-checked is inside the receive loop's `async for response in turn` body (`provider.py`). That check is reached only when a new response arrives. If the server goes quiet
after the `GoAway`, which is what happens near the ~10 minute session timeout, the receive task stays parked in the `async for` and the deadline passes unnoticed.

The adapter's tick loop keeps running regardless of whether the receive task is blocked, so this makes the deadline observable from there instead.

## Fix

- Add `GeminiLiveProvider._goaway_deadline_elapsed()`: true once `_reconnect_at_turn_boundary` is set and     `_reconnect_deadline` has passed. Returns `False` when there is no running event loop, so it stays safe for
  sync callers.
- `needs_reconnection` now also reports `True` when that deadline has elapsed, so `DiscreteTimeGeminiAdapter._execute_tick()` picks it up at the next tick boundary, before any session I/O.
- `perform_pending_reconnection()` takes over the reconnection in that case (logging a warning) rather than returning early, clearing `_reconnect_at_turn_boundary` / `_reconnect_deadline` the same way the receive loop does.


Overall the behavior isn't changed when the server keeps responding after `go_away` is received. It only enables the harness to handle the session resumption during user simulator's turn or silence period.

## Documentation

`src/tau2/voice/audio_native/gemini/README.md` describes the GoAway flow ("Provider sets `needs_reconnection` flag" => "Adapter checks at tick boundary"). It still holds the same interface; so no doc change is included. I can add more descriptions for this session resumption in your doc if you prefer. 

## Tests

- [x] Ran telecom on gemini-3.1-flash-live model and it looks good. 
