### PR TITLE
Add DeepSeek V4 Flash custom retail submission

### DIFF
--- a/web/leaderboard/public/submissions/deepseek-v4-flash_deepseek_2026-08-12/submission.json
+++ b/web/leaderboard/public/submissions/deepseek-v4-flash_deepseek_2026-08-12/submission.json
@@ -1,0 +1,51 @@
+{
+  "model_name": "deepseek-v4-flash",
+  "model_organization": "DeepSeek",
+  "submitting_organization": "Nablo",
+  "submission_date": "2026-08-12",
+  "submission_type": "custom",
+  "modality": "text",
+  "contact_info": {
+    "email": "isaac@nablo.io",
+    "name": "Isaac Kargar",
+    "github": "kargarisaac"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 89.47368421052632,
+      "pass_2": 83.33333333333334,
+      "pass_3": 78.50877192982456,
+      "pass_4": 74.56140350877193,
+      "cost": 0.001755700849122807
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "retail": "deepseek-v4-flash_nablo-react_retail_base114x4.json"
+  },
+  "references": [
+    {
+      "title": "Post-training a 4B retail agent with hard-token trajectory SFT",
+      "url": "https://nablo.io/blog/08_qwen4b_tau2_retail_sft/",
+      "type": "blog_post"
+    },
+    {
+      "title": "Tau2 retail Nablo ReAct trajectories",
+      "url": "https://huggingface.co/datasets/kargarisaac/tau2-retail-nablo-react-trajectories",
+      "type": "huggingface"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-08-09",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "deepseek-v4-flash",
+    "notes": "Single PydanticAI agent in a ReAct loop with the standard Tau retail tools and a modified general policy-grounded instruction suffix. DeepSeek V4 Flash served as agent, user simulator, and natural-language assertion judge. All 114 base tasks ran for four trials with no omissions. Cost is the measured average agent API cost per trajectory; simulator and judge cost are excluded from the leaderboard cost field.",
+    "verification": {
+      "modified_prompts": true,
+      "omitted_questions": false,
+      "details": "The agent system prompt adds a general deliberation suffix; the user simulator follows Tau's task instructions through a custom first-party DeepSeek route."
+    }
+  },
+  "reasoning_effort": "enabled"
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -2,6 +2,7 @@
   "submissions": [
     "claude-opus-4-5_sierra_2026-02-26",
     "claude-sonnet-4-5_sierra_2026-02-26",
+    "deepseek-v4-flash_deepseek_2026-08-12",
     "gpt-5-2_sierra_2026-02-26",
     "gpt-5-2-none_sierra_2026-02-26",
     "glm-5-think_sierra_2026-03-02",


### PR DESCRIPTION
## Summary

- Adds a Custom text submission for DeepSeek V4 Flash on Tau2 retail.
- Covers all 114 canonical retail base tasks with four trials each.
- Uses one PydanticAI ReAct agent with the standard Tau retail tools and a disclosed general instruction suffix.
- Uses DeepSeek V4 Flash as the user simulator and natural-language assertion judge.

## Results

| Domain | Pass^1 | Pass^2 | Pass^3 | Pass^4 |
| --- | ---: | ---: | ---: | ---: |
| Retail | 89.47% | 83.33% | 78.51% | 74.56% |

The canonical export contains 456 completed trajectories and no omitted task or infrastructure error.

## Verification artifacts

- Trajectories and checksums: https://huggingface.co/datasets/kargarisaac/tau2-retail-nablo-react-trajectories/tree/teacher-v1.0.0
- Method and experiment report: https://nablo.io/blog/08_qwen4b_tau2_retail_sft/
- Trajectory JSON SHA-256: `15fcc705c3856951175b09a783c476eb8a2146e41b64dae6178f2e1181090798`

## Checks

- `tau2 submit validate` passed on the local package with all trajectory files.
- `submission.json` passes `web/leaderboard/public/submissions/schema.json`.
- The submission directory appears exactly once in the text manifest.
- `git diff --check` passed.
