### PR TITLE
feat: report simulation results to Trajectory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "requests>=2.31.0",
     "numpy>=1.24.0",
     "httpx>=0.24.0",
+    "trajectory-sdk>=0.6.2,<0.7",
 ]
 
 [project.optional-dependencies]

--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -802,6 +802,26 @@ def run_tasks(
                     except Exception:
                         pass
 
+            trajectory_id = os.environ.get("TRAJECTORY_ID")
+            if trajectory_id:
+                from trajectory import Client
+
+                trajectories = Client().trajectories
+                trajectories.log_event(
+                    trajectory_id,
+                    event_id=result.id,
+                    name="tau2.simulation.completed",
+                    payload=result.model_dump(mode="json"),
+                )
+                if result.reward_info is not None:
+                    trajectories.log_reward(
+                        trajectory_id,
+                        reward_id=result.id,
+                        name="tau2.reward",
+                        value=result.reward_info.reward,
+                    )
+                trajectories.complete(trajectory_id)
+
             return result
         finally:
             monitor.task_finished(task_key)

--- a/uv.lock
+++ b/uv.lock
@@ -1834,6 +1834,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2741,7 +2750,7 @@ wheels = [
 
 [[package]]
 name = "tau2"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },
@@ -2761,6 +2770,7 @@ dependencies = [
     { name = "tabulate" },
     { name = "tenacity" },
     { name = "toml" },
+    { name = "trajectory-sdk" },
     { name = "typer" },
     { name = "uvicorn" },
 ]
@@ -2882,6 +2892,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tqdm", marker = "extra == 'voice'", specifier = ">=4.0" },
+    { name = "trajectory-sdk", specifier = ">=0.6.2,<0.7" },
     { name = "typer", specifier = ">=0.12.5" },
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "websockets", marker = "extra == 'voice'", specifier = ">=13.0" },
@@ -2983,6 +2994,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "trajectory-sdk"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pathspec" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/7d/f3faffbb67eb65596f15f41485fa578523f34f617cfc341bf1cd2088da57/trajectory_sdk-0.6.2.tar.gz", hash = "sha256:a2bfafdfead5048e587083b091c2625f001b944d36f9f7d473e2588a2563f3d2", size = 105979, upload-time = "2026-09-04T05:33:02.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/8b/ab8afe4c4c19044624d8ded107eacb382df0921b8483acf3c983286ac738/trajectory_sdk-0.6.2-py3-none-any.whl", hash = "sha256:13ebaf5422743ed828a212f029f50653d5412078526e560ab036db2a87e8202d", size = 187848, upload-time = "2026-09-04T05:33:00.617Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds minimal Trajectory SDK reporting at the final simulation boundary.

When `TRAJECTORY_ID` is set, τ-bench now:
- logs the completed simulation as an event
- logs the evaluated reward
- marks the trajectory complete

Also adds `trajectory-sdk>=0.6.2,<0.7` as a dependency.

Validation:
- changed-file Ruff lint and format checks pass
- requested banking smoke command completes via its existing successful checkpoint (reward 1.0)