### PR TITLE
leaderboard: Leaderboards menu and banner pointing to τ^τ-bench

### DIFF
--- a/web/leaderboard/e2e/routing.spec.js
+++ b/web/leaderboard/e2e/routing.spec.js
@@ -155,6 +155,21 @@ test('Leaderboards menu lists every track and opens/closes', async ({ page }) =>
   await expect(menu).toBeHidden()
 })
 
+test('Leaderboards menu closes on browser back/forward', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Leaderboards' }).click()
+  await page.getByRole('menuitem', { name: /τ³-Voice/ }).click()
+  await expect(page).toHaveURL(/\/leaderboard\?benchmark=voice/)
+
+  const trigger = page.getByRole('button', { name: 'Leaderboards' })
+  await trigger.click()
+  await expect(page.getByRole('menu', { name: 'Leaderboards' })).toBeVisible()
+  await page.goBack()
+  await expect(page).toHaveURL(/\/(\?.*)?$/)
+  await expect(page.getByRole('menu', { name: 'Leaderboards' })).toBeHidden()
+  await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+})
+
 test('Leaderboards menu switches benchmark while already on the leaderboard', async ({ page }) => {
   await page.goto('/leaderboard?benchmark=core')
   await expect(page.getByRole('heading', { name: 'τ²-bench Leaderboard' })).toBeVisible()

--- a/web/leaderboard/e2e/routing.spec.js
+++ b/web/leaderboard/e2e/routing.spec.js
@@ -1,6 +1,7 @@
 // Routing + prerendering behavior tests. Run against the prerendered dist/
 // served with GitHub Pages semantics (see playwright.config.js).
 import { expect, test } from '@playwright/test'
+import { HYPER_TAU_URL, LEADERBOARD_MENU } from '../src/routes.js'
 
 // ---------------------------------------------------------------------------
 // Direct loads: every route serves a real page with its own title and content.
@@ -109,7 +110,8 @@ test('nav from /progress back to /leaderboard scrolls to top and keeps params', 
   // Wait for the auto-scroll down to the progress section to happen.
   await page.waitForFunction(() => window.scrollY > 0)
 
-  await page.getByRole('button', { name: 'Leaderboard' }).click()
+  await page.getByRole('button', { name: 'Leaderboards' }).click()
+  await page.getByRole('menuitem', { name: /τ³-Voice/ }).click()
   await expect(page).toHaveURL(/\/leaderboard\?benchmark=voice/)
   await page.waitForFunction(() => window.scrollY === 0)
   await expect(page.getByRole('heading', { name: 'τ³-Voice Leaderboard' })).toBeVisible()
@@ -117,13 +119,65 @@ test('nav from /progress back to /leaderboard scrolls to top and keeps params', 
 
 test('nav links update path and title', async ({ page }) => {
   await page.goto('/')
-  await page.getByRole('button', { name: 'Leaderboard' }).click()
-  await expect(page).toHaveURL(/\/leaderboard/)
+  await page.getByRole('button', { name: 'Leaderboards' }).click()
+  await page.getByRole('menuitem', { name: /τ³-Banking/ }).click()
+  await expect(page).toHaveURL(/\/leaderboard\?benchmark=knowledge/)
   await expect(page).toHaveTitle(/Leaderboard — τ-bench/)
 
   await page.getByRole('button', { name: 'Overview' }).click()
   await expect(page).toHaveURL(/\/(\?.*)?$/)
   await expect(page).toHaveTitle(/τ-bench — Benchmarking AI Agents/)
+})
+
+// ---------------------------------------------------------------------------
+// Leaderboards menu and the τ^τ-bench pointers.
+// ---------------------------------------------------------------------------
+
+test('Leaderboards menu lists every track and opens/closes', async ({ page }) => {
+  await page.goto('/')
+  const menu = page.getByRole('menu', { name: 'Leaderboards' })
+  await expect(menu).toBeHidden()
+
+  const trigger = page.getByRole('button', { name: 'Leaderboards' })
+  await trigger.click()
+  await expect(menu).toBeVisible()
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+  await expect(menu.getByRole('menuitem')).toHaveCount(LEADERBOARD_MENU.length)
+  for (const item of LEADERBOARD_MENU) {
+    await expect(menu.getByRole('menuitem', { name: new RegExp(item.label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')) })).toBeVisible()
+  }
+
+  await page.keyboard.press('Escape')
+  await expect(menu).toBeHidden()
+
+  await trigger.click()
+  await page.locator('.hero-description').click()
+  await expect(menu).toBeHidden()
+})
+
+test('Leaderboards menu switches benchmark while already on the leaderboard', async ({ page }) => {
+  await page.goto('/leaderboard?benchmark=core')
+  await expect(page.getByRole('heading', { name: 'τ²-bench Leaderboard' })).toBeVisible()
+  await page.getByRole('button', { name: 'Leaderboards' }).click()
+  await page.getByRole('menuitem', { name: /τ³-Voice/ }).click()
+  await expect(page).toHaveURL(/\/leaderboard\?benchmark=voice/)
+  await expect(page.getByRole('heading', { name: 'τ³-Voice Leaderboard' })).toBeVisible()
+})
+
+test('τ^τ-bench entry opens the hyper-tau-bench site in a new tab', async ({ page }) => {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Leaderboards' }).click()
+  const hyper = page.getByRole('menuitem', { name: /τ\^τ-bench/ })
+  await expect(hyper).toHaveAttribute('href', HYPER_TAU_URL)
+  await expect(hyper).toHaveAttribute('target', '_blank')
+  await expect(hyper).toContainText('New')
+})
+
+test('announcement banner points at τ^τ-bench', async ({ page }) => {
+  await page.goto('/')
+  const banner = page.locator('.update-notification')
+  await expect(banner).toContainText('-bench is here')
+  await expect(banner.locator('.notification-link')).toHaveAttribute('href', HYPER_TAU_URL)
 })
 
 // ---------------------------------------------------------------------------

--- a/web/leaderboard/playwright.config.js
+++ b/web/leaderboard/playwright.config.js
@@ -3,19 +3,22 @@ import { defineConfig } from '@playwright/test'
 // E2E tests for routing + prerendering. They run against the *built and
 // prerendered* dist/ served with GitHub Pages semantics (no SPA rewrites,
 // 404.html for unknown paths) — `npm run build && npm run prerender` first.
+// PORT lets a local run sidestep a busy 4173 (the default matches `npm run serve:dist`).
+const PORT = Number(process.env.PORT || 4173)
+
 export default defineConfig({
   testDir: './e2e',
   timeout: 30000,
   retries: process.env.CI ? 1 : 0,
   use: {
-    baseURL: 'http://127.0.0.1:4173',
+    baseURL: `http://127.0.0.1:${PORT}`,
     // Use the system Chrome instead of downloading a Playwright browser;
     // it's preinstalled on GitHub runners and dev machines alike.
     channel: 'chrome',
   },
   webServer: {
     command: 'node scripts/prerender.mjs --serve',
-    port: 4173,
+    port: PORT,
     reuseExistingServer: !process.env.CI,
   },
 })

--- a/web/leaderboard/src/App.css
+++ b/web/leaderboard/src/App.css
@@ -122,7 +122,7 @@ body {
   display: none;
 }
 
-.nav-links a {
+.nav-links > a {
   text-decoration: none;
   color: #718096;
   font-weight: 500;
@@ -130,7 +130,7 @@ body {
   transition: color 0.2s ease;
 }
 
-.nav-links a:hover {
+.nav-links > a:hover {
   color: #065f46;
 }
 
@@ -188,6 +188,122 @@ body {
 .nav-cta:hover {
   background: #047857;
   transform: translateY(-1px);
+}
+
+/* Leaderboards menu in the nav */
+.nav-dropdown {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.nav-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.nav-dropdown-chevron {
+  width: 6px;
+  height: 6px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: translateY(-2px) rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.nav-dropdown.open .nav-dropdown-chevron {
+  transform: translateY(1px) rotate(-135deg);
+}
+
+.nav-dropdown-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 14px);
+  left: 50%;
+  transform: translateX(-50%);
+  min-width: 260px;
+  padding: 6px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+  z-index: 1001;
+}
+
+.nav-dropdown.open .nav-dropdown-menu {
+  display: flex;
+  flex-direction: column;
+}
+
+.nav-dropdown-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s ease;
+}
+
+.nav-dropdown-item:hover,
+.nav-dropdown-item:focus-visible {
+  background: #f0fdf4;
+  outline: none;
+}
+
+.nav-dropdown-item-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #1f2937;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.nav-dropdown-item-name sup {
+  font-size: 0.7em;
+  line-height: 0;
+}
+
+.nav-dropdown-item:hover .nav-dropdown-item-label {
+  color: #065f46;
+}
+
+.nav-dropdown-item-note {
+  color: #718096;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.nav-dropdown-item.external {
+  margin-top: 4px;
+  border-top: 1px solid #f1f5f9;
+  border-radius: 0 0 8px 8px;
+  padding-top: 12px;
+}
+
+.nav-dropdown-badge {
+  background: #065f46;
+  color: white;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.nav-dropdown-external {
+  color: #94a3b8;
+  font-size: 12px;
 }
 
 /* Update Notification */
@@ -978,15 +1094,40 @@ body {
   }
   
   .nav-links .nav-link,
-  .nav-links a {
+  .nav-links > a {
     padding: 16px 24px;
     text-align: center;
     border-bottom: 1px solid #f7fafc;
   }
   
   .nav-links .nav-link:last-child,
-  .nav-links a:last-child {
+  .nav-links > a:last-child {
     border-bottom: none;
+  }
+
+  .nav-dropdown {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nav-dropdown-trigger {
+    justify-content: center;
+  }
+
+  .nav-dropdown-menu {
+    position: static;
+    transform: none;
+    min-width: 0;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    background: #f8fafc;
+    padding: 4px 16px 8px;
+  }
+
+  .nav-dropdown-item {
+    align-items: center;
+    text-align: center;
   }
   
   .mobile-menu-toggle {
@@ -1141,24 +1282,13 @@ body {
   }
   
   .nav-links .nav-link,
-  .nav-links a {
+  .nav-links > a {
     padding: 0 !important;
     border: none !important;
   }
   
   .mobile-menu-toggle {
     display: none !important;
-  }
-  
-  /* Desktop dropdown overrides */
-  .nav-dropdown-menu {
-    position: absolute !important;
-    display: block !important;
-  }
-  
-  .nav-dropdown-menu a {
-    padding: 12px 16px !important;
-    text-align: left !important;
   }
 }
 

--- a/web/leaderboard/src/App.jsx
+++ b/web/leaderboard/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import './App.css'
-import { getViewFromPath, PAGE_META, SITE_ORIGIN, VIEW_PATHS } from './routes'
+import { getViewFromPath, HYPER_TAU_URL, LEADERBOARD_MENU, PAGE_META, SITE_ORIGIN, VIEW_PATHS } from './routes'
 import TrajectoryVisualizer from './components/TrajectoryVisualizer'
 import Leaderboard from './components/Leaderboard'
 import LeaderboardPreview from './components/LeaderboardPreview'
@@ -29,10 +29,28 @@ const applyPageMeta = (view) => {
   setHeadContent('meta[name="twitter:description"]', 'content', meta.description)
 }
 
+// Benchmark names use a caret for a superscript in plain text ("τ^τ-bench");
+// render it as one. Menu data stays JSX-free so the prerender script can
+// import it.
+const renderBenchName = (label) => {
+  const caret = label.indexOf('^')
+  if (caret === -1) return label
+  const rest = label.slice(caret + 1)
+  const supEnd = rest.search(/[^a-zA-Zα-ωΑ-Ω0-9]/)
+  const sup = supEnd === -1 ? rest : rest.slice(0, supEnd)
+  const tail = supEnd === -1 ? '' : rest.slice(supEnd)
+  return (
+    <>
+      {label.slice(0, caret)}<sup>{sup}</sup>{tail}
+    </>
+  )
+}
+
 function App() {
 
   const [currentView, setCurrentView] = useState(() => getViewFromPath(window.location.pathname))
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [leaderboardsOpen, setLeaderboardsOpen] = useState(false)
 
   // Handle navigation with URL updates
   const navigateTo = (view) => {
@@ -60,7 +78,12 @@ function App() {
   const navigateToUrl = (url) => {
     window.history.pushState(null, '', url)
     setCurrentView(getViewFromPath(new URL(url, window.location.origin).pathname))
+    // Views that keep state in the query string (the leaderboard's
+    // ?benchmark=…) re-read it on popstate; fire one so switching benchmarks
+    // from the nav menu works while that view is already mounted.
+    window.dispatchEvent(new PopStateEvent('popstate'))
     setMobileMenuOpen(false)
+    setLeaderboardsOpen(false)
     window.scrollTo(0, 0)
   }
 
@@ -102,16 +125,23 @@ function App() {
       scrollToSectionForPath(window.location.pathname)
     }
 
-    // Close mobile menu when clicking outside
+    // Close mobile menu when clicking outside; same for the Leaderboards menu.
     const handleClickOutside = (event) => {
       if (mobileMenuOpen && !event.target.closest('.nav-container')) {
         setMobileMenuOpen(false)
       }
+      if (leaderboardsOpen && !event.target.closest('.nav-dropdown')) {
+        setLeaderboardsOpen(false)
+      }
+    }
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') setLeaderboardsOpen(false)
     }
 
     // Listen to events
     window.addEventListener('popstate', handlePopState)
     document.addEventListener('click', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
 
     // Honor an initial deep-link like /progress on first paint.
     scrollToSectionForPath(window.location.pathname)
@@ -119,8 +149,9 @@ function App() {
     return () => {
       window.removeEventListener('popstate', handlePopState)
       document.removeEventListener('click', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [mobileMenuOpen])
+  }, [mobileMenuOpen, leaderboardsOpen])
 
   return (
     <div className="App">
@@ -144,7 +175,54 @@ function App() {
           </button>
           <div className={`nav-links ${mobileMenuOpen ? '' : 'mobile-hidden'}`}>
             <button onClick={() => navigateTo('home')} className={`nav-link ${currentView === 'home' ? 'active' : ''}`}>Overview</button>
-            <button onClick={() => navigateTo('leaderboard')} className={`nav-link ${currentView === 'leaderboard' ? 'active' : ''}`}>Leaderboard</button>
+            <div className={`nav-dropdown ${leaderboardsOpen ? 'open' : ''}`}>
+              <button
+                type="button"
+                onClick={() => setLeaderboardsOpen((open) => !open)}
+                className={`nav-link nav-dropdown-trigger ${currentView === 'leaderboard' ? 'active' : ''}`}
+                aria-haspopup="menu"
+                aria-expanded={leaderboardsOpen}
+              >
+                Leaderboards
+                <span className="nav-dropdown-chevron" aria-hidden="true" />
+              </button>
+              <div className="nav-dropdown-menu" role="menu" aria-label="Leaderboards">
+                {LEADERBOARD_MENU.map((item) =>
+                  item.href ? (
+                    <a
+                      key={item.key}
+                      role="menuitem"
+                      className="nav-dropdown-item external"
+                      href={item.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={item.label}
+                      onClick={() => { setLeaderboardsOpen(false); setMobileMenuOpen(false) }}
+                    >
+                      <span className="nav-dropdown-item-label">
+                        <span className="nav-dropdown-item-name">{renderBenchName(item.label)}</span>
+                        {item.badge && <span className="nav-dropdown-badge">{item.badge}</span>}
+                        <span className="nav-dropdown-external" aria-hidden="true">↗</span>
+                      </span>
+                      <span className="nav-dropdown-item-note">{item.note}</span>
+                    </a>
+                  ) : (
+                    <button
+                      key={item.key}
+                      type="button"
+                      role="menuitem"
+                      className="nav-dropdown-item"
+                      onClick={() => navigateToUrl(item.path)}
+                    >
+                      <span className="nav-dropdown-item-label">
+                        <span className="nav-dropdown-item-name">{renderBenchName(item.label)}</span>
+                      </span>
+                      <span className="nav-dropdown-item-note">{item.note}</span>
+                    </button>
+                  )
+                )}
+              </div>
+            </div>
             <button onClick={() => navigateTo('trajectory-visualizer')} className={`nav-link ${currentView === 'trajectory-visualizer' ? 'active' : ''}`}>Visualizer</button>
             <button onClick={() => navigateTo('blog')} className={`nav-link ${currentView === 'blog' ? 'active' : ''}`}>Blog</button>
             <a href="https://github.com/sierra-research/tau2-bench" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)}>GitHub</a>
@@ -158,10 +236,8 @@ function App() {
         <div className="notification-container">
           <span className="notification-badge">NEW</span>
           <span className="notification-text">
-            τ³-bench is here: <a href={`${import.meta.env.BASE_URL}blog/tau-knowledge.html`} className="notification-link"><strong>τ-knowledge</strong></a> evaluates
-            agents on knowledge-intensive tasks, and{' '}
-            <a href="https://sierra.ai/blog/tau-voice-benchmarking-real-time-voice-agents-on-real-world-tasks" className="notification-link"><strong>τ-voice</strong></a> benchmarks
-            real-time voice agents.
+            τ<sup>τ</sup>-bench is here: can coding agents <em>build</em> the customer-service agents τ-bench evaluates?{' '}
+            <a href={HYPER_TAU_URL} className="notification-link" target="_blank" rel="noopener noreferrer"><strong>Explore the τ<sup>τ</sup>-bench leaderboard →</strong></a>
           </span>
         </div>
       </div>

--- a/web/leaderboard/src/App.jsx
+++ b/web/leaderboard/src/App.jsx
@@ -122,6 +122,7 @@ function App() {
   useEffect(() => {
     const handlePopState = () => {
       setCurrentView(getViewFromPath(window.location.pathname))
+      setLeaderboardsOpen(false)
       scrollToSectionForPath(window.location.pathname)
     }
 

--- a/web/leaderboard/src/routes.js
+++ b/web/leaderboard/src/routes.js
@@ -7,6 +7,20 @@
 
 export const SITE_ORIGIN = 'https://taubench.com'
 
+// τ^τ-bench (hyper-tau-bench) is a sibling benchmark with its own site and
+// leaderboard: coding harnesses building customer-service agents. Linked from
+// the nav's Leaderboards menu and the announcement banner.
+export const HYPER_TAU_URL = 'https://sierra-research.github.io/hyper-tau-bench/'
+
+// Entries of the nav's Leaderboards menu, in display order. In-site entries
+// carry an app path; the external entry carries an absolute href.
+export const LEADERBOARD_MENU = [
+  { key: 'knowledge', label: 'τ³-Banking', note: 'Text · knowledge retrieval', path: '/leaderboard?benchmark=knowledge' },
+  { key: 'voice', label: 'τ³-Voice', note: 'Real-time voice', path: '/leaderboard?benchmark=voice' },
+  { key: 'core', label: 'τ²-bench', note: 'Text · retail, airline, telecom', path: '/leaderboard?benchmark=core' },
+  { key: 'hyper', label: 'τ^τ-bench', note: 'Agent-building agents', href: HYPER_TAU_URL, badge: 'New' },
+]
+
 // path → view name. Multiple paths may map to the same view ('/progress' is
 // the leaderboard scrolled to the progress-over-time section).
 export const ROUTES = {


### PR DESCRIPTION
## What
Points taubench.com at the new sibling benchmark, τ^τ-bench (hyper-tau-bench), at https://sierra-research.github.io/hyper-tau-bench/.

- **Nav:** the `Leaderboard` button becomes a **Leaderboards** menu listing the three tracks (τ³-Banking, τ³-Voice, τ²-bench) and a **τ^τ-bench** entry (marked New) that opens the hyper-tau-bench site in a new tab. Closes on outside click, Escape, and selection; `aria-haspopup` / `aria-expanded` on the trigger, `role=menu` / `menuitem` on the list. On mobile the menu renders inline inside the stacked nav.
- **Banner:** the announcement bar now introduces τ^τ-bench and links to its leaderboard.
- `src/routes.js` gains `HYPER_TAU_URL` and `LEADERBOARD_MENU` (plain data so `scripts/prerender.mjs` can import it). Switching the sibling site to its eventual custom domain is a one-line change there.

## Notes
- `navigateToUrl` dispatches a `popstate` after `pushState` so the leaderboard view re-reads `?benchmark=` when you switch tracks from the menu while it is already mounted (it already listens for popstate).
- Top-level nav anchor rules are scoped to direct children (`.nav-links > a`) so menu items can carry their own styling. A leftover desktop `.nav-dropdown-menu { display: block !important }` override in `App.css` (from an earlier dropdown) is removed; it would have forced the menu open.
- `playwright.config.js` honors `PORT` for local runs when 4173 is busy. Default unchanged.

## Verification
`npm run build && npm run prerender && npx playwright test`: **19 passed** (existing nav tests updated to go through the menu; new tests cover menu contents, open/close, in-place benchmark switching, the τ^τ-bench entry's href/target, and the banner link). eslint clean on touched files.