### PR TITLE
fix: add --judge-llm CLI override for NL-assertions evaluator

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -28,6 +28,8 @@ tau2 run \
 | `--user-llm` | LLM model for the user simulator |
 | `--agent-llm-args` | JSON dict of extra args for agent LLM (e.g. `'{"temperature": 0.5}'`) |
 | `--user-llm-args` | JSON dict of extra args for user LLM |
+| `--judge-llm` | LLM model for the natural-language assertions judge (default: `gpt-4.1-2025-04-14`) |
+| `--judge-llm-args` | JSON dict of extra args for the judge LLM |
 | `--agent` | Agent implementation to use (default: `llm_agent`) |
 | `--user` | User simulator implementation to use (default: `user_simulator`) |
 | `--num-trials` | Number of evaluation trials (default: `1`) |
@@ -196,6 +198,8 @@ tau2 evaluate-trajs <paths...>
 |--------|-------------|
 | `<paths>` | Paths to trajectory files, directories, or glob patterns |
 | `-o`, `--output-dir` | Directory to save updated trajectories. If omitted, only displays metrics |
+| `--fresh-tasks` | Re-grade against the current task definitions instead of the ones embedded in the results |
+| `--judge-llm` | LLM model for the natural-language assertions judge (default: `gpt-4.1-2025-04-14`) |
 
 ---
 

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -10,6 +10,8 @@ from tau2.config import (
     DEFAULT_LLM_AGENT,
     DEFAULT_LLM_EVAL_USER_SIMULATOR,
     DEFAULT_LLM_LOG_MODE,
+    DEFAULT_LLM_NL_ASSERTIONS,
+    DEFAULT_LLM_NL_ASSERTIONS_ARGS,
     DEFAULT_LLM_TEMPERATURE_AGENT,
     DEFAULT_LLM_TEMPERATURE_USER,
     DEFAULT_LLM_USER,
@@ -101,6 +103,18 @@ def add_run_args(parser):
         type=json.loads,
         default={"temperature": DEFAULT_LLM_TEMPERATURE_USER},
         help=f"The arguments to pass to the LLM for the user. Default is '{{\"temperature\": {DEFAULT_LLM_TEMPERATURE_USER}}}'.",
+    )
+    parser.add_argument(
+        "--judge-llm",
+        type=str,
+        default=DEFAULT_LLM_NL_ASSERTIONS,
+        help=f"The LLM to use as the judge for natural-language assertions. Default is {DEFAULT_LLM_NL_ASSERTIONS}.",
+    )
+    parser.add_argument(
+        "--judge-llm-args",
+        type=json.loads,
+        default=dict(DEFAULT_LLM_NL_ASSERTIONS_ARGS),
+        help=f"The arguments to pass to the judge LLM for natural-language assertions. Default is '{json.dumps(DEFAULT_LLM_NL_ASSERTIONS_ARGS)}'.",
     )
     parser.add_argument(
         "--task-set-name",
@@ -660,6 +674,8 @@ def main():
             num_tasks=args.num_tasks,
             llm_user=args.user_llm,
             llm_args_user=args.user_llm_args,
+            judge_llm=args.judge_llm,
+            judge_llm_args=args.judge_llm_args,
             num_trials=args.num_trials,
             max_errors=args.max_errors,
             timeout=args.timeout,
@@ -827,6 +843,12 @@ def main():
         "--fresh-tasks",
         action="store_true",
         help="Re-grade against the current task definitions from the data directory instead of the ones embedded in each results file.",
+    )
+    evaluate_parser.add_argument(
+        "--judge-llm",
+        type=str,
+        default=None,
+        help=f"The LLM to use as the judge for natural-language assertions. Default is {DEFAULT_LLM_NL_ASSERTIONS}.",
     )
     evaluate_parser.set_defaults(func=lambda args: run_evaluate_trajectories(args))
 
@@ -1095,7 +1117,10 @@ def run_evaluate_trajectories(args):
     logger.configure(handlers=[{"sink": sys.stderr, "level": "ERROR"}])
 
     evaluate_trajectories(
-        args.paths, args.output_dir, fresh_tasks=getattr(args, "fresh_tasks", False)
+        args.paths,
+        args.output_dir,
+        fresh_tasks=getattr(args, "fresh_tasks", False),
+        judge_llm=getattr(args, "judge_llm", None),
     )
 
 

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -26,6 +26,8 @@ from tau2.config import (
     DEFAULT_LLM_ARGS_AGENT,
     DEFAULT_LLM_ARGS_USER,
     DEFAULT_LLM_EVAL_USER_SIMULATOR,
+    DEFAULT_LLM_NL_ASSERTIONS,
+    DEFAULT_LLM_NL_ASSERTIONS_ARGS,
     DEFAULT_LLM_USER,
     DEFAULT_LOG_LEVEL,
     DEFAULT_MAX_CONCURRENCY,
@@ -322,6 +324,22 @@ class BaseRunConfig(BaseModel):
         Field(
             description="The arguments to pass to the LLM for the user simulator",
             default_factory=lambda: deepcopy(DEFAULT_LLM_ARGS_USER),
+        ),
+    ]
+
+    # ---- NL assertions judge ----
+    judge_llm: Annotated[
+        str,
+        Field(
+            description="The model to use for the natural-language assertions judge",
+            default=DEFAULT_LLM_NL_ASSERTIONS,
+        ),
+    ]
+    judge_llm_args: Annotated[
+        dict,
+        Field(
+            description="The arguments to pass to the LLM for the natural-language assertions judge",
+            default_factory=lambda: deepcopy(DEFAULT_LLM_NL_ASSERTIONS_ARGS),
         ),
     ]
 

--- a/src/tau2/evaluator/evaluator.py
+++ b/src/tau2/evaluator/evaluator.py
@@ -94,6 +94,8 @@ def evaluate_simulation(
     mode: CommunicationMode = CommunicationMode.HALF_DUPLEX,
     env_kwargs: dict = None,
     strict_replay: bool = True,
+    judge_llm: Optional[str] = None,
+    judge_llm_args: Optional[dict] = None,
 ) -> RewardInfo:
     """
     Evaluate the simulation based on the evaluation type.
@@ -112,6 +114,10 @@ def evaluate_simulation(
               Live evaluation keeps the default (True); trajectory re-grading
               passes False so recorded outputs that cosmetically predate
               current tool code do not abort the replay.
+        judge_llm: The LLM used by the NL assertions judge. Defaults to
+              DEFAULT_LLM_NL_ASSERTIONS when None.
+        judge_llm_args: The arguments passed to the NL assertions judge LLM.
+              Defaults to DEFAULT_LLM_NL_ASSERTIONS_ARGS when None.
 
     Returns:
         RewardInfo with the evaluation results.
@@ -181,6 +187,8 @@ def evaluate_simulation(
         reward_info = NLEvaluator.calculate_reward(
             task=task,
             full_trajectory=trajectory,
+            model=judge_llm,
+            model_args=judge_llm_args,
         )
     elif evaluation_type == EvaluationType.COMMUNICATE:
         reward_info = CommEvaluator.calculate_reward(
@@ -217,6 +225,8 @@ def evaluate_simulation(
             nl_reward_info = NLEvaluator.calculate_reward(
                 task=task,
                 full_trajectory=trajectory,
+                model=judge_llm,
+                model_args=judge_llm_args,
             )
 
         ## Combine all the rewards.
@@ -298,6 +308,8 @@ def evaluate_simulation(
             nl_reward_info = NLEvaluator.calculate_reward(
                 task=task,
                 full_trajectory=trajectory,
+                model=judge_llm,
+                model_args=judge_llm_args,
             )
 
         # Combine all rewards regardless of the task's reward_basis

--- a/src/tau2/evaluator/evaluator_nl_assertions.py
+++ b/src/tau2/evaluator/evaluator_nl_assertions.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 from tau2.agent.base.streaming import (
     LinearizationStrategy,
@@ -23,9 +24,18 @@ class NLAssertionsEvaluator(EvaluatorBase[Message]):
         cls,
         task: Task,
         full_trajectory: list[Message],
+        model: Optional[str] = None,
+        model_args: Optional[dict] = None,
     ) -> RewardInfo:
         """
         Calculate the reward for the simulation by using an LLM to evaluate whether the trajectory adheres to all the natural-language assertions
+
+        Args:
+            task: The task specification.
+            full_trajectory: List of messages from the conversation.
+            model: The judge model to use. Defaults to DEFAULT_LLM_NL_ASSERTIONS.
+            model_args: The arguments to pass to the judge model. Defaults to
+                DEFAULT_LLM_NL_ASSERTIONS_ARGS.
         """
         if task.evaluation_criteria is None:
             return RewardInfo(
@@ -44,7 +54,7 @@ class NLAssertionsEvaluator(EvaluatorBase[Message]):
             )
 
         nl_assertions_checks = cls.evaluate_nl_assertions(
-            full_trajectory, nl_assertions
+            full_trajectory, nl_assertions, model=model, model_args=model_args
         )
 
         # Calculate reward: 1 if all expectations are met, 0 otherwise
@@ -62,6 +72,8 @@ class NLAssertionsEvaluator(EvaluatorBase[Message]):
         cls,
         trajectory: list[Message],
         nl_assertions: list[str],
+        model: Optional[str] = None,
+        model_args: Optional[dict] = None,
     ) -> list[NLAssertionCheck]:
         """
         Evaluate whether the trajectory meets each expected outcome.
@@ -69,6 +81,9 @@ class NLAssertionsEvaluator(EvaluatorBase[Message]):
         Args:
             trajectory: List of messages from the conversation
             nl_assertions: List of natural-language assertions to evaluate
+            model: The judge model to use. Defaults to DEFAULT_LLM_NL_ASSERTIONS.
+            model_args: The arguments to pass to the judge model. Defaults to
+                DEFAULT_LLM_NL_ASSERTIONS_ARGS.
 
         Returns:
             List of evaluation results for each NL assertion, containing:
@@ -119,10 +134,12 @@ class NLAssertionsEvaluator(EvaluatorBase[Message]):
         ]
 
         assistant_message = generate(
-            model=DEFAULT_LLM_NL_ASSERTIONS,
+            model=model if model is not None else DEFAULT_LLM_NL_ASSERTIONS,
             messages=messages,
             call_name="nl_assertions_eval",
-            **DEFAULT_LLM_NL_ASSERTIONS_ARGS,
+            **(
+                model_args if model_args is not None else DEFAULT_LLM_NL_ASSERTIONS_ARGS
+            ),
         )
         result_data = json.loads(assistant_message.content)
         return [
@@ -193,10 +210,19 @@ class FullDuplexNLAssertionsEvaluator(EvaluatorBase[Tick]):
         cls,
         task: Task,
         full_trajectory: list[Tick],
+        model: Optional[str] = None,
+        model_args: Optional[dict] = None,
     ) -> RewardInfo:
         """
         Calculate the reward for the simulation by using an LLM to evaluate whether
         the trajectory adheres to all the natural-language assertions.
+
+        Args:
+            task: The task specification.
+            full_trajectory: List of ticks from the conversation.
+            model: The judge model to use. Defaults to DEFAULT_LLM_NL_ASSERTIONS.
+            model_args: The arguments to pass to the judge model. Defaults to
+                DEFAULT_LLM_NL_ASSERTIONS_ARGS.
         """
         if task.evaluation_criteria is None:
             return RewardInfo(
@@ -217,7 +243,9 @@ class FullDuplexNLAssertionsEvaluator(EvaluatorBase[Tick]):
         # Convert ticks to linearized message history
         messages = cls.ticks_to_message_history(full_trajectory)
 
-        nl_assertions_checks = cls.evaluate_nl_assertions(messages, nl_assertions)
+        nl_assertions_checks = cls.evaluate_nl_assertions(
+            messages, nl_assertions, model=model, model_args=model_args
+        )
 
         # Calculate reward: 1 if all expectations are met, 0 otherwise
         all_expectations_met = all(result.met for result in nl_assertions_checks)
@@ -234,10 +262,14 @@ class FullDuplexNLAssertionsEvaluator(EvaluatorBase[Tick]):
         cls,
         trajectory: list[Message],
         nl_assertions: list[str],
+        model: Optional[str] = None,
+        model_args: Optional[dict] = None,
     ) -> list[NLAssertionCheck]:
         """
         Evaluate whether the trajectory meets each expected outcome.
 
         Delegates to NLAssertionsEvaluator.evaluate_nl_assertions.
         """
-        return NLAssertionsEvaluator.evaluate_nl_assertions(trajectory, nl_assertions)
+        return NLAssertionsEvaluator.evaluate_nl_assertions(
+            trajectory, nl_assertions, model=model, model_args=model_args
+        )

--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -420,7 +420,11 @@ def run_single_task(
         # Layer 1: Run the simulation
         env_kwargs = _build_env_kwargs(config, task) or None
         simulation = run_simulation(
-            orchestrator, evaluation_type=evaluation_type, env_kwargs=env_kwargs
+            orchestrator,
+            evaluation_type=evaluation_type,
+            env_kwargs=env_kwargs,
+            judge_llm=config.judge_llm,
+            judge_llm_args=config.judge_llm_args,
         )
 
         # Side effects

--- a/src/tau2/runner/simulation.py
+++ b/src/tau2/runner/simulation.py
@@ -21,6 +21,8 @@ def run_simulation(
     *,
     evaluation_type: EvaluationType = EvaluationType.ALL,
     env_kwargs: Optional[dict] = None,
+    judge_llm: Optional[str] = None,
+    judge_llm_args: Optional[dict] = None,
 ) -> SimulationRun:
     """Run a simulation and evaluate the result.
 
@@ -38,6 +40,10 @@ def run_simulation(
         evaluation_type: The type of evaluation to perform. Defaults to ALL.
         env_kwargs: Additional kwargs passed to the evaluator's environment
             constructor (e.g., retrieval_variant for banking_knowledge).
+        judge_llm: The LLM used by the NL assertions judge. Defaults to
+            DEFAULT_LLM_NL_ASSERTIONS when None.
+        judge_llm_args: The arguments passed to the NL assertions judge LLM.
+            Defaults to DEFAULT_LLM_NL_ASSERTIONS_ARGS when None.
 
     Returns:
         SimulationRun with reward_info attached.
@@ -81,6 +87,8 @@ def run_simulation(
         domain=domain,
         mode=mode,
         env_kwargs=env_kwargs,
+        judge_llm=judge_llm,
+        judge_llm_args=judge_llm_args,
     )
     simulation.reward_info = reward_info
 

--- a/src/tau2/scripts/evaluate_trajectories.py
+++ b/src/tau2/scripts/evaluate_trajectories.py
@@ -93,6 +93,7 @@ def compute_simulation_rewards(
     evaluation_type: EvaluationType = EvaluationType.ALL,
     console: Optional[Console] = None,
     fresh_tasks: bool = False,
+    judge_llm: Optional[str] = None,
 ) -> Results:
     """
     Compute and update rewards for all simulations in the results.
@@ -103,6 +104,8 @@ def compute_simulation_rewards(
         console: Optional Rich console for output
         fresh_tasks: Re-grade against the current task definitions from the
             data directory instead of the ones embedded in the results file.
+        judge_llm: The LLM used by the NL assertions judge. Defaults to
+            DEFAULT_LLM_NL_ASSERTIONS when None.
     """
     results = deepcopy(results)
     if fresh_tasks:
@@ -131,6 +134,7 @@ def compute_simulation_rewards(
                 mode=get_communication_mode(results, simulation),
                 env_kwargs=_build_eval_env_kwargs(domain, task),
                 strict_replay=False,
+                judge_llm=judge_llm,
             )
 
             # Update the simulation with new reward info
@@ -150,6 +154,7 @@ def evaluate_trajectories(
     output_dir: str | None = None,
     evaluation_type: EvaluationType = EvaluationType.ALL,
     fresh_tasks: bool = False,
+    judge_llm: Optional[str] = None,
 ) -> None:
     """
     Evaluate trajectories and optionally save updated results with recomputed rewards.
@@ -160,6 +165,8 @@ def evaluate_trajectories(
         evaluation_type: Type of evaluation to perform
         fresh_tasks: Re-grade against the current task definitions from the data
             directory instead of the ones embedded in each results file.
+        judge_llm: The LLM used by the NL assertions judge. Defaults to
+            DEFAULT_LLM_NL_ASSERTIONS when None.
     """
     files = expand_paths(input_paths, extension=".json")
     console = ConsoleDisplay.console
@@ -201,6 +208,7 @@ def evaluate_trajectories(
                 evaluation_type=evaluation_type,
                 console=console,
                 fresh_tasks=fresh_tasks,
+                judge_llm=judge_llm,
             )
             console.print(
                 f"  ✅ Computed rewards for {len(updated_results.simulations)} simulation(s)",
@@ -265,6 +273,11 @@ def make_parser():
         action="store_true",
         help="Re-grade against the current task definitions from the data directory instead of the ones embedded in each results file.",
     )
+    parser.add_argument(
+        "--judge-llm",
+        default=None,
+        help="The LLM to use as the judge for natural-language assertions. Defaults to the configured judge model.",
+    )
     return parser
 
 
@@ -273,7 +286,12 @@ def main():
     logger.configure(handlers=[{"sink": sys.stderr, "level": "ERROR"}])
     parser = make_parser()
     args = parser.parse_args()
-    evaluate_trajectories(args.paths, args.output_dir, fresh_tasks=args.fresh_tasks)
+    evaluate_trajectories(
+        args.paths,
+        args.output_dir,
+        fresh_tasks=args.fresh_tasks,
+        judge_llm=args.judge_llm,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_judge_llm.py
+++ b/tests/test_judge_llm.py
@@ -1,0 +1,202 @@
+import argparse
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tau2.cli import add_run_args
+from tau2.config import DEFAULT_LLM_NL_ASSERTIONS, DEFAULT_LLM_NL_ASSERTIONS_ARGS
+from tau2.data_model.simulation import TerminationReason, TextRunConfig
+from tau2.data_model.tasks import RewardType
+from tau2.evaluator import evaluator_nl_assertions
+from tau2.evaluator.evaluator import EvaluationType, evaluate_simulation
+from tau2.evaluator.evaluator_nl_assertions import NLAssertionsEvaluator
+from tau2.runner import batch
+from tau2.runner import simulation as runner_simulation
+
+NL_ASSERTION = "The agent greeted the user."
+
+
+@pytest.fixture
+def task_with_nl_assertions(base_task):
+    """Mock task graded only on NL assertions."""
+    task = base_task.model_copy(deep=True)
+    task.evaluation_criteria.nl_assertions = [NL_ASSERTION]
+    task.evaluation_criteria.reward_basis = [RewardType.NL_ASSERTION]
+    return task
+
+
+@pytest.fixture
+def captured_generate(monkeypatch):
+    """Capture the kwargs the NL assertions judge passes to `generate`."""
+    captured = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            content=json.dumps(
+                {
+                    "results": [
+                        {
+                            "expectedOutcome": NL_ASSERTION,
+                            "reasoning": "The agent said hello.",
+                            "metExpectation": True,
+                        }
+                    ]
+                }
+            )
+        )
+
+    monkeypatch.setattr(evaluator_nl_assertions, "generate", fake_generate)
+    return captured
+
+
+def test_evaluate_nl_assertions_defaults_to_configured_judge(captured_generate):
+    NLAssertionsEvaluator.evaluate_nl_assertions([], [NL_ASSERTION])
+
+    assert captured_generate["model"] == DEFAULT_LLM_NL_ASSERTIONS
+    assert (
+        captured_generate["temperature"]
+        == DEFAULT_LLM_NL_ASSERTIONS_ARGS["temperature"]
+    )
+
+
+def test_evaluate_nl_assertions_uses_custom_judge(captured_generate):
+    NLAssertionsEvaluator.evaluate_nl_assertions(
+        [],
+        [NL_ASSERTION],
+        model="gpt-4o",
+        model_args={"temperature": 0.7},
+    )
+
+    assert captured_generate["model"] == "gpt-4o"
+    assert captured_generate["temperature"] == 0.7
+
+
+def test_calculate_reward_uses_custom_judge(captured_generate, task_with_nl_assertions):
+    reward_info = NLAssertionsEvaluator.calculate_reward(
+        task=task_with_nl_assertions,
+        full_trajectory=[],
+        model="gpt-4o",
+        model_args={"temperature": 0.7},
+    )
+
+    assert reward_info.reward == 1.0
+    assert captured_generate["model"] == "gpt-4o"
+    assert captured_generate["temperature"] == 0.7
+
+
+def test_evaluate_simulation_threads_judge_llm(
+    captured_generate, task_with_nl_assertions, domain_name
+):
+    simulation = SimpleNamespace(
+        termination_reason=TerminationReason.AGENT_STOP,
+        messages=[],
+        ticks=None,
+    )
+
+    evaluate_simulation(
+        simulation=simulation,
+        task=task_with_nl_assertions,
+        evaluation_type=EvaluationType.NL_ASSERTIONS,
+        solo_mode=False,
+        domain=domain_name,
+        judge_llm="gpt-4o",
+        judge_llm_args={"temperature": 0.7},
+    )
+
+    assert captured_generate["model"] == "gpt-4o"
+    assert captured_generate["temperature"] == 0.7
+
+
+def test_run_simulation_threads_judge_llm(monkeypatch, base_task):
+    captured = {}
+    reward_info = SimpleNamespace(reward=1.0)
+
+    def fake_evaluate_simulation(**kwargs):
+        captured["judge_llm"] = kwargs["judge_llm"]
+        captured["judge_llm_args"] = kwargs["judge_llm_args"]
+        return reward_info
+
+    monkeypatch.setattr(
+        runner_simulation, "evaluate_simulation", fake_evaluate_simulation
+    )
+
+    environment = SimpleNamespace(
+        get_policy=lambda: "policy",
+        get_domain_name=lambda: "mock",
+    )
+    orchestrator = SimpleNamespace(
+        run=lambda: SimpleNamespace(policy=None, reward_info=None),
+        environment=environment,
+        task=base_task,
+    )
+
+    result = runner_simulation.run_simulation(
+        orchestrator,
+        judge_llm="gpt-4o",
+        judge_llm_args={"temperature": 0.7},
+    )
+
+    assert result.reward_info is reward_info
+    assert captured == {
+        "judge_llm": "gpt-4o",
+        "judge_llm_args": {"temperature": 0.7},
+    }
+
+
+def test_run_single_task_uses_config_judge_llm(monkeypatch, base_task):
+    captured = {}
+    simulation = SimpleNamespace(reward_info=SimpleNamespace(reward=1.0))
+
+    def fake_build_orchestrator(*args, **kwargs):
+        return SimpleNamespace(environment=SimpleNamespace(get_policy=lambda: "policy"))
+
+    def fake_run_simulation(orchestrator, **kwargs):
+        captured["judge_llm"] = kwargs["judge_llm"]
+        captured["judge_llm_args"] = kwargs["judge_llm_args"]
+        return simulation
+
+    monkeypatch.setattr(batch, "build_orchestrator", fake_build_orchestrator)
+    monkeypatch.setattr(batch, "run_simulation", fake_run_simulation)
+
+    config = TextRunConfig(
+        domain="mock",
+        judge_llm="gpt-4o",
+        judge_llm_args={"temperature": 0.7},
+    )
+
+    assert batch.run_single_task(config, base_task) is simulation
+    assert captured == {
+        "judge_llm": "gpt-4o",
+        "judge_llm_args": {"temperature": 0.7},
+    }
+
+
+def test_run_config_defaults_to_configured_judge():
+    config = TextRunConfig(domain="mock")
+
+    assert config.judge_llm == DEFAULT_LLM_NL_ASSERTIONS
+    assert config.judge_llm_args == DEFAULT_LLM_NL_ASSERTIONS_ARGS
+
+
+def test_cli_parses_judge_llm_flags():
+    parser = argparse.ArgumentParser()
+    add_run_args(parser)
+
+    defaults = parser.parse_args(["--domain", "mock"])
+    assert defaults.judge_llm == DEFAULT_LLM_NL_ASSERTIONS
+    assert defaults.judge_llm_args == DEFAULT_LLM_NL_ASSERTIONS_ARGS
+
+    overridden = parser.parse_args(
+        [
+            "--domain",
+            "mock",
+            "--judge-llm",
+            "gpt-4o",
+            "--judge-llm-args",
+            '{"temperature": 0.7}',
+        ]
+    )
+    assert overridden.judge_llm == "gpt-4o"
+    assert overridden.judge_llm_args == {"temperature": 0.7}


### PR DESCRIPTION
## Summary

`DEFAULT_LLM_NL_ASSERTIONS` had no CLI override, so the NL-assertions judge always ran on the hardcoded default model. This PR adds `--judge-llm` / `--judge-llm-args` and threads them all the way down to `NLAssertionsEvaluator`.

Scope note: this PR covers **only the NL-assertions judge**, which is the failure reported in #474. `DEFAULT_LLM_ENV_INTERFACE` is also mentioned in that issue and is intentionally left for a follow-up PR to keep this change reviewable — so I used `Refs #474` rather than `Fixes`, please close the issue as you see fit.

### Why this bites harder than it looks

Reproduced on `main` before writing any code (retail task 2, an OpenAI-compatible endpoint whose key has no access to `gpt-4.1-2025-04-14`):

```
conversation completes normally (~30s) -> NL judge calls the hardcoded default -> 403
-> simulation marked as an infra error -> retry re-runs the ENTIRE conversation
-> R1, R2, R3 all die at the same judge call
-> final: Infra Errors 1 / Evaluated 0 / Total Tasks 0
```

The retry loop multiplies the loss: every judge failure re-burns a full agent+user conversation. The reporter's 40 lost tasks cost roughly 160 conversations worth of tokens.

## Changes Made

Follows the existing `--review-model` / `--agent-llm` pattern. Every new parameter is optional and falls back to today's defaults.

| File | Change |
|---|---|
| `evaluator/evaluator_nl_assertions.py` | `calculate_reward()` / `evaluate_nl_assertions()` take optional `model` / `model_args`; fall back to `DEFAULT_LLM_NL_ASSERTIONS(_ARGS)` when `None`. Same for `FullDuplexNLAssertionsEvaluator`, so voice runs are covered too |
| `evaluator/evaluator.py` | `evaluate_simulation(judge_llm=None, judge_llm_args=None)`, forwarded at all four `NLEvaluator.calculate_reward()` call sites |
| `data_model/simulation.py` | `BaseRunConfig.judge_llm` / `judge_llm_args`. Putting them on the config (not just in CLI locals) is what makes `tau2 run --workers N` inherit them — workers rebuild the config via `model_validate()`, so a CLI-local variable would have silently fallen back to the default, i.e. exactly the bug in #474 |
| `runner/simulation.py`, `runner/batch.py` | `run_simulation()` accepts the two kwargs; `run_single_task()` passes `config.judge_llm(_args)` |
| `cli.py` | `--judge-llm` / `--judge-llm-args` on `tau2 run` (next to `--user-llm-args`), plus `--judge-llm` on `tau2 evaluate-trajs` so recorded trajectories can be re-graded with a different judge |
| `scripts/evaluate_trajectories.py` | optional `judge_llm` on `evaluate_trajectories()` / `compute_simulation_rewards()`, wired to the standalone parser too |
| `docs/cli-reference.md` | documented the new flags (also added the previously undocumented `--fresh-tasks` row) |
| `tests/test_judge_llm.py` | new, 8 tests |

No breaking changes, no new dependencies. Results-file format is unchanged (verified below).

`model_args=None` means "use the default args"; `model_args={}` is an explicit "no extra args" and is respected — hence the `is not None` checks rather than truthiness.

## Testing

Ran against a real OpenAI-compatible endpoint (not mocks) and compared every result against `main` with the changes stashed.

**Regression check — per-test A/B diff, identical model setup:**

| Suite | `main` | This PR |
|---|---|---|
| `make test` (core) | 232 passed | 240 passed |
| `make test-voice` + `make test-gym` | 294 passed, 3 skipped | 294 passed, 3 skipped |
| `make check-all` (ruff lint + format) | — | passes, 328 files |

Diffing the per-test outcome lists: all 233 pre-existing core tests keep their exact status, the only delta is the 8 new tests. Voice/streaming/gym unchanged (`FullDuplexNLAssertionsEvaluator` is touched by this PR, hence running that tier).

**End-to-end, retail task 2 (`reward_basis: [DB, NL_ASSERTION]`):**

| Case | Result |
|---|---|
| `main`, no new flags | 403 on the judge, run lost (repro above) |
| This PR, **no** `--judge-llm` | byte-for-byte the same failure — default path unchanged |
| This PR, `--judge-llm <model>` | `USER_STOP`, `Reward 1.0 (DB: 1.0, NL_ASSERTION: 1.0)` |
| `evaluate-trajs` without / with `--judge-llm` | fails as before / re-grades successfully |
| `tau2 run --workers 1 --judge-llm <model>` | judge override honoured inside the worker process, `Reward 1.0` |

Verified from the `--verbose-logs` LLM call logs that the three roles stay on their own models (agent/user on one model, `nl_assertions_eval` on the `--judge-llm` model), in both the in-process and `--workers` paths.

**Backward compatibility:** a `results.json` produced by `main` contains no `judge_llm` key anywhere — the new config fields do not change the saved format — and the new code loads and re-grades that old file fine.

**Also checked:** the two new config fields are isolated per config instance, do not mutate the `config.py` constants, and dicts passed in from the caller are copied by pydantic.

New tests cover: default fallback, custom `model` / `model_args`, `calculate_reward`, `evaluate_simulation` threading, `run_simulation` threading, `run_single_task` reading it off the config, config defaults, and CLI flag parsing.

## Documentation

- `docs/cli-reference.md`: `--judge-llm` / `--judge-llm-args` under `tau2 run`, `--judge-llm` under `tau2 evaluate-trajs`, plus the missing `--fresh-tasks` row.
- Docstrings updated on every function that gained a parameter.

## Checklist

- [x] Tests pass (`make test`, plus `make test-voice` and `make test-gym` since this touches the full-duplex evaluator)
- [x] Code follows style guidelines (`make check-all`)
- [x] Documentation updated
- [x] Breaking changes noted (there are none)

## Notes for reviewers

Two pre-existing issues I hit while testing, unrelated to this PR and present on `main` — happy to open separate issues if useful:

1. `tests/test_streaming/test_discrete_time_audio_native_agent.py` fails at collection: it imports `tau2.voice.audio_native.openai.tick_runner`, which does not exist. I excluded that file from the voice-tier run on both sides of the comparison.
2. `llm_utils.get_response_cost()` raises `TypeError: expected string or bytes-like object` when a provider omits `model` from the response body, because `_parse_ft_model_name()` assumes it is a string.
