### PR TITLE
Clarify standard submission boundaries for τ-voice

### DIFF
--- a/docs/leaderboard-submission.md
+++ b/docs/leaderboard-submission.md
@@ -30,23 +30,61 @@ The leaderboard distinguishes between two types of submissions:
 
 ### Standard Submissions (Default)
 
-Standard submissions evaluate a **general-purpose LLM** using the **default τ-bench scaffold**:
-- A general-purpose LLM as the agent (not specifically trained for this benchmark)
-- The standard tool set provided by τ-bench
-- Default prompts and evaluation protocol
-- No modifications to the evaluation setup
+Standard submissions use the documented default **benchmark-side evaluation
+setup** for their modality. The model or system being evaluated is treated as
+the product behind its agent interface; its internal implementation does not
+determine the submission type.
 
-If you're evaluating an off-the-shelf LLM using τ-bench as documented without modifications, your submission is **standard**. You don't need to specify `submission_type` in your JSON (it defaults to `"standard"`).
+All standard submissions use:
+
+- The standard task set, domain policies, tools, and evaluator
+- The default user simulator and evaluation protocol for the track
+- No benchmark-side prompt, tool, orchestration, task-selection, or grading
+  modifications
+- No access to hidden task goals, reference actions, evaluator state, or other
+  benchmark data outside the standard agent interface
+- A model or system that was not trained specifically on τ-bench tasks,
+  rewards, or evaluation data
+
+#### Text τ-bench
+
+A standard text submission evaluates a general-purpose LLM through the default
+τ-bench agent scaffold, with the standard tool set and prompts. Replacing or
+augmenting that benchmark-side scaffold with a planner, router, additional
+agent, custom tool, or modified control flow makes the submission custom.
+
+#### τ-voice
+
+A standard voice submission presents one τ-voice-compatible agent interface to
+the benchmark and uses the default τ-voice harness, prompts, domain policies,
+tool schemas and results, user simulator, task set, and evaluator.
+
+The voice system may use any internal product architecture behind that
+interface, including proprietary ASR and TTS, multiple models or agents,
+internal prompts and tools, routing, and orchestration. Those implementation
+details do **not** make the submission custom as long as they are contained
+inside the submitted system and require no benchmark-side evaluation changes.
+A transport or protocol adapter that only connects the system to the standard
+τ-voice agent interface is also allowed.
+
+If you're evaluating an off-the-shelf model or voice system through the
+appropriate standard interface without benchmark-side modifications, your
+submission is **standard**. You don't need to specify `submission_type` in your
+JSON (it defaults to `"standard"`).
 
 ### Custom Submissions
 
-Custom submissions include **any approach that differs from the standard evaluation**, such as:
+Custom submissions include **any approach that changes the benchmark-side
+evaluation setup**, such as:
 
 **Modified Scaffolds:**
-- Multi-model routers or model ensembles
+- Multi-model routers, model ensembles, or additional agents implemented by
+  the benchmark-side submission code
 - Additional tools beyond the standard τ-bench tool set
-- Modified agent orchestration or control flow
-- Modified prompts or system instructions
+- Modified τ-bench or τ-voice orchestration or control flow
+- Modified benchmark-supplied prompts or system instructions
+- A non-default user simulator, task selection, speech configuration, or
+  evaluation protocol
 
 **Domain-Specific Training:**
 - Models trained or fine-tuned specifically on τ-bench domains (airline, retail, telecom customer service)
@@ -58,7 +96,8 @@ Custom submissions **must** include detailed methodology documentation:
 1. **Set `submission_type` to `"custom"`** in your `submission.json`
 2. **Provide comprehensive `methodology.notes`** explaining what modifications were made, why, and how the custom system works at a high level
 3. **Link to your implementation** in the `references` array (GitHub repo, paper, blog post)
-4. **Set `methodology.verification.modified_prompts` to `true`** if you modified any prompts
+4. **Set `methodology.verification.modified_prompts` to `true`** if you
+   modified any benchmark-supplied prompts
 
 ---
 

--- a/src/tau2/scripts/leaderboard/submission.py
+++ b/src/tau2/scripts/leaderboard/submission.py
@@ -409,8 +409,11 @@ class Submission(BaseModelNoExtra):
     submission_date: date = Field(..., description="Date of submission")
     submission_type: Literal["standard", "custom"] = Field(
         "standard",
-        description="Type of submission: 'standard' uses the default tau2-bench scaffold, "
-        "'custom' uses modified scaffolds (multi-model routers, additional tools, custom prompting, etc.)",
+        description="Type of submission: 'standard' uses the default benchmark-side "
+        "tau2-bench or tau-voice evaluation setup; 'custom' modifies benchmark-side "
+        "prompts, tools, orchestration, user simulation, tasks, or evaluation. Internal "
+        "implementation behind one compatible agent interface does not alone make a "
+        "submission custom.",
     )
     modality: Literal["text", "voice"] = Field(
         "text",

--- a/web/leaderboard/public/submissions/schema.json
+++ b/web/leaderboard/public/submissions/schema.json
@@ -889,7 +889,7 @@
     },
     "submission_type": {
       "default": "standard",
-      "description": "Type of submission: 'standard' uses the default tau2-bench scaffold, 'custom' uses modified scaffolds (multi-model routers, additional tools, custom prompting, etc.)",
+      "description": "Type of submission: 'standard' uses the default benchmark-side tau2-bench or tau-voice evaluation setup; 'custom' modifies benchmark-side prompts, tools, orchestration, user simulation, tasks, or evaluation. Internal implementation behind one compatible agent interface does not alone make a submission custom.",
       "enum": [
         "standard",
         "custom"

--- a/web/leaderboard/src/components/Leaderboard.jsx
+++ b/web/leaderboard/src/components/Leaderboard.jsx
@@ -764,11 +764,11 @@ const Leaderboard = () => {
                   <h4>Submission Types</h4>
                   <div className="filter-info-item">
                     <strong>Standard</strong>
-                    <p>Results using the default τ-bench scaffold: a base LLM with the standard tool set and prompts.</p>
+                    <p>Results using the default benchmark-side τ-bench or τ-voice setup. A submitted system may use any internal architecture behind one compatible agent interface.</p>
                   </div>
                   <div className="filter-info-item">
                     <strong>Custom</strong>
-                    <p>Results using modified scaffolds, such as multi-model routers, additional tools, custom prompting strategies, or other orchestration approaches.</p>
+                    <p>Results that modify benchmark-side prompts, tools, orchestration, user simulation, tasks, or evaluation, or use benchmark-specific training or data.</p>
                   </div>
                   <div className="filter-info-item">
                     <strong>Legacy (v1)</strong>


### PR DESCRIPTION
## Summary

Clarifies that standard/custom classification is determined at the benchmark-side evaluation boundary, and documents separate criteria for text tau-bench and tau-voice.

For tau-voice, a system remains standard when it:

- Presents one tau-voice-compatible agent interface
- Uses the default benchmark-side harness, prompts, policies, tools, simulator, tasks, and evaluator
- Does not access hidden benchmark or evaluator data
- Is not trained specifically on tau-bench tasks or evaluation data

The evaluated product may use any internal architecture behind that interface, including proprietary ASR/TTS, multiple models or agents, internal prompts and tools, routing, and orchestration. Those internals do not alone make the submission custom.

A voice submission is custom when the benchmark-side setup changes, including modified prompts, tools, orchestration, simulator, task selection, speech configuration, or evaluation protocol.

## Changes

- Splits standard criteria into Text tau-bench and tau-voice sections
- Clarifies the internal-product versus benchmark-scaffold boundary
- Updates the leaderboard filter tooltip
- Updates the Pydantic field description and regenerated JSON schema

## Validation

- Generated schema is up to date
- Python module compilation passes
- Submission-type schema assertion passes
- git diff --check passes

make check-all could not run locally because Ruff is absent from the existing environment; leaderboard CI covers the web build and E2E checks.