### PR TITLE
Leaderboard: airline submissions — claude-sonnet-4-6 (standard) + cascade-governed-sonnet-4-6 (custom)

### DIFF
--- a/web/leaderboard/public/submissions/cascade-governed-sonnet-4-6_cascade-dynamics_2026-08-22/submission.json
+++ b/web/leaderboard/public/submissions/cascade-governed-sonnet-4-6_cascade-dynamics_2026-08-22/submission.json
@@ -1,0 +1,36 @@
+{
+  "model_name": "cascade-governed-sonnet-4-6",
+  "model_organization": "Cascade Dynamics",
+  "submitting_organization": "Cascade Dynamics",
+  "submission_date": "2026-08-22",
+  "submission_type": "custom",
+  "modality": "text",
+  "contact_info": {
+    "email": "info@cascadedynamics.ai",
+    "github": "dancinglumberjack"
+  },
+  "results": {
+    "airline": {
+      "pass_1": 87.0,
+      "pass_2": 85.0,
+      "pass_3": 83.5,
+      "pass_4": 82.0,
+      "cost": 0.23787799499999998
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_results.json"
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-22",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "claude-sonnet-4-6",
+    "notes": "Custom scaffold: Cascade Dynamics governance layer wrapping the stock llm_agent loop with the same underlying model (Anthropic claude-sonnet-4-6) as our companion standard submission. The wrapper deterministically checks each proposed write tool call against rules compiled from the domain's written policy; a violating call is intercepted BEFORE execution and the model receives the violated rule as policy feedback, then re-decides (bounded retries, fail-open on unverifiable facts). No benchmark prompts, tools, tasks, user simulator, or evaluator were modified; no training on tau-bench data. Audit log of all gate decisions retained. Purpose: same-model A/B of governed vs standard scaffold (Pass^4 0.820 vs 0.760). Implementation details available to maintainers on request. Avg cost per conversation USD 0.2379 from provider usage metadata at list pricing. Reference: https://cascadedynamics.ai/benchmarks.html",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/claude-sonnet-4-6_anthropic_2026-08-22/submission.json
+++ b/web/leaderboard/public/submissions/claude-sonnet-4-6_anthropic_2026-08-22/submission.json
@@ -1,0 +1,36 @@
+{
+  "model_name": "claude-sonnet-4-6",
+  "model_organization": "Anthropic",
+  "submitting_organization": "Cascade Dynamics",
+  "submission_date": "2026-08-22",
+  "submission_type": "standard",
+  "modality": "text",
+  "contact_info": {
+    "email": "info@cascadedynamics.ai",
+    "github": "dancinglumberjack"
+  },
+  "results": {
+    "airline": {
+      "pass_1": 82.5,
+      "pass_2": 79.33333333333333,
+      "pass_3": 77.5,
+      "pass_4": 76.0,
+      "cost": 0.25280352
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_results.json"
+  },
+  "methodology": {
+    "evaluation_date": "2026-08-22",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "claude-sonnet-4-6",
+    "notes": "Standard-scaffold control arm; run by Cascade Dynamics alongside a governed custom-track submission of the same model for comparison. Avg cost per conversation USD 0.2528 from provider usage metadata at list pricing.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -28,7 +28,9 @@
     "grok-4-5_sierra_2026-08-04",
     "inkling_sierra_2026-08-04",
     "claude-opus-5_sierra_2026-08-04",
-    "qwen3-8-max_sierra_2026-08-04"
+    "qwen3-8-max_sierra_2026-08-04",
+    "claude-sonnet-4-6_anthropic_2026-08-22",
+    "cascade-governed-sonnet-4-6_cascade-dynamics_2026-08-22"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",


### PR DESCRIPTION
Two airline-domain submissions from one controlled same-model comparison (50 tasks × 4 trials per arm, identical agent and user-simulator model: claude-sonnet-4-6, evaluated 2026-08-22 on tau2-bench v1.0.1+ grading).

## Results

| entry | track | Pass^1 | Pass^2 | Pass^3 | Pass^4 | $/conv |
|---|---|---|---|---|---|---|
| claude-sonnet-4-6 | standard | 82.5 | 79.3 | 77.5 | 76.0 | $0.2528 |
| cascade-governed-sonnet-4-6 | custom | 87.0 | 85.0 | 83.5 | 82.0 | $0.2379 |

## What the custom entry is

The governed entry wraps the stock `llm_agent` loop in a deterministic policy-gate layer compiled from the airline domain's written policy: each proposed write tool call is checked pre-execution against rules the policy itself notes the APIs do not enforce (cancellation eligibility, basic-economy modification, baggage math, payment-mix limits, compensation eligibility). A violating call is intercepted before execution and the model receives the violated rule as feedback, then re-decides (bounded retries; fail-open on unverifiable facts). No benchmark prompts, tools, tasks, user simulator, or evaluation protocol were modified; no model training on τ-bench data; `submission_type` is set to `custom` accordingly. A full audit log of gate decisions was retained. Additional implementation detail is available to maintainers on request.

## Trajectories

Full trajectory files for both entries (as produced by `tau2 submit prepare`; both pass `tau2 submit validate`): https://github.com/Cascade-Dynamics-AI/tau3-submission-artifacts

## Notes for review

- User simulator is claude-sonnet-4-6 (not the recommended gpt-5.2); reported in both submission.json files.
- Airline-only submissions per the single-domain provision in the submission guide; we expect to extend to further domains.
- Contact: info@cascadedynamics.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)