### PR TITLE
Leaderboard submission: Qwen3.6-35B-A3B (reasoning: none) — telecom + airline

### DIFF
--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -28,7 +28,8 @@
     "grok-4-5_sierra_2026-08-04",
     "inkling_sierra_2026-08-04",
     "claude-opus-5_sierra_2026-08-04",
-    "qwen3-8-max_sierra_2026-08-04"
+    "qwen3-8-max_sierra_2026-08-04",
+    "qwen3.6-35b-a3b-none_hopper_2026-08-15"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",

--- a/web/leaderboard/public/submissions/qwen3.6-35b-a3b-none_hopper_2026-08-15/submission.json
+++ b/web/leaderboard/public/submissions/qwen3.6-35b-a3b-none_hopper_2026-08-15/submission.json
@@ -1,0 +1,59 @@
+{
+  "model_name": "Qwen3.6-35B-A3B",
+  "model_organization": "Alibaba",
+  "submitting_organization": "Hopper",
+  "submission_date": "2026-08-15",
+  "submission_type": "standard",
+  "modality": "text",
+  "reasoning_effort": "none",
+  "contact_info": {
+    "email": "pavan@withhopper.com",
+    "name": "Pavan Katta",
+    "github": "pavanyellow"
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "telecom": "qwen3.6-35b-a3b_none_telecom_gpt-5.2_4trials.json",
+    "airline": "qwen3.6-35b-a3b_none_airline_gpt-5.2_4trials.json"
+  },
+  "references": [
+    {
+      "title": "Hopper — fast inference for voice agents",
+      "url": "https://withhopper.com",
+      "type": "other"
+    }
+  ],
+  "results": {
+    "telecom": {
+      "pass_1": 97.36842105263158,
+      "pass_2": 94.73684210526315,
+      "pass_3": 92.10526315789473,
+      "pass_4": 89.47368421052632,
+      "cost": null
+    },
+    "airline": {
+      "pass_1": 76.0,
+      "pass_2": 67.0,
+      "pass_3": 60.0,
+      "pass_4": 54.0,
+      "cost": null
+    }
+  },
+  "model_release": {
+    "release_date": "2026-04-16",
+    "announcement_url": "https://qwen.ai/blog?id=qwen3.6-35b-a3b",
+    "announcement_title": "Qwen3.6-35B-A3B: Agentic Coding Power, Now Open to All"
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-15",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "gpt-5.2",
+    "notes": "Agent: openai/qwen/qwen3.6-35b-a3b served via OpenRouter, pinned to six fp8 providers (DeepInfra, Parasail, AtlasCloud, Venice, AkashML, Io Net) with allow_fallbacks: false and require_parameters: true. Reasoning DISABLED for the agent (reasoning: {enabled: false}); verified at request level that no reasoning tokens were produced (empty usage.reasoning_tokens, no reasoning content). Agent temperature 0. User simulator: gpt-5.2 with reasoning_effort: low. 4 trials, seed 300 (tau2 default), max-steps 200, max-errors 10 (defaults). Telecom: all 456 simulations terminated naturally (user_stop); zero infrastructure errors, zero too_many_errors. Airline: 199/200 user_stop, 1 max_steps; zero infrastructure errors. We evaluate the non-thinking condition because our focus is voice agents, where reasoning latency is not viable in production.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard tau2-bench scaffold, default prompts, all tasks on the base split. One infrastructure-only local change: raised the hardcoded httpx connection-pool limit in llm_utils.py to support high --max-concurrency (no effect on prompts, tasks, or scoring)."
+    }
+  }
+}


### PR DESCRIPTION
## Standard text submission: Qwen3.6-35B-A3B with reasoning disabled

We evaluate **Qwen3.6-35B-A3B** (Alibaba, open weights) as the agent with **reasoning disabled** — the non-thinking condition. Our focus at [Hopper](https://withhopper.com) is voice agents, where reasoning latency is not viable in production, so we benchmark the configuration voice agents actually run.

### Results (4 trials, seed 300, all tasks, base split)

| domain | pass^1 | pass^2 | pass^3 | pass^4 |
|--------|--------|--------|--------|--------|
| telecom | 97.37 | 94.74 | 92.11 | 89.47 |
| airline | 76.00 | 67.00 | 60.00 | 54.00 |

### Methodology

- **Agent**: `qwen/qwen3.6-35b-a3b` served via OpenRouter, pinned to six fp8 providers (DeepInfra, Parasail, AtlasCloud, Venice, AkashML, Io Net) with `allow_fallbacks: false` and `require_parameters: true`. Temperature 0. Reasoning disabled via `reasoning: {enabled: false}` and **verified per-request** (no reasoning content, zero reasoning tokens in usage).
- **User simulator**: gpt-5.2 with `reasoning_effort: low` (per current leaderboard guidance).
- **Config**: 4 trials, seed 300, max-steps 200, max-errors 10 (all defaults), tau2-bench v1.0.1, standard prompts, no omitted tasks.
- **Run health**: telecom 456/456 simulations ended in user_stop (zero infrastructure or too_many_errors terminations); airline 199/200 user_stop, 1 max_steps.
- **Harness note (disclosed)**: we raised the hardcoded httpx connection-pool limit in `llm_utils.py` locally to support high `--max-concurrency`. This is infrastructure-only — prompts, tasks, and scoring untouched.
- Sanity check of our setup: we first reproduced the existing `gemini-3-flash_sierra_2026-03-02` telecom entry with identical methodology (seed 123, reasoning high) and matched it within trial noise — pass^4 exactly (70.18).

### Trajectories

Full trajectory files (both domains): https://github.com/pavanyellow/tau2-bench/releases/tag/trajectories-qwen3.6-35b-a3b-none-2026-08-15

Happy to re-run or provide anything else needed for verification.