### PR TITLE
feat: add reusable Modal voice experiment runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ OPENAI_API_KEY=<your_key_here>
 ELEVENLABS_API_KEY=<your_key_here>
 DEEPGRAM_API_KEY=<your_key_here>
 
+# Required only for Pine's OpenAI-compatible realtime models (pine-*).
+PINE_API_KEY=<your_key_here>
+PINE_REALTIME_BASE_URL=<your_realtime_websocket_url_here>
+
 # Required for banking_knowledge qwen_embeddings* retrieval configs (via OpenRouter)
 OPENROUTER_API_KEY=<your_key_here>
 

--- a/src/experiments/modal/README.md
+++ b/src/experiments/modal/README.md
@@ -4,14 +4,14 @@
 runner is provider-agnostic: providers, models, domains, speech complexities,
 user simulators, and user-simulator arguments are all command-line inputs.
 
-Create a private Modal environment, a Secret containing the API keys required
+Create a private Modal environment, Secrets containing the API keys required
 by the selected providers, and (optionally) a Volume. Configure their names
 before invoking the launcher:
 
 ```bash
 export TAU2_MODAL_APP_NAME=tau2-experiments
 export TAU2_MODAL_VOLUME_NAME=tau2-experiment-results
-export TAU2_MODAL_SECRET_NAMES=tau2-experiment-keys
+export TAU2_MODAL_SECRET_NAMES=tau2-experiment-keys,tau2-experiment-review-key
 
 modal run --detach --env tau-bench \
   src/experiments/modal/run_tau_voice.py::run \
@@ -22,8 +22,8 @@ modal run --detach --env tau-bench \
 ```
 
 The launcher has no web endpoint. Results stay in the configured private Modal
-Volume. API credentials are supplied through Modal Secrets and are excluded
-from the uploaded repository image.
+Volume. API credentials are supplied through two Modal Secrets (evaluation and
+review) and are excluded from the uploaded repository image.
 
 To intentionally continue an existing checkpoint, pass `--resume`. Without
 that flag, the launcher refuses to reuse a non-empty result directory.

--- a/src/experiments/modal/README.md
+++ b/src/experiments/modal/README.md
@@ -1,0 +1,39 @@
+# Modal experiment runner
+
+`run_tau_voice.py` runs the existing tau-voice experiment grid on Modal. The
+runner is provider-agnostic: providers, models, domains, speech complexities,
+user simulators, and user-simulator arguments are all command-line inputs.
+
+Create a private Modal environment, a Secret containing the API keys required
+by the selected providers, and (optionally) a Volume. Configure their names
+before invoking the launcher:
+
+```bash
+export TAU2_MODAL_APP_NAME=tau2-experiments
+export TAU2_MODAL_VOLUME_NAME=tau2-experiment-results
+export TAU2_MODAL_SECRET_NAMES=tau2-experiment-keys
+
+modal run --detach --env tau-bench \
+  src/experiments/modal/run_tau_voice.py::run \
+  --providers openai:gpt-realtime \
+  --domains retail,airline,telecom \
+  --complexities regular \
+  --result-root /results/my-run
+```
+
+The launcher has no web endpoint. Results stay in the configured private Modal
+Volume. API credentials are supplied through Modal Secrets and are excluded
+from the uploaded repository image.
+
+To intentionally continue an existing checkpoint, pass `--resume`. Without
+that flag, the launcher refuses to reuse a non-empty result directory.
+
+Pine models use the normal OpenAI provider syntax:
+
+```bash
+--providers openai:pine-voice-preview
+```
+
+Set `PINE_API_KEY` and `PINE_REALTIME_BASE_URL` in the Modal Secret. The OpenAI
+realtime provider selects them automatically for model names beginning with
+`pine-`.

--- a/src/experiments/modal/__init__.py
+++ b/src/experiments/modal/__init__.py
@@ -1,0 +1,1 @@
+"""Modal launchers for tau2 experiments."""

--- a/src/experiments/modal/run_tau_voice.py
+++ b/src/experiments/modal/run_tau_voice.py
@@ -1,0 +1,271 @@
+"""Run configurable tau-voice experiment grids on Modal.
+
+The launcher is intentionally provider-agnostic. It delegates experiment
+configuration to :mod:`experiments.tau_voice.run_multiple` and uses a Modal
+Volume only for durable results.
+
+Resource names are configured when the module is loaded:
+
+* ``TAU2_MODAL_APP_NAME`` (default: ``tau2-experiments``)
+* ``TAU2_MODAL_VOLUME_NAME`` (default: ``tau2-experiment-results``)
+* ``TAU2_MODAL_SECRET_NAMES`` (default: ``tau2-experiment-keys``)
+
+Example::
+
+    modal run --detach --env tau-bench \
+      src/experiments/modal/run_tau_voice.py::run \
+      --providers openai:gpt-realtime \
+      --domains retail,airline \
+      --complexities regular \
+      --result-root /results/my-experiment
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import modal
+
+APP_NAME = os.environ.get("TAU2_MODAL_APP_NAME", "tau2-experiments")
+VOLUME_NAME = os.environ.get("TAU2_MODAL_VOLUME_NAME", "tau2-experiment-results")
+SECRET_NAMES = tuple(
+    name.strip()
+    for name in os.environ.get("TAU2_MODAL_SECRET_NAMES", "tau2-experiment-keys").split(
+        ","
+    )
+    if name.strip()
+)
+
+REMOTE_REPO = Path("/root/tau2")
+RESULTS_ROOT = Path("/results")
+
+
+def _find_repo_root() -> Path:
+    """Find the local checkout while remaining importable in Modal containers."""
+    source = Path(__file__).resolve()
+    for parent in source.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return REMOTE_REPO
+
+
+REPO_ROOT = _find_repo_root()
+
+app = modal.App(APP_NAME)
+results_volume = modal.Volume.from_name(VOLUME_NAME, create_if_missing=True)
+secrets = [modal.Secret.from_name(name) for name in SECRET_NAMES]
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .apt_install(
+        "build-essential",
+        "ffmpeg",
+        "git",
+        "libsndfile1",
+        "portaudio19-dev",
+    )
+    .pip_install_from_pyproject(
+        str(REPO_ROOT / "pyproject.toml"),
+        optional_dependencies=["voice"],
+    )
+    .env(
+        {
+            "PYTHONPATH": str(REMOTE_REPO / "src"),
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    .add_local_dir(
+        str(REPO_ROOT),
+        remote_path=str(REMOTE_REPO),
+        ignore=[
+            ".env",
+            ".git/**",
+            ".venv/**",
+            ".pytest_cache/**",
+            ".ruff_cache/**",
+            "**/__pycache__/**",
+            "data/simulations/**",
+            "web/leaderboard/node_modules/**",
+        ],
+    )
+)
+
+
+def _csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _result_root(value: str) -> Path:
+    path = Path(value)
+    if not path.is_absolute() or RESULTS_ROOT not in path.parents:
+        raise ValueError(f"result_root must be a child of {RESULTS_ROOT}")
+    return path
+
+
+def _command(
+    *,
+    result_root: Path,
+    providers: str,
+    domains: str,
+    complexities: str,
+    user_llm: str,
+    user_llm_args: str | None,
+    max_concurrency: int,
+    num_tasks: int | None,
+) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "experiments.tau_voice.run_multiple",
+        "--providers",
+        providers,
+        "--domains",
+        domains,
+        "--complexities",
+        complexities,
+        "--user-llm",
+        user_llm,
+        "--max-concurrency",
+        str(max_concurrency),
+        "--save-to",
+        str(result_root),
+    ]
+    if user_llm_args:
+        parsed = json.loads(user_llm_args)
+        if not isinstance(parsed, dict):
+            raise ValueError("user_llm_args must decode to a JSON object")
+        command.extend(["--user-llm-args", json.dumps(parsed)])
+    if num_tasks is not None:
+        command.extend(["--num-tasks", str(num_tasks)])
+    return command
+
+
+def _validate_environment(required_env: str) -> None:
+    missing = [name for name in _csv(required_env) if not os.environ.get(name)]
+    if missing:
+        raise RuntimeError(
+            "Missing required keys in the configured Modal Secrets: "
+            + ", ".join(missing)
+        )
+
+
+@app.function(
+    image=image,
+    secrets=secrets,
+    volumes={str(RESULTS_ROOT): results_volume},
+    cpu=8,
+    memory=32768,
+    timeout=24 * 60 * 60,
+)
+def run_experiment(
+    result_root: str,
+    providers: str,
+    domains: str,
+    complexities: str,
+    user_llm: str,
+    user_llm_args: str | None,
+    max_concurrency: int,
+    num_tasks: int | None,
+    required_env: str,
+    resume: bool,
+) -> None:
+    """Run or resume a tau-voice experiment grid."""
+    _validate_environment(required_env)
+    save_to = _result_root(result_root)
+    if save_to.exists() and any(save_to.iterdir()) and not resume:
+        raise RuntimeError(
+            f"Refusing to reuse existing result directory {save_to}; pass --resume "
+            "only when intentionally continuing that experiment."
+        )
+
+    save_to.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        _command(
+            result_root=save_to,
+            providers=providers,
+            domains=domains,
+            complexities=complexities,
+            user_llm=user_llm,
+            user_llm_args=user_llm_args,
+            max_concurrency=max_concurrency,
+            num_tasks=num_tasks,
+        ),
+        cwd=REMOTE_REPO,
+        check=True,
+        env=os.environ.copy(),
+    )
+    results_volume.commit()
+    print(f"Experiment complete; committed {save_to} to {VOLUME_NAME}", flush=True)
+
+
+@app.function(
+    image=modal.Image.debian_slim(python_version="3.12"),
+    volumes={str(RESULTS_ROOT): results_volume},
+    timeout=10 * 60,
+)
+def show_status(result_root: str) -> None:
+    """Print a provider-agnostic summary of result checkpoints."""
+    results_volume.reload()
+    root = _result_root(result_root)
+    result_files = sorted(root.glob("*/results.json"))
+    if not result_files:
+        print(f"No result checkpoints found under {root}")
+        return
+
+    for path in result_files:
+        data = json.loads(path.read_text())
+        simulations = data.get("simulation_index", [])
+        infrastructure = [
+            item
+            for item in simulations
+            if item.get("termination_reason") == "infrastructure_error"
+        ]
+        valid = len(simulations) - len(infrastructure)
+        passes = sum(
+            item.get("reward") == 1
+            and item.get("termination_reason") != "infrastructure_error"
+            for item in simulations
+        )
+        rate = 100 * passes / valid if valid else 0.0
+        print(
+            f"{path.parent.name}: valid={valid} passes={passes} "
+            f"rate={rate:.2f}% infrastructure={len(infrastructure)}"
+        )
+
+
+@app.local_entrypoint()
+def run(
+    result_root: str,
+    providers: str,
+    domains: str = "airline,retail",
+    complexities: str = "control,regular",
+    user_llm: str = "gpt-4.1-2025-04-14",
+    user_llm_args: str | None = None,
+    max_concurrency: int = 8,
+    num_tasks: int | None = None,
+    required_env: str = "",
+    resume: bool = False,
+) -> None:
+    """Launch a configurable experiment in the private Modal environment."""
+    run_experiment.remote(
+        result_root=result_root,
+        providers=providers,
+        domains=domains,
+        complexities=complexities,
+        user_llm=user_llm,
+        user_llm_args=user_llm_args,
+        max_concurrency=max_concurrency,
+        num_tasks=num_tasks,
+        required_env=required_env,
+        resume=resume,
+    )
+
+
+@app.local_entrypoint()
+def status(result_root: str) -> None:
+    """Show result checkpoint progress without reading any secrets."""
+    show_status.remote(result_root)

--- a/src/experiments/modal/run_tau_voice.py
+++ b/src/experiments/modal/run_tau_voice.py
@@ -8,7 +8,7 @@ Resource names are configured when the module is loaded:
 
 * ``TAU2_MODAL_APP_NAME`` (default: ``tau2-experiments``)
 * ``TAU2_MODAL_VOLUME_NAME`` (default: ``tau2-experiment-results``)
-* ``TAU2_MODAL_SECRET_NAMES`` (default: ``tau2-experiment-keys``)
+* ``TAU2_MODAL_SECRET_NAMES`` (defaults to evaluation and review secrets)
 
 Example::
 
@@ -34,11 +34,18 @@ APP_NAME = os.environ.get("TAU2_MODAL_APP_NAME", "tau2-experiments")
 VOLUME_NAME = os.environ.get("TAU2_MODAL_VOLUME_NAME", "tau2-experiment-results")
 SECRET_NAMES = tuple(
     name.strip()
-    for name in os.environ.get("TAU2_MODAL_SECRET_NAMES", "tau2-experiment-keys").split(
-        ","
-    )
+    for name in os.environ.get(
+        "TAU2_MODAL_SECRET_NAMES",
+        "tau2-experiment-keys,tau2-experiment-review-key",
+    ).split(",")
     if name.strip()
 )
+
+if len(SECRET_NAMES) != 2:
+    raise ValueError(
+        "TAU2_MODAL_SECRET_NAMES must contain exactly two Secret names: "
+        "evaluation and review"
+    )
 
 REMOTE_REPO = Path("/root/tau2")
 RESULTS_ROOT = Path("/results")

--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -23,6 +23,7 @@ run concurrently across N worker processes (see docs/designs/parallel-runner.md)
 """
 
 import argparse
+import json
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -96,13 +97,14 @@ def build_command(
     num_tasks: int | None = None,
     seed: int = DEFAULT_SEED,
     user_llm: str = DEFAULT_LLM_USER,
+    user_llm_args: dict | None = None,
     max_concurrency: int = 8,
     max_steps_seconds: int | None = None,
 ) -> list[str]:
     cmd = [
-        "uv",
-        "run",
-        "tau2",
+        sys.executable,
+        "-m",
+        "tau2.cli",
         "run",
         "--domain",
         domain,
@@ -125,6 +127,8 @@ def build_command(
         "--save-to",
         save_to,
     ]
+    if user_llm_args is not None:
+        cmd.extend(["--user-llm-args", json.dumps(user_llm_args)])
     if spec.reasoning_effort is not None:
         cmd.extend(["--reasoning-effort", spec.reasoning_effort])
     if spec.cascaded_config is not None:
@@ -145,6 +149,7 @@ def build_config(
     num_tasks: int | None = None,
     seed: int = DEFAULT_SEED,
     user_llm: str = DEFAULT_LLM_USER,
+    user_llm_args: dict | None = None,
     max_concurrency: int = 8,
     max_steps_seconds: int | None = None,
 ):
@@ -161,7 +166,7 @@ def build_config(
     if max_steps_seconds is not None:
         audio_kwargs["max_steps_seconds"] = max_steps_seconds
 
-    return VoiceRunConfig(
+    config_kwargs = dict(
         domain=domain,
         num_tasks=num_tasks,
         llm_user=user_llm,
@@ -174,6 +179,9 @@ def build_config(
         audio_native_config=AudioNativeConfig(**audio_kwargs),
         speech_complexity=complexity,
     )
+    if user_llm_args is not None:
+        config_kwargs["llm_args_user"] = user_llm_args
+    return VoiceRunConfig(**config_kwargs)
 
 
 def main():
@@ -207,6 +215,12 @@ def main():
     )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--user-llm", type=str, default=DEFAULT_LLM_USER)
+    parser.add_argument(
+        "--user-llm-args",
+        type=json.loads,
+        default=None,
+        help="JSON object passed to the user simulator model.",
+    )
     parser.add_argument("--max-concurrency", type=int, default=8)
     parser.add_argument(
         "--save-to",
@@ -248,6 +262,7 @@ def main():
         num_tasks=args.num_tasks,
         seed=args.seed,
         user_llm=args.user_llm,
+        user_llm_args=args.user_llm_args,
         max_concurrency=args.max_concurrency,
         max_steps_seconds=args.max_steps_seconds,
     )

--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -6,12 +6,18 @@ Provider syntax: "provider", "provider:model", or "provider:model:reasoning"
   - openai                           (default model, no reasoning)
   - openai:gpt-realtime-1.5          (specific model)
   - openai:gpt-realtime-1.5:high     (model + reasoning effort)
+  - openai:pine-voice-preview        (Pine's OpenAI-compatible model)
   - livekit                           (default cascaded config)
   - livekit::openai-thinking          (default model + cascaded config)
+
+Pine models use the normal OpenAI provider syntax. Set ``PINE_API_KEY`` and
+``PINE_REALTIME_BASE_URL``; the OpenAI realtime provider selects them
+automatically for model names beginning with ``pine-``.
 
 Usage:
     python -m experiments.tau_voice.run_multiple --providers openai,gemini --save-to data/exp/my_run
     python -m experiments.tau_voice.run_multiple --providers openai:gpt-realtime-1.5:high --save-to data/exp/run --num-tasks 5
+    python -m experiments.tau_voice.run_multiple --providers openai:pine-voice-preview --save-to data/exp/pine
     python -m experiments.tau_voice.run_multiple --providers livekit,livekit::openai-thinking --save-to data/exp/run
 
 By default the grid runs sequentially, one `tau2 run` subprocess per combo.

--- a/src/tau2/voice/audio_native/openai/provider.py
+++ b/src/tau2/voice/audio_native/openai/provider.py
@@ -38,9 +38,6 @@ load_dotenv()
 PINE_MODEL_PREFIX = "pine-"
 PINE_API_KEY_ENV = "PINE_API_KEY"
 PINE_REALTIME_BASE_URL_ENV = "PINE_REALTIME_BASE_URL"
-# Compatibility with the names used by early internal Pine evaluation jobs.
-LEGACY_PINE_API_KEY_ENV = "TAU2_OPENAI_REALTIME_API_KEY"
-LEGACY_PINE_REALTIME_BASE_URL_ENV = "TAU2_OPENAI_REALTIME_BASE_URL"
 
 
 class OpenAIVADMode(str, Enum):
@@ -140,14 +137,8 @@ class OpenAIRealtimeProvider:
         """
         self.model = model or self.DEFAULT_MODEL
         if self.model.startswith(PINE_MODEL_PREFIX):
-            self.base_url = os.environ.get(
-                PINE_REALTIME_BASE_URL_ENV
-            ) or os.environ.get(LEGACY_PINE_REALTIME_BASE_URL_ENV)
-            self.api_key = (
-                api_key
-                or os.environ.get(PINE_API_KEY_ENV)
-                or os.environ.get(LEGACY_PINE_API_KEY_ENV)
-            )
+            self.base_url = os.environ.get(PINE_REALTIME_BASE_URL_ENV)
+            self.api_key = api_key or os.environ.get(PINE_API_KEY_ENV)
             if not self.base_url:
                 raise ValueError(
                     "Pine Realtime base URL not provided. Set "

--- a/src/tau2/voice/audio_native/openai/provider.py
+++ b/src/tau2/voice/audio_native/openai/provider.py
@@ -35,6 +35,13 @@ from tau2.voice.utils.openai_utils import audio_format_to_openai
 
 load_dotenv()
 
+PINE_MODEL_PREFIX = "pine-"
+PINE_API_KEY_ENV = "PINE_API_KEY"
+PINE_REALTIME_BASE_URL_ENV = "PINE_REALTIME_BASE_URL"
+# Compatibility with the names used by early internal Pine evaluation jobs.
+LEGACY_PINE_API_KEY_ENV = "TAU2_OPENAI_REALTIME_API_KEY"
+LEGACY_PINE_REALTIME_BASE_URL_ENV = "TAU2_OPENAI_REALTIME_BASE_URL"
+
 
 class OpenAIVADMode(str, Enum):
     """Voice Activity Detection modes supported by OpenAI's Realtime API.
@@ -88,7 +95,7 @@ class OpenAIRealtimeProvider:
     and both audio and text modalities.
 
     Attributes:
-        BASE_URL: The WebSocket endpoint for OpenAI's Realtime API.
+        base_url: The WebSocket endpoint selected for the requested model.
         DEFAULT_MODEL: The default model to use for realtime sessions.
         api_key: The OpenAI API key for authentication.
         model: The model identifier to use for the session.
@@ -122,8 +129,8 @@ class OpenAIRealtimeProvider:
         """Initialize the OpenAI Realtime provider.
 
         Args:
-            api_key: OpenAI API key. If not provided, reads from OPENAI_API_KEY
-                environment variable.
+            api_key: Explicit API key. If not provided, Pine models read from
+                PINE_API_KEY and OpenAI models read from OPENAI_API_KEY.
             model: Model identifier to use. Defaults to DEFAULT_MODEL.
             reasoning_effort: Reasoning effort for thinking models ("minimal",
                 "low", "medium", "high"). If None, not sent to the API.
@@ -131,11 +138,31 @@ class OpenAIRealtimeProvider:
         Raises:
             ValueError: If no API key is provided or found in environment.
         """
-        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
-        if not self.api_key:
-            raise ValueError("OpenAI API key not provided. Set OPENAI_API_KEY env var.")
-
         self.model = model or self.DEFAULT_MODEL
+        if self.model.startswith(PINE_MODEL_PREFIX):
+            self.base_url = os.environ.get(
+                PINE_REALTIME_BASE_URL_ENV
+            ) or os.environ.get(LEGACY_PINE_REALTIME_BASE_URL_ENV)
+            self.api_key = (
+                api_key
+                or os.environ.get(PINE_API_KEY_ENV)
+                or os.environ.get(LEGACY_PINE_API_KEY_ENV)
+            )
+            if not self.base_url:
+                raise ValueError(
+                    "Pine Realtime base URL not provided. Set "
+                    f"{PINE_REALTIME_BASE_URL_ENV}."
+                )
+            if not self.api_key:
+                raise ValueError(f"Pine API key not provided. Set {PINE_API_KEY_ENV}.")
+        else:
+            self.base_url = self.BASE_URL
+            self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+            if not self.api_key:
+                raise ValueError(
+                    "OpenAI API key not provided. Set OPENAI_API_KEY env var."
+                )
+
         self.reasoning_effort = reasoning_effort
         self.ws: Optional[websockets.WebSocketClientProtocol] = None
         self._current_vad_config: Optional[OpenAIVADConfig] = None
@@ -177,7 +204,7 @@ class OpenAIRealtimeProvider:
         if self.is_connected:
             return
 
-        url = f"{self.BASE_URL}?model={self.model}"
+        url = f"{self.base_url}?model={self.model}"
         headers = {"Authorization": f"Bearer {self.api_key}"}
 
         self.ws = await websockets.connect(url, additional_headers=headers)

--- a/tests/test_experiments/test_tau_voice_run_multiple.py
+++ b/tests/test_experiments/test_tau_voice_run_multiple.py
@@ -1,0 +1,35 @@
+import json
+import sys
+
+from experiments.tau_voice.run_multiple import (
+    ProviderSpec,
+    build_command,
+    build_config,
+)
+
+
+def test_build_command_uses_current_python_and_user_llm_args():
+    command = build_command(
+        "retail",
+        ProviderSpec(provider="openai", model="pine-voice-preview"),
+        "regular",
+        "/tmp/results",
+        user_llm="gpt-5.5-2026-04-23",
+        user_llm_args={"reasoning_effort": "xhigh"},
+    )
+
+    assert command[:3] == [sys.executable, "-m", "tau2.cli"]
+    args_index = command.index("--user-llm-args")
+    assert json.loads(command[args_index + 1]) == {"reasoning_effort": "xhigh"}
+
+
+def test_build_config_sets_user_llm_args():
+    config = build_config(
+        "retail",
+        ProviderSpec(provider="openai", model="pine-voice-preview"),
+        "regular",
+        "/tmp/results",
+        user_llm_args={"reasoning_effort": "xhigh"},
+    )
+
+    assert config.llm_args_user == {"reasoning_effort": "xhigh"}

--- a/tests/test_voice/test_audio_native/test_openai_provider_config.py
+++ b/tests/test_voice/test_audio_native/test_openai_provider_config.py
@@ -1,0 +1,33 @@
+import pytest
+
+from tau2.config import DEFAULT_OPENAI_REALTIME_BASE_URL
+from tau2.voice.audio_native.openai.provider import OpenAIRealtimeProvider
+
+
+def test_openai_model_uses_openai_environment(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+
+    provider = OpenAIRealtimeProvider(model="gpt-realtime")
+
+    assert provider.api_key == "openai-key"
+    assert provider.base_url == DEFAULT_OPENAI_REALTIME_BASE_URL
+
+
+def test_pine_model_uses_pine_environment(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("PINE_API_KEY", "pine-key")
+    monkeypatch.setenv("PINE_REALTIME_BASE_URL", "wss://pine.example/realtime")
+
+    provider = OpenAIRealtimeProvider(model="pine-voice-preview")
+
+    assert provider.api_key == "pine-key"
+    assert provider.base_url == "wss://pine.example/realtime"
+
+
+def test_pine_model_requires_pine_base_url(monkeypatch):
+    monkeypatch.setenv("PINE_API_KEY", "pine-key")
+    monkeypatch.delenv("PINE_REALTIME_BASE_URL", raising=False)
+    monkeypatch.delenv("TAU2_OPENAI_REALTIME_BASE_URL", raising=False)
+
+    with pytest.raises(ValueError, match="PINE_REALTIME_BASE_URL"):
+        OpenAIRealtimeProvider(model="pine-voice-preview")

--- a/tests/test_voice/test_audio_native/test_openai_provider_config.py
+++ b/tests/test_voice/test_audio_native/test_openai_provider_config.py
@@ -27,7 +27,6 @@ def test_pine_model_uses_pine_environment(monkeypatch):
 def test_pine_model_requires_pine_base_url(monkeypatch):
     monkeypatch.setenv("PINE_API_KEY", "pine-key")
     monkeypatch.delenv("PINE_REALTIME_BASE_URL", raising=False)
-    monkeypatch.delenv("TAU2_OPENAI_REALTIME_BASE_URL", raising=False)
 
     with pytest.raises(ValueError, match="PINE_REALTIME_BASE_URL"):
         OpenAIRealtimeProvider(model="pine-voice-preview")


### PR DESCRIPTION
## Summary
- add a provider-agnostic Modal launcher under src/experiments/modal
- pass user simulator arguments through tau-voice run_multiple in both subprocess and worker modes
- route pine-prefixed models through Pine credentials and realtime endpoint inside the OpenAI provider
- document private Modal resource configuration and intentional checkpoint resume

## Testing
- 5 focused pytest tests passed
- full repository Ruff lint and format checks passed
- Modal CLI loaded successfully in tau-bench
- generic status function read the existing private result volume successfully