### PR TITLE
fix(metrics): keep all-infra-error tasks in pass^k denominator (#493)

### DIFF
--- a/src/tau2/metrics/agent_metrics.py
+++ b/src/tau2/metrics/agent_metrics.py
@@ -135,14 +135,21 @@ def get_metrics_df(results: Results) -> tuple[pd.DataFrame, int]:
     """
     df = results.to_df()
 
-    infra_count = (
-        df.termination_reason == TerminationReason.INFRASTRUCTURE_ERROR
-    ).sum()
+    # Compare against the enum value rather than the enum member: under
+    # pandas 3.x the str-Enum column is inferred as a string dtype, whose
+    # elements are the raw values (e.g. "infrastructure_error"), while
+    # str(Enum member) is "TerminationReason.INFRASTRUCTURE_ERROR", so
+    # comparing the column to the member never matches and infrastructure
+    # errors are silently kept.
+    infra_mask = (
+        df.termination_reason == TerminationReason.INFRASTRUCTURE_ERROR.value
+    )
+    infra_count = infra_mask.sum()
     if infra_count > 0:
         logger.warning(
             f"Excluding {infra_count} infrastructure error simulation(s) from metrics."
         )
-        df = df[df.termination_reason != TerminationReason.INFRASTRUCTURE_ERROR]
+        df = df[~infra_mask]
 
     if df.empty:
         df["success"] = pd.Series(dtype=bool)
@@ -170,6 +177,13 @@ def get_tasks_pass_hat_k(results: Results) -> pd.DataFrame:
     """
     Compute the pass^k for each k from 1 to the maximum number of trials.
     """
+    # Build task infos from the unfiltered data so that tasks for which every
+    # trial ended with an infrastructure error still appear in the index:
+    # such tasks have zero successful trials and must contribute pass^k = 0
+    # to the task-level average instead of vanishing from the denominator
+    # (which would inflate pass^k, e.g. reporting 100% from a single
+    # successful simulation).
+    df_all = results.to_df()
     df, max_k = get_metrics_df(results)
     if df.empty or max_k == 0:
         return pd.DataFrame()
@@ -186,8 +200,12 @@ def get_tasks_pass_hat_k(results: Results) -> pd.DataFrame:
         "task_num_user_actions",
         "task_num_actions",
     ]
-    df_task_infos = df.groupby("task_id").first()[task_columns]
+    df_task_infos = df_all.groupby("task_id").first()[task_columns]
     df_pass_hat_k = df_task_infos.join(df_pass_hat_k)
+    # All-infrastructure-error tasks have no pass^k values after the join;
+    # they had zero successful trials, so fill with 0.0.
+    pass_columns = [c for c in df_pass_hat_k.columns if c.startswith("pass^")]
+    df_pass_hat_k[pass_columns] = df_pass_hat_k[pass_columns].fillna(0.0)
     return df_pass_hat_k
 
 
@@ -244,9 +262,12 @@ def compute_metrics(results: Results) -> AgentMetrics:
             pass_hat_ks[k] = df_pass_hat_k[column].mean()
     avg_agent_cost = df.agent_cost.mean()
 
-    # Counts exclude infrastructure errors
+    # Simulation counts exclude infrastructure errors (they never ran), but
+    # the task count covers the full configured evaluation matrix: a task
+    # whose trials all hit infrastructure errors is still a task that was not
+    # passed, so it must not disappear from task-level denominators.
     total_simulations = len(evaluated_sims)
-    total_tasks = len(set(sim.task_id for sim in evaluated_sims))
+    total_tasks = len(set(sim.task_id for sim in results.simulations))
 
     # Action metrics
     total_read_actions = 0

--- a/tests/test_agent_metrics.py
+++ b/tests/test_agent_metrics.py
@@ -1,0 +1,136 @@
+"""Regression tests for infrastructure-error handling in agent metrics.
+
+Covers issue #493: tasks for which every trial ended with an
+INFRASTRUCTURE_ERROR used to vanish from the task-level denominator (and under
+pandas 3.x the infra-error filter itself silently never matched), so pass^k
+could be reported as 100% from a single successful simulation.
+"""
+
+import pytest
+
+from tau2.data_model.simulation import (
+    AgentInfo,
+    Info,
+    Results,
+    RewardInfo,
+    SimulationRun,
+    TerminationReason,
+    UserInfo,
+)
+from tau2.data_model.tasks import EvaluationCriteria, Task, UserScenario
+from tau2.environment.environment import EnvironmentInfo
+from tau2.metrics.agent_metrics import (
+    compute_metrics,
+    get_metrics_df,
+    get_tasks_pass_hat_k,
+)
+
+NOW = "2026-08-31T00:00:00"
+
+
+def _make_sim(sim_id, task_id, trial, termination, reward):
+    return SimulationRun(
+        id=sim_id,
+        task_id=task_id,
+        start_time=NOW,
+        end_time=NOW,
+        duration=1.0,
+        termination_reason=termination,
+        trial=trial,
+        reward_info=RewardInfo(reward=reward) if reward is not None else None,
+    )
+
+
+def _make_results(sims, num_trials=2, task_ids=("task_001", "task_002")):
+    info = Info(
+        git_commit="test",
+        num_trials=num_trials,
+        max_steps=10,
+        max_errors=5,
+        user_info=UserInfo(implementation="dummy_user"),
+        agent_info=AgentInfo(implementation="llm_agent"),
+        environment_info=EnvironmentInfo(domain_name="airline", policy=""),
+    )
+    tasks = [
+        Task(
+            id=task_id,
+            user_scenario=UserScenario(instructions=f"do {task_id}"),
+            evaluation_criteria=EvaluationCriteria(),
+        )
+        for task_id in task_ids
+    ]
+    return Results(info=info, tasks=tasks, simulations=sims)
+
+
+def _issue_493_results():
+    """The minimal example from issue #493: 2 tasks x 2 trials (4 slots).
+
+    task_001: trial 0 succeeds, trial 1 infra error
+    task_002: both trials infra error
+    """
+    sims = [
+        _make_sim("s1", "task_001", 0, TerminationReason.AGENT_STOP, 1.0),
+        _make_sim("s2", "task_001", 1, TerminationReason.INFRASTRUCTURE_ERROR, None),
+        _make_sim("s3", "task_002", 0, TerminationReason.INFRASTRUCTURE_ERROR, None),
+        _make_sim("s4", "task_002", 1, TerminationReason.INFRASTRUCTURE_ERROR, None),
+    ]
+    return _make_results(sims, num_trials=2)
+
+
+def test_infra_errors_are_filtered_from_metrics_df():
+    """The infra-error filter must actually match under pandas 2.x/3.x."""
+    results = _issue_493_results()
+    df, _ = get_metrics_df(results)
+    assert len(df) == 1
+    assert (
+        df.termination_reason != TerminationReason.INFRASTRUCTURE_ERROR.value
+    ).all()
+
+
+def test_all_infra_task_stays_in_pass_hat_k_denominator():
+    """A task whose trials all hit infra errors must contribute pass^k = 0."""
+    results = _issue_493_results()
+    df_pk = get_tasks_pass_hat_k(results)
+    assert set(df_pk.index) == {"task_001", "task_002"}
+    assert df_pk.loc["task_001", "pass^1"] == pytest.approx(1.0)
+    assert df_pk.loc["task_002", "pass^1"] == pytest.approx(0.0)
+
+
+def test_pass_hat_1_not_inflated_to_100_percent():
+    """4 slots with a single success must not report pass^1 = 1.0."""
+    results = _issue_493_results()
+    metrics = compute_metrics(results)
+    assert metrics.infra_error_count == 3
+    assert metrics.total_simulations == 1
+    assert metrics.total_tasks == 2
+    assert metrics.pass_hat_ks[1] == pytest.approx(0.5)
+
+
+def test_all_infra_simulations_yield_empty_pass_hat_k():
+    """If every simulation is an infra error, no pass^k is reported."""
+    sims = [
+        _make_sim("s1", "task_001", 0, TerminationReason.INFRASTRUCTURE_ERROR, None),
+        _make_sim("s2", "task_001", 1, TerminationReason.INFRASTRUCTURE_ERROR, None),
+    ]
+    results = _make_results(sims, num_trials=2, task_ids=("task_001",))
+    metrics = compute_metrics(results)
+    assert metrics.infra_error_count == 2
+    assert metrics.pass_hat_ks == {}
+
+
+def test_metrics_unchanged_without_infra_errors():
+    """Normal runs (no infra errors) keep their previous pass^k values."""
+    sims = [
+        _make_sim("s1", "task_001", 0, TerminationReason.AGENT_STOP, 1.0),
+        _make_sim("s2", "task_001", 1, TerminationReason.AGENT_STOP, 0.0),
+        _make_sim("s3", "task_002", 0, TerminationReason.AGENT_STOP, 0.0),
+        _make_sim("s4", "task_002", 1, TerminationReason.AGENT_STOP, 0.0),
+    ]
+    results = _make_results(sims, num_trials=2)
+    metrics = compute_metrics(results)
+    assert metrics.infra_error_count == 0
+    assert metrics.total_simulations == 4
+    assert metrics.total_tasks == 2
+    # task_001: 1 success of 2 trials -> pass^1 = C(1,1)/C(2,1) = 0.5
+    # task_002: 0 successes -> 0.0; mean = 0.25
+    assert metrics.pass_hat_ks[1] == pytest.approx(0.25)


### PR DESCRIPTION
## Summary

Fixes #493.

Two related problems made `pass^k` unreliable when simulations terminated with `INFRASTRUCTURE_ERROR`:

1. **The infra-error filter silently never matched under pandas 3.x.** `get_metrics_df()` compared the `termination_reason` column against the `TerminationReason` enum *member*. pandas 3 infers the str-Enum column as string dtype (elements are the raw values, e.g. `"infrastructure_error"`), while `str(member)` is `"TerminationReason.INFRASTRUCTURE_ERROR"`, so the comparison was all-`False`: no rows were ever excluded and the exclusion warning never fired. (On pandas 2.x the column stays object dtype and the comparison works, which is why the issue's reported symptom — tasks vanishing from the denominator — appeared there.) The comparison now uses the enum's `.value`.

2. **All-infra-error tasks vanished from the task-level denominator.** After exclusion, `get_tasks_pass_hat_k()` grouped only the remaining simulations, so a task whose trials *all* hit infra errors produced no group and dropped out of the `pass^k` average — letting 1 successful simulation among 4 slots report `pass^1 = 1.0` (100%). Task infos are now built from the unfiltered data, and all-infra tasks are reindexed with `pass^k = 0.0` (zero successful trials). `total_tasks` in `compute_metrics()` likewise covers the full configured matrix.

`avg_reward` is intentionally left as the mean over simulations that actually produced a reward (infra-error simulations have none); `total_simulations` still counts only simulations that ran. Happy to adjust if maintainers prefer different semantics.

## Reproduction (issue's minimal example)

2 tasks × 2 trials: task_001 trial 0 succeeds (reward 1), trial 1 infra error; task_002 both trials infra errors.

| | Before (pandas 3) | Before (pandas 2, per issue) | After |
|---|---|---|---|
| infra exclusion warning | never fires | fires | fires |
| `pass^1` | 0.25 (filter broken; infra rows counted as failures) | **1.0 (inflated)** | **0.5** |
| `total_tasks` | 1 | 1 | **2** |

## Testing

- New `tests/test_agent_metrics.py` (5 tests): the issue's minimal example (`pass^1 = 0.5`, `total_tasks = 2`, `infra_error_count = 3`), the filter actually matching under pandas 3, all-infra runs yielding no `pass^k`, and unchanged values for runs without infra errors.
- Fails 3/5 on the unpatched code, passes after the fix.
- Full `tests/test_agent_metrics.py` + `tests/test_results_format.py`: 46 passed.
