### PR TITLE
Add CloudSurf-4B-FC leaderboard submission

### DIFF
--- a/web/leaderboard/public/submissions/cloudsurf-4b-fc_cloudsurf-software_2026-08-17/submission.json
+++ b/web/leaderboard/public/submissions/cloudsurf-4b-fc_cloudsurf-software_2026-08-17/submission.json
@@ -1,0 +1,72 @@
+{
+  "model_name": "CloudSurf-4B-FC",
+  "model_organization": "CloudSurf Software",
+  "submitting_organization": "CloudSurf Software",
+  "submission_date": "2026-08-17",
+  "submission_type": "custom",
+  "modality": "text",
+  "contact_info": {
+    "email": "brady@cloudsurf.com",
+    "name": "K. Brady Davis",
+    "github": "worldMachine"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 46.92982456140351,
+      "pass_2": 29.093567251461987,
+      "pass_3": 20.394736842105264,
+      "pass_4": 14.912280701754385,
+      "cost": 0.042
+    },
+    "airline": {
+      "pass_1": 40.0,
+      "pass_2": 26.333333333333336,
+      "pass_3": 18.5,
+      "pass_4": 14.000000000000002,
+      "cost": 0.049
+    },
+    "telecom": {
+      "pass_1": 15.350877192982457,
+      "pass_2": 11.988304093567253,
+      "pass_3": 10.087719298245613,
+      "pass_4": 8.771929824561402,
+      "cost": 0.128
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_results.json",
+    "retail": "retail_results.json",
+    "telecom": "telecom_results.json"
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-18",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "gpt-5.2",
+    "verification": {
+      "modified_prompts": true,
+      "omitted_questions": false,
+      "details": "Serving bridge appends a function-calling instruction block to the system message; details in notes."
+    },
+    "notes": "CloudSurf-4B-FC is a function-calling fine-tune of google/gemma-4-E4B-it (weights and adapters public on Hugging Face; base revision pinned in the model card). Not trained on any tau-bench data: an 8-gram normalized-overlap decontamination check of the full training mix against all four tau2-bench domains (tasks, policies, schemas; tau2 @ c339866) found 0 collisions (2026-08-17). Zero-shot on tau2 — no domain-specific prompting, tuning, or task filtering. Scaffold: the standard tau2 llm_agent against a local OpenAI-compatible sglang endpoint, with a thin serving-layer bridge for the model's function-calling format. Marked custom for two bridge behaviors, disclosed fully: (1) the bridge appends a fixed function-calling instruction block (BFCL prompt-mode style, including behavioral instructions) to each domain's policy system message — hence modified_prompts: true; (2) when a generation terminates inside the model's thought channel with an empty answer, the bridge attempts to recover a bracket-format tool-call list from the raw/thought text instead of returning the empty answer (an empty-answer salvage path that goes beyond wire-format parsing). The bridge script is published unabridged in the model repo (serving/fc_tau2_bridge.py) with serving instructions in the model card. The trajectory model string 'openai/cloudsurf-4b-fc' is the litellm route for the local endpoint and refers to this model, not an OpenAI model. Config: agent temperature 0.0; user simulator gpt-5.2 with reasoning_effort=low (the leaderboard reference configuration; temperature not set — the gpt-5 family rejects it outside reasoning_effort=none); 4 trials per task; base split, all tasks per domain (banking_knowledge not attempted); evaluation and submission tooling both at tau2-bench commit c339866. Results were stable across user-simulator reasoning configurations: an earlier full run with reasoning_effort=none scored retail 45.2 / airline 41.0 (within trial noise of the reference-config 46.9 / 40.0 reported here). Cost fields are average per-trajectory estimates: measured gpt-5.2 user-simulator API spend from the trajectories plus amortized single-H100 serving time (~$0.007/trajectory); agent-side inference ran locally."
+  },
+  "model_release": {
+    "release_date": "2026-08-17",
+    "announcement_url": "https://huggingface.co/cloudsurf-software/CloudSurf-4B-FC",
+    "announcement_title": "CloudSurf-4B-FC on Hugging Face"
+  },
+  "reasoning_effort": "enabled",
+  "references": [
+    {
+      "title": "CloudSurf-4B-FC model card",
+      "url": "https://huggingface.co/cloudsurf-software/CloudSurf-4B-FC",
+      "type": "model_card"
+    },
+    {
+      "title": "Evaluation trajectories (full tau2 simulation files)",
+      "url": "https://huggingface.co/datasets/cloudsurf-software/tau2-trajectories-cloudsurf-4b-fc",
+      "type": "huggingface"
+    }
+  ]
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -28,7 +28,8 @@
     "grok-4-5_sierra_2026-08-04",
     "inkling_sierra_2026-08-04",
     "claude-opus-5_sierra_2026-08-04",
-    "qwen3-8-max_sierra_2026-08-04"
+    "qwen3-8-max_sierra_2026-08-04",
+    "cloudsurf-4b-fc_cloudsurf-software_2026-08-17"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",


### PR DESCRIPTION
## Add CloudSurf-4B-FC (custom) — text leaderboard, 3 domains

**Model**: [CloudSurf-4B-FC](https://huggingface.co/cloudsurf-software/CloudSurf-4B-FC)
— a function-calling fine-tune of `google/gemma-4-E4B-it` (4B effective
parameters), weights and adapters public on Hugging Face. Zero-shot on τ² —
no domain-specific prompting, tuning, or task filtering, and **not trained on
any τ-bench data** (8-gram normalized-overlap decontamination of the full
training mix against all four τ² domains — tasks, policies, schemas at
`c339866` — found 0 collisions).

### Results — base split, 4 trials/task, all tasks per domain

User simulator `gpt-5.2` with `reasoning_effort=low` — the leaderboard
reference configuration (temperature not set; the gpt-5 family rejects it
outside `reasoning_effort=none`) — agent temperature 0.0, evaluation and
submission tooling both at tau2-bench commit `c339866`.

| Domain | Pass^1 | Pass^2 | Pass^3 | Pass^4 | avg $/trajectory |
|---|---:|---:|---:|---:|---:|
| retail | 46.9 | 29.1 | 20.4 | 14.9 | $0.042 |
| airline | 40.0 | 26.3 | 18.5 | 14.0 | $0.049 |
| telecom | 15.4 | 12.0 | 10.1 | 8.8 | $0.128 |

Results were stable across user-simulator reasoning configs: an earlier full
run at `reasoning_effort=none` scored retail 45.2 / airline 41.0 (within
trial noise of the reference-config numbers above).

Cost = measured gpt-5.2 user-simulator API spend from the trajectories plus
amortized single-H100 serving time (~$0.007/trajectory); agent-side inference
ran locally. (`banking_knowledge` not attempted.)

### Custom-scaffold disclosure

The agent is the standard tau2 `llm_agent` against a local OpenAI-compatible
endpoint. In front of the sglang backend sits a thin serving bridge that
adapts the model's prompt-mode function-calling format, published unabridged
in the model repo
([`serving/fc_tau2_bridge.py`](https://huggingface.co/cloudsurf-software/CloudSurf-4B-FC/blob/main/serving/fc_tau2_bridge.py)).
We marked the submission **custom** for two bridge behaviors:

1. It appends a fixed function-calling instruction block to each domain's
   policy system message (hence `modified_prompts: true` in the submission).
2. When a generation terminates inside the model's thought channel with an
   empty answer, it attempts to recover a bracket-format tool-call list from
   the raw text before returning the empty answer.

Everything else is wire-format adaptation (turn rendering, bracket-list →
`tool_calls` parsing). Happy to have maintainers reclassify if you judge the
line differently. Note: the trajectory model string `openai/cloudsurf-4b-fc`
is the litellm route for the local endpoint (it is not an OpenAI model); the
display name is `CloudSurf-4B-FC` — `tau2 submit validate` flags this
expected mismatch plus the deliberate non-zero cost fields (local serving
records cost 0.0; ours are real estimates).

### Trajectories

Full, unmodified `results.json` per domain (prepared with `tau2 submit
prepare`, validated with `tau2 submit validate`):
**https://huggingface.co/datasets/cloudsurf-software/tau2-trajectories-cloudsurf-4b-fc**

### Why this entry

Small-model economics: current board leaders (pulled 2026-08-17: Qwen
3.5-397B-A17B 87.9, Gemini 3.0 Pro 85.4, Claude Opus 4.5 85.3 overall) are
one to two orders of magnitude larger. This row documents where a 4B open
model with a disclosed scaffold lands on the same tasks at ~$0.04–0.13 per
trajectory.

cc @benshi34 for text-submission review. @soham-sierra — the custom-scaffold disclosure above may be relevant to the standard/custom line being drawn in #444; happy to be reclassified either way.
