### PR TITLE
fix: retry empty text-mode user-simulator completions instead of crashing the episode

### DIFF
--- a/src/tau2/user/user_simulator.py
+++ b/src/tau2/user/user_simulator.py
@@ -65,6 +65,33 @@ def get_global_user_sim_guidelines(use_tools: bool = False) -> str:
     return user_sim_guidelines
 
 
+EMPTY_COMPLETION_REMINDER = (
+    "Important: your previous reply was empty. Every reply must contain either a "
+    "message for the agent or a tool call. If you have nothing further to say, "
+    f"either continue the conversation naturally or end it with '{STOP}' per the "
+    "guidelines above."
+)
+
+
+def _is_empty_completion(message: AssistantMessage) -> bool:
+    """No text content and no tool calls: cannot become a valid user message."""
+    return not (message.has_content() or message.is_tool_call())
+
+
+def _with_empty_completion_reminder(
+    system_messages: list[SystemMessage],
+) -> list[SystemMessage]:
+    """The system messages with the non-empty reminder appended to the last one."""
+    if not system_messages:
+        return [SystemMessage(role="system", content=EMPTY_COMPLETION_REMINDER)]
+    reminded = list(system_messages)
+    last = reminded[-1]
+    reminded[-1] = SystemMessage(
+        role="system", content=f"{last.content or ''}\n\n{EMPTY_COMPLETION_REMINDER}"
+    )
+    return reminded
+
+
 def get_global_user_sim_guidelines_voice(use_tools: bool = False) -> str:
     """
     Get the global user simulator guidelines for voice mode.
@@ -239,6 +266,31 @@ class UserSimulator(
             call_name="user_simulator_response",
             **self.llm_args,
         )
+
+        if _is_empty_completion(assistant_message):
+            # An empty completion (no content, no tool calls) cannot become a valid
+            # user message: the orchestrator's validation would fail the episode as
+            # an infrastructure error. This occurs e.g. right after the user's own
+            # tool call returns, when the scenario leaves the simulator nothing
+            # further to say (#470). Retry once with an explicit reminder — the
+            # text-mode sibling of the voice simulator's empty-turn handling (#440).
+            logger.warning(
+                "User simulator returned an empty completion (no content, no tool "
+                "calls); retrying once with an explicit reminder."
+            )
+            assistant_message = generate(
+                model=self.llm,
+                messages=_with_empty_completion_reminder(state.system_messages)
+                + state.flip_roles(),
+                tools=self.tools,
+                call_name="user_simulator_response",
+                **self.llm_args,
+            )
+            if _is_empty_completion(assistant_message):
+                raise ValueError(
+                    "User simulator returned an empty completion twice in a row; "
+                    "cannot produce a valid user message."
+                )
 
         user_response = assistant_message.content
         logger.debug(f"Response: {user_response}")

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -64,3 +64,50 @@ def test_dummy_user_no_args():
     dummy = DummyUser()
     state = dummy.get_init_state()
     assert state.messages == []
+
+
+@pytest.mark.parametrize("empty_content", [None, "", "   \n"])
+def test_empty_completion_is_retried_with_a_reminder(
+    monkeypatch,
+    user_simulator: UserSimulator,
+    first_agent_message: AssistantMessage,
+    empty_content,
+):
+    """An empty completion (no content, no tool calls) is retried once with an
+    explicit reminder in the system prompt, instead of crashing the episode (#470)."""
+    prompts = []
+    responses = [
+        AssistantMessage(role="assistant", content=empty_content),
+        AssistantMessage(role="assistant", content="Where is my deposit?"),
+    ]
+
+    def fake_generate(model, messages, tools=None, call_name=None, **kwargs):
+        prompts.append(messages)
+        return responses[len(prompts) - 1]
+
+    monkeypatch.setattr("tau2.user.user_simulator.generate", fake_generate)
+    state = user_simulator.get_init_state()
+    user_msg, state = user_simulator.generate_next_message(first_agent_message, state)
+
+    assert user_msg.content == "Where is my deposit?"
+    assert len(prompts) == 2
+    # The retry carries the reminder in the system prompt; the first call does not.
+    assert "your previous reply was empty" in prompts[1][0].content
+    assert "your previous reply was empty" not in prompts[0][0].content
+
+
+def test_empty_completion_twice_raises_a_clear_error(
+    monkeypatch,
+    user_simulator: UserSimulator,
+    first_agent_message: AssistantMessage,
+):
+    """Two empty completions in a row raise a descriptive error rather than letting
+    message validation fail deeper in the orchestrator."""
+
+    def fake_generate(model, messages, tools=None, call_name=None, **kwargs):
+        return AssistantMessage(role="assistant", content=None)
+
+    monkeypatch.setattr("tau2.user.user_simulator.generate", fake_generate)
+    state = user_simulator.get_init_state()
+    with pytest.raises(ValueError, match="empty completion twice"):
+        user_simulator.generate_next_message(first_agent_message, state)


### PR DESCRIPTION
## Summary

In text mode, a user-simulator completion with no content and no tool calls kills the episode: `UserMessage.validate()` raises and the run is booked as `infrastructure_error` after all retries. This reproduces deterministically (16/16 across two agent implementations, including the stock `llm_agent`) on scenarios that instruct the user to speak and fire a tracking-only user tool in one turn — `banking_knowledge/task_034` — because the tool call routes to ENV before the agent sees the verbal half, and after the silent tool result the simulator has nothing left to say at the default `temperature: 0.0`. Full mechanism and repro command in #470.

## Changes

- `src/tau2/user/user_simulator.py`: after the user-simulator `generate` call, if the completion has no content and no tool calls, retry once with an explicit reminder appended to the system prompt (the reminder also points at the `###STOP###` convention, so a user with genuinely nothing to add has a valid way out). If the completion is empty twice in a row, raise a descriptive `ValueError` at the source instead of letting validation fail deeper in the orchestrator. The reminder never enters the recorded conversation — it only shapes the retried completion.
- `tests/test_user.py`: two new tests (one parametrized over `None`/empty/whitespace content) mocking `generate` — the retry path returns the recovered message and carries the reminder only in the retry prompt; the double-empty path raises the descriptive error.

This is the text-mode sibling of #440 (voice simulator: drop empty/whitespace turns when flipping roles).

## Testing

- `uv run pytest tests/test_user.py` — the 4 new tests pass (mocked, no LLM calls); the pre-existing live-LLM test `test_user_simulator` fails in my environment with a provider billing error both with and without this change (verified via stash), as do the other live-LLM tests in `make test` — no non-environmental failures.
- `make lint` and `make format` clean.
- Field verification of the failure mode this fixes: `tau2 run --domain banking_knowledge --task-ids task_034 --retrieval-config bm25 --agent llm_agent --agent-llm anthropic/claude-sonnet-4-6 --user user_simulator --user-llm anthropic/claude-sonnet-4-5 --num-trials 1` crashes 4/4 attempts on unpatched v1.0.1/main.

## Checklist

- [x] Tests pass locally (new tests; pre-existing live-LLM failures are environmental and unaffected by this change)
- [x] `make lint` / `make format` clean
- [x] New functionality has accompanying tests
- [x] Issue-first: #470

Fixes #470