### PR TITLE
Add independently verified Pine Voice submissions

### DIFF
--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -47,7 +47,9 @@
     "gemini-3-1-flash-live-preview-thinking-high-banking_google_2026-07-13",
     "xai-realtime-banking_xai_2026-07-13",
     "qwen3-5-omni-plus-realtime_qwen_2026-08-06",
-    "grok-voice-think-fast-2-0_xai_2026-08-06"
+    "grok-voice-think-fast-2-0_xai_2026-08-06",
+    "pine-voice-preview-user-sim-v1-0_pineai_2026-08-17",
+    "pine-voice-preview-user-sim-gpt-5-5_pineai_2026-08-17"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",

--- a/web/leaderboard/public/submissions/pine-voice-preview-user-sim-gpt-5-5_pineai_2026-08-17/submission.json
+++ b/web/leaderboard/public/submissions/pine-voice-preview-user-sim-gpt-5-5_pineai_2026-08-17/submission.json
@@ -1,0 +1,147 @@
+{
+  "model_name": "Pine Voice Preview",
+  "model_organization": "Pine AI",
+  "submitting_organization": "Pine AI",
+  "submission_date": "2026-08-17",
+  "submission_type": "custom",
+  "modality": "voice",
+  "contact_info": {
+    "email": "arvinx@19pine.ai",
+    "name": "Arvin Xu",
+    "github": "a7vinx"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 85.08771929824562
+    },
+    "airline": {
+      "pass_1": 80.0
+    },
+    "telecom": {
+      "pass_1": 75.43859649122807
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_regular_openai_pine-voice-preview",
+    "retail": "retail_regular_openai_pine-voice-preview",
+    "telecom": "telecom_regular_openai_pine-voice-preview"
+  },
+  "references": [
+    {
+      "title": "Pine AI",
+      "url": "https://19pine.ai",
+      "type": "other"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-08-15",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "gpt-5.5-2026-04-23 (xhigh)",
+    "notes": "Custom submission from Pine AI, independently evaluated by Sierra. The agent is a two-agent system: (1) a voice agent handling real-time speech via a customized ASR -> LLM -> TTS pipeline coordinated by a custom interaction model that governs turn-taking, backchanneling, and other conversational dynamics; (2) a background agent (gemini-3.5-flash) that issues the tool calls for the operational task. The two agents share context.\nAll voice-side models are the same production models serving 19pine.ai -- not benchmark-trained. No files in this tau-voice repo are modified. On top of the standard tau-voice agent system prompt, Pine prepends an additional scaffold system message that defines each agent's identity and role (the real-time voice agent vs. the background tool-calling agent), the responsibilities each one owns, and how the two coordinate and share context.\nSierra independently evaluated the full base splits on all three domains (retail 114, airline 50, telecom 114), 1 trial per task, --speech-complexity regular. User simulator is the standard v1.0 pipeline with only its LLM swapped to gpt-5.5-2026-04-23 at reasoning_effort=xhigh; all other simulator components (TTS, transcription, decision models, audio pipeline) are unchanged. The four telecom infrastructure errors are counted as non-passes, so the denominator remains 114. Not directly comparable to standard-user-simulator leaderboard entries. A matched-simulator companion result under v1.0 (gpt-4.1) is submitted separately. User-side voices are local ElevenLabs personas created via the standard setup_voices script; not Sierra-managed submission voices.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard tau-voice agent prompt, user-simulator prompt, domain policies (data/tau2/domains/<domain>/policy.md), tool schemas, tool results, and evaluator are byte-identical to upstream -- no file in the tau-voice repo is modified. The agent additionally receives a prepended scaffold system message defining each agent's identity and role (real-time voice agent vs. background tool-calling agent), the responsibilities it owns, and how the two coordinate and share context. Sierra independently ran the full base splits: retail 114, airline 50, telecom 114; 1 trial per task at regular speech complexity; no task omitted. The four telecom infrastructure errors are retained as non-passes, preserving the 114-task denominator. User-side voices are local ElevenLabs personas from setup_voices (not Sierra-managed submission voices)."
+    }
+  },
+  "voice_config": {
+    "provider": "Pine AI",
+    "model": "pine-voice-preview",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "interaction_metrics": {
+    "version": "1.0",
+    "config": {
+      "tick_duration_sec": 0.2,
+      "no_yield_window_sec": 2.0,
+      "backchannel_yield_window_sec": 1.0,
+      "vocal_tic_yield_window_sec": 1.0,
+      "non_directed_yield_window_sec": 1.0,
+      "vocal_tic_response_window_sec": 2.0,
+      "non_directed_response_window_sec": 2.0
+    },
+    "domains": {
+      "airline": {
+        "response_latency_mean": 2.0630014858841017,
+        "yield_latency_mean": 1.2120000000000002,
+        "response_rate": 0.9505649717514124,
+        "yield_rate": 0.38699690402476783,
+        "agent_interruption_rate": 0.943502824858757,
+        "selectivity_backchannel": 0.9411764705882353,
+        "selectivity_vocal_tic": 0.4731182795698925,
+        "selectivity_non_directed": 0.38636363636363635,
+        "counts": {
+          "n_simulations": 50,
+          "response_total": 708,
+          "yield_total": 646,
+          "backchannel_total": 51,
+          "vocal_tic_total": 93,
+          "non_directed_total": 44,
+          "agent_interrupts_count": 668
+        }
+      },
+      "retail": {
+        "response_latency_mean": 2.034962962962963,
+        "yield_latency_mean": 1.2004310344827587,
+        "response_rate": 0.9440559440559441,
+        "yield_rate": 0.45048543689320386,
+        "agent_interruption_rate": 0.7867132867132867,
+        "selectivity_backchannel": 0.98989898989899,
+        "selectivity_vocal_tic": 0.5251396648044693,
+        "selectivity_non_directed": 0.40625,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 1430,
+          "yield_total": 1030,
+          "backchannel_total": 99,
+          "vocal_tic_total": 179,
+          "non_directed_total": 96,
+          "agent_interrupts_count": 1125
+        }
+      },
+      "telecom": {
+        "response_latency_mean": 1.904272863568215,
+        "yield_latency_mean": 1.1698945349952063,
+        "response_rate": 0.9424231720240198,
+        "yield_rate": 0.394776684330053,
+        "agent_interruption_rate": 0.5662310137760509,
+        "selectivity_backchannel": 0.9736842105263158,
+        "selectivity_vocal_tic": 0.6120092378752886,
+        "selectivity_non_directed": 0.41916167664670656,
+        "counts": {
+          "n_simulations": 110,
+          "response_total": 2831,
+          "yield_total": 2642,
+          "backchannel_total": 38,
+          "vocal_tic_total": 433,
+          "non_directed_total": 167,
+          "agent_interrupts_count": 1603
+        }
+      }
+    },
+    "overall": {
+      "response_latency_mean": 2.0007457708050933,
+      "yield_latency_mean": 1.1941085231593218,
+      "response_rate": 0.9456813626104589,
+      "yield_rate": 0.4107530084160082,
+      "agent_interruption_rate": 0.7654823751160316,
+      "selectivity_backchannel": 0.9682532236711804,
+      "selectivity_vocal_tic": 0.5367557274165501,
+      "selectivity_non_directed": 0.4039251043367809,
+      "counts": {
+        "agent_interrupts_count": 3396,
+        "backchannel_total": 188,
+        "n_simulations": 274,
+        "non_directed_total": 307,
+        "response_total": 4969,
+        "vocal_tic_total": 705,
+        "yield_total": 4318
+      }
+    }
+  },
+  "reasoning_effort": "enabled"
+}

--- a/web/leaderboard/public/submissions/pine-voice-preview-user-sim-v1-0_pineai_2026-08-17/submission.json
+++ b/web/leaderboard/public/submissions/pine-voice-preview-user-sim-v1-0_pineai_2026-08-17/submission.json
@@ -1,0 +1,147 @@
+{
+  "model_name": "Pine Voice Preview",
+  "model_organization": "Pine AI",
+  "submitting_organization": "Pine AI",
+  "submission_date": "2026-08-17",
+  "submission_type": "custom",
+  "modality": "voice",
+  "contact_info": {
+    "email": "arvinx@19pine.ai",
+    "name": "Arvin Xu",
+    "github": "a7vinx"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 70.17543859649122
+    },
+    "airline": {
+      "pass_1": 70.0
+    },
+    "telecom": {
+      "pass_1": 85.96491228070175
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_regular_openai_pine-voice-preview",
+    "retail": "retail_regular_openai_pine-voice-preview",
+    "telecom": "telecom_regular_openai_pine-voice-preview"
+  },
+  "references": [
+    {
+      "title": "Pine AI",
+      "url": "https://19pine.ai",
+      "type": "other"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-08-12",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "v1.0",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false,
+      "details": "Standard tau-voice agent prompt, user-simulator prompt, domain policies (data/tau2/domains/<domain>/policy.md), tool schemas, tool results, and evaluator are byte-identical to upstream -- no file in the tau-voice repo is modified. The agent additionally receives a prepended scaffold system message defining each agent's identity and role (real-time voice agent vs. background tool-calling agent), the responsibilities it owns, and how the two coordinate and share context. Sierra independently ran the full base splits: retail 114, airline 50, telecom 114; 1 trial per task at regular speech complexity; no task omitted. The single telecom infrastructure error is retained as a non-pass, preserving the 114-task denominator. User-side voices are local ElevenLabs personas from setup_voices (not Sierra-managed submission voices)."
+    },
+    "notes": "Custom submission from Pine AI, independently evaluated by Sierra. The agent is a two-agent system: (1) a voice agent handling real-time speech via a customized ASR -> LLM -> TTS pipeline coordinated by a custom interaction model that governs turn-taking, backchanneling, and other conversational dynamics; (2) a background agent (gemini-3.5-flash) that issues the tool calls for the operational task. The two agents share context.\nAll voice-side models are the same production models serving 19pine.ai -- not benchmark-trained. No files in this tau-voice repo are modified. On top of the standard tau-voice agent system prompt, Pine prepends an additional scaffold system message that defines each agent's identity and role (the real-time voice agent vs. the background tool-calling agent), the responsibilities each one owns, and how the two coordinate and share context.\nSierra independently evaluated the full base splits on all three domains (retail 114, airline 50, telecom 114), 1 trial per task, --speech-complexity regular. User simulator is the standard v1.0 pipeline (gpt-4.1). The single telecom infrastructure error is counted as a non-pass, so the denominator remains 114. User-side voices are local ElevenLabs personas created via the standard setup_voices script; not Sierra-managed submission voices.\nA companion independently evaluated result uses gpt-5.5-2026-04-23 at reasoning_effort=xhigh as the user-simulator LLM."
+  },
+  "voice_config": {
+    "provider": "Pine AI",
+    "model": "pine-voice-preview",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "interaction_metrics": {
+    "version": "1.0",
+    "config": {
+      "tick_duration_sec": 0.2,
+      "no_yield_window_sec": 2.0,
+      "backchannel_yield_window_sec": 1.0,
+      "vocal_tic_yield_window_sec": 1.0,
+      "non_directed_yield_window_sec": 1.0,
+      "vocal_tic_response_window_sec": 2.0,
+      "non_directed_response_window_sec": 2.0
+    },
+    "domains": {
+      "airline": {
+        "response_latency_mean": 2.1953232462173315,
+        "yield_latency_mean": 1.1394422310756973,
+        "response_rate": 0.920253164556962,
+        "yield_rate": 0.46395563770794823,
+        "agent_interruption_rate": 0.4835443037974684,
+        "selectivity_backchannel": 0.9803921568627451,
+        "selectivity_vocal_tic": 0.5263157894736843,
+        "selectivity_non_directed": 0.4117647058823529,
+        "counts": {
+          "n_simulations": 50,
+          "response_total": 790,
+          "yield_total": 541,
+          "backchannel_total": 51,
+          "vocal_tic_total": 95,
+          "non_directed_total": 34,
+          "agent_interrupts_count": 382
+        }
+      },
+      "retail": {
+        "response_latency_mean": 2.274142480211082,
+        "yield_latency_mean": 1.1258687258687259,
+        "response_rate": 0.9154589371980676,
+        "yield_rate": 0.49521988527724664,
+        "agent_interruption_rate": 0.4993961352657005,
+        "selectivity_backchannel": 0.9615384615384616,
+        "selectivity_vocal_tic": 0.5333333333333333,
+        "selectivity_non_directed": 0.5800000000000001,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 1656,
+          "yield_total": 1046,
+          "backchannel_total": 104,
+          "vocal_tic_total": 210,
+          "non_directed_total": 100,
+          "agent_interrupts_count": 827
+        }
+      },
+      "telecom": {
+        "response_latency_mean": 1.940700068634178,
+        "yield_latency_mean": 1.116380297823597,
+        "response_rate": 0.9448767833981842,
+        "yield_rate": 0.4045412418906395,
+        "agent_interruption_rate": 0.42347600518806744,
+        "selectivity_backchannel": 0.9701492537313433,
+        "selectivity_vocal_tic": 0.5377643504531722,
+        "selectivity_non_directed": 0.4840764331210191,
+        "counts": {
+          "n_simulations": 113,
+          "response_total": 3084,
+          "yield_total": 2158,
+          "backchannel_total": 67,
+          "vocal_tic_total": 331,
+          "non_directed_total": 157,
+          "agent_interrupts_count": 1306
+        }
+      }
+    },
+    "overall": {
+      "response_latency_mean": 2.1367219316875303,
+      "yield_latency_mean": 1.1272304182560067,
+      "response_rate": 0.9268629617177379,
+      "yield_rate": 0.4545722549586115,
+      "agent_interruption_rate": 0.4688054814170788,
+      "selectivity_backchannel": 0.97069329071085,
+      "selectivity_vocal_tic": 0.5324711577533966,
+      "selectivity_non_directed": 0.49194704633445735,
+      "counts": {
+        "agent_interrupts_count": 2515,
+        "backchannel_total": 222,
+        "n_simulations": 277,
+        "non_directed_total": 291,
+        "response_total": 5530,
+        "vocal_tic_total": 636,
+        "yield_total": 3745
+      }
+    }
+  },
+  "reasoning_effort": "enabled"
+}


### PR DESCRIPTION
## Summary

Adds two independently evaluated Pine Voice Preview submissions to the voice leaderboard:

- GPT-4.1 user simulator: retail 80/114 (70.18%), airline 35/50 (70.00%), telecom 98/114 (85.96%)
- GPT-5.5 xhigh user simulator: retail 97/114 (85.09%), airline 40/50 (80.00%), telecom 86/114 (75.44%)

Telecom uses the full 114-task denominator. Infrastructure failures are counted as non-passes: one for GPT-4.1 and four for GPT-5.5.

The trimmed trajectory and canonical-audio bundles were uploaded to the public tau-bench S3 bucket. Both submission records set trajectories_available to true and include the verified trajectory mappings and recomputed voice interaction metrics.

## Validation

- All 278 trajectories per submission passed format, task-coverage, and trial-count validation
- Both submission JSON files pass the repository Pydantic schema
- Public submission metadata and all six domain results files were fetched and parsed after upload
- Manifest validation and git diff --check pass

The generic metrics checker warns on telecom because it excludes infrastructure errors by default; the submitted rates intentionally retain those errors in the 114-task denominator.