### PR TITLE
fix(orchestrator): make the /{env_id}/set_state endpoint callable again

### DIFF
--- a/src/tau2/orchestrator/environment_manager.py
+++ b/src/tau2/orchestrator/environment_manager.py
@@ -25,6 +25,7 @@ class EnvironmentResponse(BaseModel):
 
 
 class SetStateRequest(BaseModel):
+    initialization_data: Optional[InitializationData] = None
     actions: list[Action]
     message_history: list[Message]
 
@@ -152,7 +153,12 @@ class EnvironmentManager:
 
         @self.app.post("/{env_id}/set_state")
         async def set_state(env_id: str, request: SetStateRequest) -> StatusResponse:
-            self.set_environment_state(env_id, request.actions, request.message_history)
+            self.set_environment_state(
+                env_id,
+                request.initialization_data,
+                request.actions,
+                request.message_history,
+            )
             return StatusResponse(status="success")
 
         @self.app.post("/{env_id}/stop_environment")
@@ -202,7 +208,7 @@ class EnvironmentManager:
     def set_environment_state(
         self,
         env_id: str,
-        initialization_data: InitializationData,
+        initialization_data: Optional[InitializationData],
         initialization_actions: list[EnvFunctionCall],
         message_history: list[tuple[str, Message]],
     ):


### PR DESCRIPTION
### Problem

`POST /{env_id}/set_state` on the `EnvironmentManager` server cannot succeed — the handler
raises `TypeError` before it touches the environment.

```python
# src/tau2/orchestrator/environment_manager.py:154
@self.app.post("/{env_id}/set_state")
async def set_state(env_id: str, request: SetStateRequest) -> StatusResponse:
    self.set_environment_state(env_id, request.actions, request.message_history)
    return StatusResponse(status="success")
```

```python
# src/tau2/orchestrator/environment_manager.py:202
def set_environment_state(
    self,
    env_id: str,
    initialization_data: InitializationData,
    initialization_actions: list[EnvFunctionCall],
    message_history: list[tuple[str, Message]],
):
```

Three arguments are supplied where four are required, so:
`TypeError: set_environment_state() missing 1 required positional argument: 'message_history'`.
Note that the arguments are also shifted by one — `request.actions` would land in
`initialization_data` and `request.message_history` in `initialization_actions` — so this is not
a "just append one more argument" slip; the call is off by a whole parameter.

The root cause is that `SetStateRequest` has no way to express `initialization_data` at all:

```python
# src/tau2/orchestrator/environment_manager.py:27
class SetStateRequest(BaseModel):
    actions: list[Action]
    message_history: list[Message]
```

even though `InitializationData` is already imported in this module (L8) purely for the
`set_environment_state` annotation, and the underlying environment method accepts it:

```python
# src/tau2/environment/environment.py:293
def set_state(
    self,
    initialization_data: Optional[InitializationData],
    initialization_actions: Optional[list[EnvFunctionCall]],
    message_history: list[Message],
    strict: bool = True,
):
```

### Fix

* `SetStateRequest` gains `initialization_data: Optional[InitializationData] = None`.
  It is optional with a `None` default, so **existing request bodies keep working unchanged** —
  they simply get the `None` that the code was already (incorrectly) trying to express.
* The handler passes all four arguments in the right order.
* `set_environment_state`'s annotation for `initialization_data` becomes
  `Optional[InitializationData]`, matching `Environment.set_state`, which is what actually
  receives it.

### Verification

The defect is a signature mismatch, so it needs no running server to demonstrate. I extracted
`EnvironmentManager.set_environment_state`'s signature from `main` (`a2c0247`) via AST and bound
both call shapes with `inspect.Signature.bind`:

```
EnvironmentManager.set_environment_state (self, env_id, initialization_data, initialization_actions, message_history)
   TypeError route /{env_id}/set_state  L155 (current) -> missing a required argument: 'message_history'
   OK        this PR                    L156 (fixed)
```

`ruff format --line-length 88` reports the patched file as already formatted.

If you would rather not touch the request schema, the smaller alternative is to pass a literal
`None` for `initialization_data` at the call site — happy to switch to that. I went with the
optional field because the endpoint otherwise has no way to reach a capability the manager and
`Environment.set_state` both already support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
