### PR TITLE
fix(banking_knowledge): validate close_bank_account_7392 reason against a fixed set (unblocks tasks 065/068/069)

### DIFF
--- a/src/tau2/domains/banking_knowledge/tools.py
+++ b/src/tau2/domains/banking_knowledge/tools.py
@@ -2508,14 +2508,14 @@ For deposits without available images, the dispute will proceed based on custome
     def close_bank_account_7392(
         self,
         account_id: str,
-        reason: str = "Customer requested closure",
+        reason: str = "customer_request",
         waive_early_closure_fee: bool = False,
     ) -> str:
         """Close a customer's bank account (checking or savings).
 
         Args:
             account_id (string): The ID of the bank account to close
-            reason (string, optional): The reason for closing the account
+            reason (string, optional): The reason for closing the account. Must be one of: 'customer_request', 'simplifying_finances', 'moving_banks', 'fees_too_high', 'fraud_suspected', 'other'
             waive_early_closure_fee (boolean, optional): Whether to waive early closure fees
 
         Returns:
@@ -2547,6 +2547,18 @@ For deposits without available images, the dispute will proceed based on custome
 
         if not account_id:
             return "Error: Missing required parameter (account_id)."
+
+        # closure_reason enters the hashed DB state; free-form text breaks eval
+        valid_reasons = [
+            "customer_request",
+            "simplifying_finances",
+            "moving_banks",
+            "fees_too_high",
+            "fraud_suspected",
+            "other",
+        ]
+        if reason not in valid_reasons:
+            return f"Error: Invalid reason. Must be one of: {valid_reasons}"
 
         if account_id not in self.db.accounts.data:
             return f"Error: Account '{account_id}' not found."

--- a/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
+++ b/tests/test_domains/test_banking_knowledge/test_tools_knowledge.py
@@ -1571,6 +1571,38 @@ class TestCloseBankAccount:
         assert "Error" in resp.content
         assert "not found" in resp.content
 
+    def test_close_free_form_reason_rejected(self, environment: Environment):
+        environment.tools.db.accounts.data["chk_closed"]["status"] = "OPEN"
+        resp = call_discoverable_agent(
+            environment,
+            "close_bank_account_7392",
+            {
+                "account_id": "chk_closed",
+                "reason": "Customer requested Evergreen closure after splitting balance",
+            },
+        )
+        assert "Error" in resp.content
+        assert "Invalid reason" in resp.content
+        # account must stay untouched after a rejected call
+        assert environment.tools.db.accounts.data["chk_closed"]["status"] == "OPEN"
+
+    def test_close_enum_reason_accepted(self, environment: Environment):
+        environment.tools.db.accounts.data["chk_closed"]["status"] = "OPEN"
+        resp = call_discoverable_agent(
+            environment,
+            "close_bank_account_7392",
+            {
+                "account_id": "chk_closed",
+                "reason": "fraud_suspected",
+            },
+        )
+        assert not resp.error
+        assert "closed successfully" in resp.content
+        assert (
+            environment.tools.db.accounts.data["chk_closed"]["closure_reason"]
+            == "fraud_suspected"
+        )
+
 
 class TestTransferFundsBetweenAccounts:
     """Tests for transfer_funds_between_bank_accounts_7291."""


### PR DESCRIPTION
## Summary

While running `banking_knowledge` at scale on our side — 60+ runs across 6 retrieval configs plus a 10-trial × 3 frontier-model study, over a thousand simulations in total — we noticed that **tasks 065, 068 and 069 were never solved by any model**. We then checked the published leaderboard trajectories (27 submissions, v1.0.1 scorer): same picture — **0 successes in ~106 attempts on each of the three tasks**.

Digging into the failed trajectories, we found the cause.

## The bug

`close_bank_account_7392` accepts an **unconstrained, optional free-text `reason` with a default** (`"Customer requested closure"`), stores it on the account record, and that record is part of the hashed DB state compared by the env evaluator.

The gold trajectories for 065/068/069 leave the parameter at its default. An agent that puts the bank into **exactly the gold final state** but words the closure reason more specifically — e.g. `"Customer requested closure after transferring full balance to new Silver Plus Account"` — gets reward 0. In **17 of 90** failed attempts from our frontier-model study, the final bank state matches gold exactly and the *only* diverging field is the free-text `closure_reason`.

Every other `reason`-style parameter in the domain is effectively categorical and legitimately discriminating (`stolen` vs `lost` in T079/T077, `fraud_suspected`, `annual_fee`…), and `log_credit_card_closure_reason_4521` already **validates its `closure_reason` against a fixed set**. This tool is the one exception.

## The fix

Apply the same pattern as `log_credit_card_closure_reason_4521`:

- validate `reason` against a fixed set (`customer_request`, `simplifying_finances`, `moving_banks`, `fees_too_high`, `fraud_suspected`, `other`) and return an explicit error otherwise, so the agent is guided to a canonical value instead of being silently penalized;
- change the default from the sentence `"Customer requested closure"` to `customer_request`.

**Gold trajectories are unaffected**: no gold action sets this parameter and no fixture references the old default (checked across `tasks/`, `tasks.json`, `db.json`). Rejected calls leave the account untouched.

Tests added for both the rejection and the accepted-enum paths.

## Related

Fixes #485.

#463 reports the same class of issue ("loosely-specified write actions penalize semantically equivalent answers") on a different example (task_048); this PR fixes the concrete instance that blocks 065/068/069.

