### PR TITLE
Leaderboard submissions: GLM-5.2, Gemma-4-31B, Qwen3.8-27B (non-thinking) — telecom

### DIFF
--- a/web/leaderboard/public/submissions/gemma-4-31b-it_hopper_2026-08-16/submission.json
+++ b/web/leaderboard/public/submissions/gemma-4-31b-it_hopper_2026-08-16/submission.json
@@ -1,0 +1,45 @@
+{
+  "model_name": "Gemma 4 31B IT",
+  "model_organization": "Google",
+  "submitting_organization": "Hopper",
+  "submission_date": "2026-08-16",
+  "submission_type": "standard",
+  "modality": "text",
+  "contact_info": {
+    "email": "pavan@withhopper.com",
+    "name": "Pavan Katta",
+    "github": "pavanyellow"
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "telecom": "gemma-4-31b-it_telecom_gpt-5.2_4trials.json"
+  },
+  "references": [
+    {
+      "title": "Hopper — fast inference for voice agents",
+      "url": "https://withhopper.com",
+      "type": "other"
+    }
+  ],
+  "results": {
+    "telecom": {
+      "pass_1": 70.39473684210526,
+      "pass_2": 54.67836257309941,
+      "pass_3": 45.39473684210526,
+      "pass_4": 39.473684210526315,
+      "cost": null
+    }
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-16",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "gpt-5.2",
+    "notes": "Gemma 4 31B IT is natively non-reasoning (no thinking mode). Agent served via OpenRouter pinned to bf16 providers (CoreWeave, Novita, Venice, OpenInference) with allow_fallbacks: false and require_parameters: true; temperature 0. User simulator: gpt-5.2 with reasoning_effort: low. 4 trials, seed 300, max-steps 200, max-errors 10 (defaults). All 456 simulations completed with zero infrastructure errors. Evaluated as part of our voice-agent (no-reasoning-latency) model survey.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard tau2-bench scaffold, default prompts, all tasks on the base split. One infrastructure-only local change: raised the hardcoded httpx connection-pool limit in llm_utils.py to support high --max-concurrency (no effect on prompts, tasks, or scoring)."
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/glm-5.2-none_hopper_2026-08-16/submission.json
+++ b/web/leaderboard/public/submissions/glm-5.2-none_hopper_2026-08-16/submission.json
@@ -1,0 +1,51 @@
+{
+  "model_name": "GLM-5.2",
+  "model_organization": "Z.ai",
+  "submitting_organization": "Hopper",
+  "submission_date": "2026-08-16",
+  "submission_type": "standard",
+  "modality": "text",
+  "reasoning_effort": "none",
+  "contact_info": {
+    "email": "pavan@withhopper.com",
+    "name": "Pavan Katta",
+    "github": "pavanyellow"
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "telecom": "glm-5.2_none_telecom_gpt-5.2_4trials.json"
+  },
+  "references": [
+    {
+      "title": "Hopper — fast inference for voice agents",
+      "url": "https://withhopper.com",
+      "type": "other"
+    }
+  ],
+  "results": {
+    "telecom": {
+      "pass_1": 96.49122807017544,
+      "pass_2": 93.12865497076024,
+      "pass_3": 89.91228070175438,
+      "pass_4": 86.84210526315789,
+      "cost": null
+    }
+  },
+  "model_release": {
+    "release_date": "2026-06-16",
+    "announcement_url": "https://z.ai/blog/glm-5.2",
+    "announcement_title": "GLM-5.2: Built for Long-Horizon Tasks"
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-16",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "gpt-5.2",
+    "notes": "Non-thinking condition: agent reasoning DISABLED (reasoning: {enabled: false}) and verified per-request (no reasoning content, zero reasoning tokens). Agent: z-ai/glm-5.2 served via OpenRouter pinned to fp8 providers (StreamLake, Baidu, Novita, GMICloud) with allow_fallbacks: false and require_parameters: true; temperature 0. User simulator: gpt-5.2 with reasoning_effort: low. 4 trials, seed 300, max-steps 200, max-errors 10 (defaults). All 456 simulations completed with zero infrastructure errors. We evaluate the non-thinking condition because our focus is voice agents, where reasoning latency is not viable in production.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard tau2-bench scaffold, default prompts, all tasks on the base split. One infrastructure-only local change: raised the hardcoded httpx connection-pool limit in llm_utils.py to support high --max-concurrency (no effect on prompts, tasks, or scoring)."
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -28,7 +28,10 @@
     "grok-4-5_sierra_2026-08-04",
     "inkling_sierra_2026-08-04",
     "claude-opus-5_sierra_2026-08-04",
-    "qwen3-8-max_sierra_2026-08-04"
+    "qwen3-8-max_sierra_2026-08-04",
+    "glm-5.2-none_hopper_2026-08-16",
+    "gemma-4-31b-it_hopper_2026-08-16",
+    "qwen3.8-27b-none_hopper_2026-08-16"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",

--- a/web/leaderboard/public/submissions/qwen3.8-27b-none_hopper_2026-08-16/submission.json
+++ b/web/leaderboard/public/submissions/qwen3.8-27b-none_hopper_2026-08-16/submission.json
@@ -1,0 +1,46 @@
+{
+  "model_name": "Qwen3.8-27B",
+  "model_organization": "Alibaba",
+  "submitting_organization": "Hopper",
+  "submission_date": "2026-08-16",
+  "submission_type": "standard",
+  "modality": "text",
+  "reasoning_effort": "none",
+  "contact_info": {
+    "email": "pavan@withhopper.com",
+    "name": "Pavan Katta",
+    "github": "pavanyellow"
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "telecom": "qwen3.8-27b_none_telecom_gpt-5.2_4trials.json"
+  },
+  "references": [
+    {
+      "title": "Hopper — fast inference for voice agents",
+      "url": "https://withhopper.com",
+      "type": "other"
+    }
+  ],
+  "results": {
+    "telecom": {
+      "pass_1": 72.58771929824562,
+      "pass_2": 55.84795321637427,
+      "pass_3": 45.83333333333333,
+      "pass_4": 39.473684210526315,
+      "cost": null
+    }
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-16",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "gpt-5.2",
+    "notes": "Non-thinking condition: agent reasoning DISABLED (reasoning: {enabled: false}, i.e. enable_thinking=false) and verified per-request. Agent: qwen/qwen3.8-27b served via OpenRouter pinned to AkashML (bf16) with allow_fallbacks: false and require_parameters: true; temperature 0. User simulator: gpt-5.2 with reasoning_effort: low. 4 trials, seed 300, max-steps 200, max-errors 10 (defaults). All 456 simulations completed; zero infrastructure errors. Transparency note: in 1 of 456 simulations the model spontaneously produced <think> content despite disabled thinking (hybrid-model soft-switch leak); reported metrics here are computed natively over ALL 456 trajectories for verifiability. Excluding that one simulation changes pass^1 to 72.44 and pass^4 to 39.82. We evaluate the non-thinking condition because our focus is voice agents, where reasoning latency is not viable in production.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard tau2-bench scaffold, default prompts, all tasks on the base split. One infrastructure-only local change: raised the hardcoded httpx connection-pool limit in llm_utils.py to support high --max-concurrency (no effect on prompts, tasks, or scoring)."
+    }
+  }
+}


### PR DESCRIPTION
## Three standard text submissions: open models in the non-thinking condition

Follow-up to #475 (Qwen3.6-35B-A3B). Same methodology, three more open models evaluated with **reasoning disabled** — the configuration voice agents actually run in production, which is [Hopper](https://withhopper.com)'s focus.

### Results (τ²-telecom, 4 trials, seed 300, all tasks, base split)

| model | pass^1 | pass^2 | pass^3 | pass^4 |
|-------|--------|--------|--------|--------|
| GLM-5.2 (reasoning: none) | 96.49 | 93.13 | 89.91 | 86.84 |
| Qwen3.8-27B (reasoning: none) | 72.59 | 55.85 | 45.83 | 39.47 |
| Gemma 4 31B IT (natively non-reasoning) | 70.39 | 54.68 | 45.39 | 39.47 |

### Shared methodology

- Agents served via OpenRouter pinned to fixed providers with `allow_fallbacks: false` and `require_parameters: true` (GLM-5.2: fp8 StreamLake/Baidu/Novita/GMICloud; Gemma: bf16 CoreWeave/Novita/Venice/OpenInference; Qwen3.8: bf16 AkashML). Temperature 0.
- Reasoning disabled via `reasoning: {enabled: false}` and **verified per-request** (no reasoning content, zero reasoning tokens in usage). Transparency: Qwen3.8 spontaneously produced think content in 1/456 simulations (hybrid soft-switch leak); reported metrics are computed natively over all 456 trajectories for verifiability, with the excluding-variant noted in methodology.notes.
- User simulator: gpt-5.2 with `reasoning_effort: low`. 4 trials, seed 300, max-steps/max-errors defaults, tau2-bench v1.0.1. Zero infrastructure errors in all three runs.
- Disclosed infra-only change: raised the hardcoded httpx connection-pool limit in `llm_utils.py` (no effect on prompts, tasks, or scoring).

### Trajectories

All three domains' trajectory files: https://github.com/pavanyellow/tau2-bench/releases/tag/trajectories-hopper-nonthinking-2026-08-16

Happy to provide anything else needed for verification.