### PR TITLE
refactor: replace multiprocessing.Lock with threading.Lock in checkpointing

### DIFF
--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -11,7 +11,6 @@ execute them.
 import asyncio
 import asyncio.base_events
 import json
-import multiprocessing
 import os
 import random
 import threading
@@ -756,7 +755,7 @@ def prepare_batch(
     if config.llm_args_user and "seed" in config.llm_args_user:
         logger.warning("Each trial will modify the seed for the user")
 
-    lock = multiprocessing.Lock()
+    lock = threading.Lock()
 
     # Create run-level voice settings and persona config for voice mode
     user_voice_settings, user_persona_config = make_voice_run_settings(config)

--- a/src/tau2/runner/checkpoint.py
+++ b/src/tau2/runner/checkpoint.py
@@ -14,8 +14,9 @@ import json
 import multiprocessing
 import os
 import tempfile
+import threading
 from pathlib import Path
-from typing import Callable, Literal, Optional
+from typing import Callable, Literal, Optional, Union
 
 from loguru import logger
 
@@ -226,7 +227,7 @@ def try_resume(
 
 def create_checkpoint_fns(
     save_path: Optional[Path],
-    lock: multiprocessing.Lock,
+    lock: threading.Lock,
 ) -> tuple[Callable, Callable]:
     """Create thread-safe checkpoint save and replace functions.
 
@@ -236,7 +237,7 @@ def create_checkpoint_fns(
 
     Args:
         save_path: Path to the results JSON file. If None, returns no-ops.
-        lock: Multiprocessing lock for thread safety.
+        lock: Threading lock for thread safety.
 
     Returns:
         Tuple of (save_fn, replace_fn).
@@ -412,7 +413,7 @@ def create_checkpoint_fns(
 # Backward-compatible wrappers (used by external code or older call sites)
 def create_checkpoint_saver(
     save_path: Optional[Path],
-    lock: multiprocessing.Lock,
+    lock: Union[threading.Lock, multiprocessing.Lock],
 ) -> Callable:
     """Create a thread-safe checkpoint save function.
 
@@ -424,7 +425,7 @@ def create_checkpoint_saver(
 
 def create_checkpoint_replacer(
     save_path: Optional[Path],
-    lock: multiprocessing.Lock,
+    lock: Union[threading.Lock, multiprocessing.Lock],
 ) -> Callable:
     """Create a thread-safe checkpoint replace function.
 


### PR DESCRIPTION
## Summary
Replaces `multiprocessing.Lock` with `threading.Lock` in `prepare_batch()` and related checkpoint functions. `multiprocessing.Lock` allocates IPC semaphores that are unnecessary because checkpointing never crosses process boundaries: 
local execution runs in a single process via `ThreadPoolExecutor`, and worker processes return results to the controller over HTTP where checkpoints are written within the controller process using its own `threading.Lock`.

## Changes Made
- Replaced `multiprocessing.Lock()` with `threading.Lock()` in `prepare_batch()` (`src/tau2/runner/batch.py`).
- Updated `create_checkpoint_fns` signature and docstring in `src/tau2/runner/checkpoint.py` to reference `threading.Lock`.
- Updated backward-compatible wrappers (`create_checkpoint_saver`, `create_checkpoint_replacer`) to accept `Union[threading.Lock, multiprocessing.Lock]`.
- Removed unused `multiprocessing` import from `batch.py`.
- No breaking changes or new dependencies introduced.

## Testing
- Ran core test suites via `uv run pytest tests/test_checkpoint.py tests/test_run.py tests/test_agent.py tests/test_orchestrator.py -v` (39 passed, 1 xpassed).

## Documentation
- Updated docstring in `create_checkpoint_fns` to accurately reflect `threading.Lock` instead of multiprocessing lock.

## Checklist
- [x] Tests pass (`make test`; also run relevant tier targets if changes touch voice/knowledge/gym)
- [x] Code follows style guidelines (`make check-all`)
- [x] Documentation updated
- [x] Breaking changes noted (none)