### PR TITLE
feat: add evaluator provenance

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -31,6 +31,27 @@ required of the agent, this page is for you.
 [issue-224]: https://github.com/sierra-research/tau2-bench/issues/224
 [issue-129]: https://github.com/sierra-research/tau2-bench/issues/129
 
+## Evaluator provenance: live versus replay
+
+Environment evaluation can be performed against either a caller-provided live
+environment or a reconstructed environment. The returned `RewardInfo` makes
+this distinction explicit:
+
+| Field | Meaning |
+|-------|---------|
+| `evaluation_mode` | `"live"` when the candidate is the current environment; `"replay"` when it is reconstructed from recorded messages. |
+| `state_source` | The source of the candidate state: `"live"` or `"replayed"`. |
+| `replayed_actions` | The trajectory and reference tool calls executed while rebuilding evaluator state, with each entry labeled `trajectory` or `reference`. |
+| `warnings` | Provenance or replay-fidelity warnings. Lenient re-grading (`strict_replay=False`) always adds a warning. |
+
+`EnvironmentEvaluator.calculate_reward(...)` is the backward-compatible
+replay entry point. Use `EnvironmentEvaluator.evaluate_live(...)` when the
+candidate environment itself is available. A replay reward is a statement
+about the reconstructed state; it is not evidence that the same write occurred
+in the original live environment. For example, a proxy-intercepted write can
+produce `evaluation_mode="live", reward=0.0` for the live environment while a
+separate replay evaluation produces `evaluation_mode="replay", reward=1.0`.
+
 ## The task schema, in plain English
 
 A task's `evaluation_criteria` (see

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -50,7 +50,7 @@ from tau2.config import (
     DEFAULT_YIELD_THRESHOLD_WHEN_INTERRUPTING_SECONDS,
 )
 from tau2.data_model.audio_effects import EffectTimeline
-from tau2.data_model.message import Message, Tick
+from tau2.data_model.message import Message, Tick, ToolCall
 from tau2.data_model.persona import PersonaConfig
 from tau2.data_model.tasks import Action, EnvAssertion, RewardType, Task
 from tau2.data_model.usage import SessionUsage
@@ -749,6 +749,20 @@ class EnvAssertionCheck(BaseModel):
     reward: float
 
 
+class ReplayedAction(BaseModel):
+    """A tool call that was executed while reconstructing evaluator state.
+
+    ``source`` distinguishes calls recovered from the candidate trajectory from
+    the reference actions used to build the target state.  This is diagnostic
+    provenance only; it does not change how rewards are computed.
+    """
+
+    source: Literal["trajectory", "reference"] = Field(
+        description="Where the replayed tool call came from."
+    )
+    tool_call: ToolCall = Field(description="The tool call executed during replay.")
+
+
 # =============================================================================
 # Review Data Models (for LLM-based conversation review)
 # =============================================================================
@@ -1115,6 +1129,34 @@ class RewardInfo(BaseModel):
     info: Annotated[
         Optional[dict],
         Field(description="Additional information about the reward.", default=None),
+    ]
+    evaluation_mode: Annotated[
+        Optional[Literal["live", "replay"]],
+        Field(
+            description="Whether the evaluated candidate state was live or replayed.",
+            default=None,
+        ),
+    ]
+    state_source: Annotated[
+        Optional[Literal["live", "replayed"]],
+        Field(
+            description="Source of the candidate state used for evaluation.",
+            default=None,
+        ),
+    ]
+    replayed_actions: Annotated[
+        list[ReplayedAction],
+        Field(
+            description="Tool calls executed while reconstructing evaluator state.",
+            default_factory=list,
+        ),
+    ]
+    warnings: Annotated[
+        list[str],
+        Field(
+            description="Warnings about evaluation provenance or replay fidelity.",
+            default_factory=list,
+        ),
     ]
 
     @property

--- a/src/tau2/evaluator/evaluator.py
+++ b/src/tau2/evaluator/evaluator.py
@@ -266,6 +266,10 @@ def evaluate_simulation(
             communicate_checks=communicate_reward_info.communicate_checks,
             reward_basis=task.evaluation_criteria.reward_basis,
             reward_breakdown=reward_breakdown,
+            evaluation_mode=env_reward_info.evaluation_mode,
+            state_source=env_reward_info.state_source,
+            replayed_actions=env_reward_info.replayed_actions,
+            warnings=env_reward_info.warnings,
             info={
                 "env": env_reward_info.info,
                 "nl": nl_reward_info.info if nl_reward_info is not None else None,
@@ -283,6 +287,7 @@ def evaluate_simulation(
             full_trajectory=trajectory,
             solo_mode=solo_mode,
             env_kwargs=env_kwargs,
+            strict_replay=strict_replay,
         )
         action_reward_info = ActEvaluator.calculate_reward(
             task=task,
@@ -339,6 +344,10 @@ def evaluate_simulation(
                 *([RewardType.NL_ASSERTION] if nl_reward_info is not None else []),
             ],
             reward_breakdown=reward_breakdown,
+            evaluation_mode=env_reward_info.evaluation_mode,
+            state_source=env_reward_info.state_source,
+            replayed_actions=env_reward_info.replayed_actions,
+            warnings=env_reward_info.warnings,
             info={
                 "env": env_reward_info.info,
                 "nl": nl_reward_info.info if nl_reward_info is not None else None,

--- a/src/tau2/evaluator/evaluator_env.py
+++ b/src/tau2/evaluator/evaluator_env.py
@@ -6,18 +6,234 @@ from tau2.data_model.message import (
     AssistantMessage,
     Message,
     Tick,
+    ToolCall,
     UserMessage,
 )
-from tau2.data_model.simulation import DBCheck, EnvAssertionCheck, RewardInfo
+from tau2.data_model.simulation import (
+    DBCheck,
+    EnvAssertionCheck,
+    ReplayedAction,
+    RewardInfo,
+)
 from tau2.data_model.tasks import RewardType, Task
 from tau2.environment.environment import Environment
 from tau2.evaluator.evaluator_base import EvaluatorBase
+
+
+def _tool_calls_from_messages(messages: list[Message]) -> list[ToolCall]:
+    """Extract recorded tool calls in the order used by environment replay."""
+    tool_calls = []
+    for message in messages:
+        if isinstance(message, (AssistantMessage, UserMessage)):
+            tool_calls.extend(message.tool_calls or [])
+    return tool_calls
+
+
+def _replayed_trajectory_tool_calls(
+    environment: Environment,
+    messages: list[Message],
+) -> list[ToolCall]:
+    """Return the trajectory calls that ``Environment.set_state`` replays."""
+    return [
+        tool_call
+        for tool_call in _tool_calls_from_messages(messages)
+        if environment._has_tool(tool_call.name)
+        and environment._is_mutating_tool(tool_call.name)
+    ]
+
+
+def _reference_tool_calls(task: Task) -> list[ToolCall]:
+    """Convert the task's reference actions into serializable tool calls."""
+    return [
+        ToolCall(
+            id=action.action_id,
+            name=action.name,
+            arguments=action.arguments,
+            requestor=action.requestor,
+        )
+        for action in (task.evaluation_criteria.actions or [])
+    ]
+
+
+def _provenance_warnings(
+    evaluation_mode: str,
+    strict_replay: bool,
+) -> list[str]:
+    """Build warnings that keep replay results distinct from live results."""
+    warnings = []
+    if evaluation_mode == "replay":
+        warnings.append(
+            "evaluation_mode='replay': the candidate state was reconstructed "
+            "from recorded tool calls and does not certify live environment state."
+        )
+    if not strict_replay:
+        warning = (
+            "strict_replay=False: recorded tool outputs were not required to "
+            "match replayed outputs."
+        )
+        if evaluation_mode == "replay":
+            warning += " Reward reflects replayed state only."
+        else:
+            warning += " The live candidate state was not reconstructed."
+        warnings.append(warning)
+    return warnings
+
+
+def _build_state_reward(
+    predicted_environment: Environment,
+    gold_environment: Environment,
+    task: Task,
+    *,
+    evaluation_mode: str,
+    state_source: str,
+    replayed_actions: list[ReplayedAction],
+    strict_replay: bool,
+) -> RewardInfo:
+    """Score two environments and attach explicit evaluator provenance."""
+    agent_db_hash = gold_environment.get_db_hash()
+    user_db_hash = gold_environment.get_user_db_hash()
+    predicted_agent_db_hash = predicted_environment.get_db_hash()
+    predicted_user_db_hash = predicted_environment.get_user_db_hash()
+    agent_db_match = agent_db_hash == predicted_agent_db_hash
+    user_db_match = user_db_hash == predicted_user_db_hash
+    db_match = agent_db_match and user_db_match
+    db_reward = 1.0 if db_match else 0.0
+    db_check = DBCheck(db_match=db_match, db_reward=db_reward)
+
+    env_assertions = task.evaluation_criteria.env_assertions or []
+    env_assertion_checks = []
+    env_assertion_reward = 1.0
+    for env_assertion in env_assertions:
+        success = predicted_environment.run_env_assertion(
+            env_assertion,
+            raise_assertion_error=False,
+        )
+        res = EnvAssertionCheck(
+            env_assertion=env_assertion,
+            met=success,
+            reward=1.0 if success else 0.0,
+        )
+        env_assertion_checks.append(res)
+        env_assertion_reward *= res.reward
+
+    reward = 1.0
+    reward_breakdown = {}
+    if RewardType.DB in task.evaluation_criteria.reward_basis:
+        reward_breakdown[RewardType.DB] = db_reward
+        reward *= db_reward
+    if RewardType.ENV_ASSERTION in task.evaluation_criteria.reward_basis:
+        reward_breakdown[RewardType.ENV_ASSERTION] = env_assertion_reward
+        reward *= env_assertion_reward
+
+    return RewardInfo(
+        reward=reward,
+        db_check=db_check,
+        env_assertions=env_assertion_checks,
+        reward_basis=task.evaluation_criteria.reward_basis,
+        reward_breakdown=reward_breakdown,
+        evaluation_mode=evaluation_mode,
+        state_source=state_source,
+        replayed_actions=replayed_actions,
+        warnings=_provenance_warnings(evaluation_mode, strict_replay),
+    )
 
 
 class EnvironmentEvaluator(EvaluatorBase[Message]):
     """
     Evaluator focuses on endstate of the simulation environment.
     """
+
+    @classmethod
+    def evaluate_live(
+        cls,
+        environment: Environment,
+        environment_constructor: Callable[[], Environment],
+        task: Task,
+        solo_mode: bool = False,
+        env_kwargs: dict = None,
+        strict_replay: bool = True,
+    ) -> RewardInfo:
+        """Evaluate the current environment state without replaying a trajectory.
+
+        The reference state is still constructed by replaying the task's
+        reference actions in a fresh environment.  The candidate state remains
+        the caller-provided live environment, so a proxy-intercepted write is
+        not mistaken for a successful live task merely because replay succeeds.
+        """
+        if task.evaluation_criteria is None:
+            return RewardInfo(
+                reward=1.0,
+                evaluation_mode="live",
+                state_source="live",
+                info={"note": "No evaluation criteria"},
+            )
+        expected_actions = task.evaluation_criteria.actions
+        env_assertions = task.evaluation_criteria.env_assertions
+        if expected_actions is None and env_assertions is None:
+            return RewardInfo(
+                reward=1.0,
+                db_check=DBCheck(db_match=True, db_reward=1.0),
+                evaluation_mode="live",
+                state_source="live",
+                info={"note": "No expected actions or env assertions"},
+            )
+
+        initialization_data = None
+        if (
+            task.initial_state is not None
+            and task.initial_state.initialization_data is not None
+        ):
+            initialization_data = task.initial_state.initialization_data
+
+        initialization_actions = None
+        if (
+            task.initial_state is not None
+            and task.initial_state.initialization_actions is not None
+        ):
+            initialization_actions = task.initial_state.initialization_actions
+
+        message_history = []
+        if (
+            task.initial_state is not None
+            and task.initial_state.message_history is not None
+        ):
+            message_history = task.initial_state.message_history
+
+        if env_kwargs is None:
+            env_kwargs = {}
+
+        gold_environment = environment_constructor(**env_kwargs)
+        gold_environment.set_state(
+            initialization_data=initialization_data,
+            initialization_actions=initialization_actions,
+            message_history=message_history,
+            strict=strict_replay,
+        )
+        for action in task.evaluation_criteria.actions or []:
+            try:
+                gold_environment.make_tool_call(
+                    tool_name=action.name,
+                    requestor=action.requestor,
+                    **action.arguments,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Error in golden actions {action.name}({action.arguments}): {e}"
+                )
+
+        replayed_actions = [
+            ReplayedAction(source="reference", tool_call=tool_call)
+            for tool_call in _reference_tool_calls(task)
+        ]
+        return _build_state_reward(
+            environment,
+            gold_environment,
+            task,
+            evaluation_mode="live",
+            state_source="live",
+            replayed_actions=replayed_actions,
+            strict_replay=strict_replay,
+        )
 
     @classmethod
     def calculate_reward(
@@ -114,54 +330,27 @@ class EnvironmentEvaluator(EvaluatorBase[Message]):
                     f"Error in golden actions {action.name}({action.arguments}): {e}"
                 )
 
-        # Comparing the environments
-        agent_db_hash = gold_environment.get_db_hash()
-        user_db_hash = gold_environment.get_user_db_hash()
-        predicted_agent_db_hash = predicted_environment.get_db_hash()
-        predicted_user_db_hash = predicted_environment.get_user_db_hash()
-        agent_db_match = agent_db_hash == predicted_agent_db_hash
-        user_db_match = user_db_hash == predicted_user_db_hash
-        if agent_db_match and user_db_match:
-            db_reward = 1.0
-            db_match = True
-        else:
-            db_reward = 0.0
-            db_match = False
-
-        db_check = DBCheck(db_match=db_match, db_reward=db_reward)
-
-        # Run env assertions
-        env_assertions = task.evaluation_criteria.env_assertions or []
-        env_assertion_checks = []
-        env_assertion_reward = 1.0
-        for env_assertion in env_assertions:
-            success = predicted_environment.run_env_assertion(
-                env_assertion,
-                raise_assertion_error=False,
-            )
-            res = EnvAssertionCheck(
-                env_assertion=env_assertion,
-                met=success,
-                reward=1.0 if success else 0.0,
-            )
-            env_assertion_checks.append(res)
-            env_assertion_reward *= res.reward
-
-        reward = 1.0
-        reward_breakdown = {}
-        if RewardType.DB in task.evaluation_criteria.reward_basis:
-            reward_breakdown[RewardType.DB] = db_reward
-            reward *= db_reward
-        if RewardType.ENV_ASSERTION in task.evaluation_criteria.reward_basis:
-            reward_breakdown[RewardType.ENV_ASSERTION] = env_assertion_reward
-            reward *= env_assertion_reward
-
-        return RewardInfo(
-            reward=reward,
-            db_check=db_check,
-            env_assertions=env_assertion_checks,
-            reward_basis=task.evaluation_criteria.reward_basis,
-            reward_breakdown=reward_breakdown,
+        replayed_actions = [
+            *(
+                ReplayedAction(source="trajectory", tool_call=tool_call)
+                for tool_call in _replayed_trajectory_tool_calls(
+                    predicted_environment,
+                    full_trajectory,
+                )
+            ),
+            *(
+                ReplayedAction(source="reference", tool_call=tool_call)
+                for tool_call in _reference_tool_calls(task)
+            ),
+        ]
+        return _build_state_reward(
+            predicted_environment,
+            gold_environment,
+            task,
+            evaluation_mode="replay",
+            state_source="replayed",
+            replayed_actions=replayed_actions,
+            strict_replay=strict_replay,
         )
 
 
@@ -169,6 +358,26 @@ class FullDuplexEnvironmentEvaluator(EvaluatorBase[Tick]):
     """
     Evaluator focuses on endstate of the simulation environment.
     """
+
+    @classmethod
+    def evaluate_live(
+        cls,
+        environment: Environment,
+        environment_constructor: Callable[[], Environment],
+        task: Task,
+        solo_mode: bool = False,
+        env_kwargs: dict = None,
+        strict_replay: bool = True,
+    ) -> RewardInfo:
+        """Evaluate a current live state for a full-duplex simulation."""
+        return EnvironmentEvaluator.evaluate_live(
+            environment=environment,
+            environment_constructor=environment_constructor,
+            task=task,
+            solo_mode=solo_mode,
+            env_kwargs=env_kwargs,
+            strict_replay=strict_replay,
+        )
 
     @classmethod
     def ticks_to_message_history(cls, ticks: list[Tick]) -> list[Message]:
@@ -321,52 +530,28 @@ class FullDuplexEnvironmentEvaluator(EvaluatorBase[Tick]):
                     f"Error in golden actions {action.name}({action.arguments}): {e}"
                 )
 
-        # Comparing the environments
-        agent_db_hash = gold_environment.get_db_hash()
-        user_db_hash = gold_environment.get_user_db_hash()
-        predicted_agent_db_hash = predicted_environment.get_db_hash()
-        predicted_user_db_hash = predicted_environment.get_user_db_hash()
-        agent_db_match = agent_db_hash == predicted_agent_db_hash
-        user_db_match = user_db_hash == predicted_user_db_hash
-        if agent_db_match and user_db_match:
-            db_reward = 1.0
-            db_match = True
-        else:
-            db_reward = 0.0
-            db_match = False
-
-        db_check = DBCheck(db_match=db_match, db_reward=db_reward)
-
-        # Run env assertions
-        env_assertions = task.evaluation_criteria.env_assertions or []
-        env_assertion_checks = []
-        env_assertion_reward = 1.0
-        for env_assertion in env_assertions:
-            success = predicted_environment.run_env_assertion(
-                env_assertion,
-                raise_assertion_error=False,
-            )
-            res = EnvAssertionCheck(
-                env_assertion=env_assertion,
-                met=success,
-                reward=1.0 if success else 0.0,
-            )
-            env_assertion_checks.append(res)
-            env_assertion_reward *= res.reward
-
-        reward = 1.0
-        reward_breakdown = {}
-        if RewardType.DB in task.evaluation_criteria.reward_basis:
-            reward_breakdown[RewardType.DB] = db_reward
-            reward *= db_reward
-        if RewardType.ENV_ASSERTION in task.evaluation_criteria.reward_basis:
-            reward_breakdown[RewardType.ENV_ASSERTION] = env_assertion_reward
-            reward *= env_assertion_reward
-
-        return RewardInfo(
-            reward=reward,
-            db_check=db_check,
-            env_assertions=env_assertion_checks,
-            reward_basis=task.evaluation_criteria.reward_basis,
-            reward_breakdown=reward_breakdown,
+        replayed_actions = [
+            *(
+                ReplayedAction(
+                    source="trajectory",
+                    tool_call=tool_call,
+                )
+                for tool_call in _replayed_trajectory_tool_calls(
+                    predicted_environment,
+                    predicted_message_history,
+                )
+            ),
+            *(
+                ReplayedAction(source="reference", tool_call=tool_call)
+                for tool_call in _reference_tool_calls(task)
+            ),
+        ]
+        return _build_state_reward(
+            predicted_environment,
+            gold_environment,
+            task,
+            evaluation_mode="replay",
+            state_source="replayed",
+            replayed_actions=replayed_actions,
+            strict_replay=strict_replay,
         )

--- a/tests/test_evaluator_provenance.py
+++ b/tests/test_evaluator_provenance.py
@@ -1,0 +1,128 @@
+"""Regression tests for evaluator state provenance."""
+
+from tau2.data_model.message import AssistantMessage, ToolCall, ToolMessage
+from tau2.data_model.tasks import (
+    Action,
+    EvaluationCriteria,
+    RewardType,
+    Task,
+    UserScenario,
+)
+from tau2.evaluator.evaluator_env import EnvironmentEvaluator
+
+
+class _MockEnvironment:
+    """Small deterministic environment for evaluator-only tests."""
+
+    def __init__(self, **_kwargs):
+        self.state = 0
+
+    def set_state(
+        self,
+        initialization_data,
+        initialization_actions,
+        message_history,
+        strict=True,
+    ):
+        del initialization_data, initialization_actions, strict
+        for message in message_history:
+            if isinstance(message, AssistantMessage):
+                self.state += sum(
+                    tool_call.name == "write"
+                    for tool_call in (message.tool_calls or [])
+                )
+
+    def make_tool_call(self, tool_name, requestor="assistant", **_kwargs):
+        del requestor
+        if tool_name == "write":
+            self.state += 1
+
+    def _has_tool(self, tool_name):
+        return tool_name == "write"
+
+    def _is_mutating_tool(self, tool_name):
+        return tool_name == "write"
+
+    def get_db_hash(self):
+        return str(self.state)
+
+    def get_user_db_hash(self):
+        return "user-state"
+
+    def run_env_assertion(self, _assertion, raise_assertion_error=True):
+        del raise_assertion_error
+        return True
+
+
+def _task() -> Task:
+    return Task(
+        id="mock/provenance",
+        user_scenario=UserScenario(instructions="write one item"),
+        evaluation_criteria=EvaluationCriteria(
+            actions=[
+                Action(
+                    action_id="reference-write",
+                    name="write",
+                    arguments={},
+                )
+            ],
+            reward_basis=[RewardType.DB],
+        ),
+    )
+
+
+def _trajectory():
+    call = ToolCall(id="call-write", name="write", arguments={})
+    return [
+        AssistantMessage(role="assistant", tool_calls=[call]),
+        ToolMessage(
+            id=call.id,
+            role="tool",
+            requestor="assistant",
+            content='{"ok": true}',
+        ),
+    ]
+
+
+def test_replay_result_exposes_state_provenance():
+    result = EnvironmentEvaluator.calculate_reward(
+        environment_constructor=_MockEnvironment,
+        task=_task(),
+        full_trajectory=_trajectory(),
+    )
+
+    assert result.reward == 1.0
+    assert result.evaluation_mode == "replay"
+    assert result.state_source == "replayed"
+    assert [(item.source, item.tool_call.name) for item in result.replayed_actions] == [
+        ("trajectory", "write"),
+        ("reference", "write"),
+    ]
+    assert any("does not certify live environment state" in w for w in result.warnings)
+
+
+def test_live_result_does_not_inherit_replay_success():
+    result = EnvironmentEvaluator.evaluate_live(
+        environment=_MockEnvironment(),
+        environment_constructor=_MockEnvironment,
+        task=_task(),
+    )
+
+    assert result.reward == 0.0
+    assert result.db_check.db_match is False
+    assert result.evaluation_mode == "live"
+    assert result.state_source == "live"
+    assert [(item.source, item.tool_call.name) for item in result.replayed_actions] == [
+        ("reference", "write")
+    ]
+
+
+def test_lenient_replay_emits_warning():
+    result = EnvironmentEvaluator.calculate_reward(
+        environment_constructor=_MockEnvironment,
+        task=_task(),
+        full_trajectory=_trajectory(),
+        strict_replay=False,
+    )
+
+    assert any("strict_replay=False" in warning for warning in result.warnings)


### PR DESCRIPTION
## Summary
Add evaluator provenance to distinguish live evaluation from reference replay.

## Changes Made
- Add evaluation mode, state source, replayed actions, and warnings to reward results.
- Add live evaluation support using the caller-provided environment state.
- Preserve replay evaluation behavior.
- Add focused regression tests.
- Update evaluator documentation.

## Testing
- 68 focused tests passed.
- Ruff lint check passed.
- Ruff format check passed.
- `git diff --check` passed.
- Full `make test` was not run because this checkout is sparse.

## Documentation
- Updated `docs/evaluation.md`.

## Checklist
- [x] Relevant tests pass
- [x] Code follows style guidelines
- [x] Documentation updated
- [x] No new dependencies
- [x] Breaking changes considered; none intended