### PR TITLE
fix: detect llm_agent_solo_gt as solo mode when re-grading trajectories (#502)

### DIFF
--- a/src/tau2/scripts/evaluate_trajectories.py
+++ b/src/tau2/scripts/evaluate_trajectories.py
@@ -16,12 +16,21 @@ from tau2.orchestrator.modes import CommunicationMode
 from tau2.utils.display import ConsoleDisplay
 from tau2.utils.io_utils import expand_paths
 
+# Agent implementations that run without a real user (paired with dummy_user). Their trajectories must be
+# replayed with the environment in solo mode so the user-side tools are present. "llm_agent_solo_gt" is the
+# ground-truth variant used to record some result files; omitting it dropped those tools on replay and
+# silently collapsed the re-graded scores (see #502).
+SOLO_AGENT_IMPLEMENTATIONS = ("llm_agent_solo", "llm_agent_solo_gt")
+
 
 def is_solo_mode(results: Results) -> bool:
     """Checks if the solo mode is the same for all the tasks."""
     agent_implementation = results.info.agent_info.implementation
     user_implementation = results.info.user_info.implementation
-    if agent_implementation == "llm_agent_solo" and user_implementation == "dummy_user":
+    if (
+        agent_implementation in SOLO_AGENT_IMPLEMENTATIONS
+        and user_implementation == "dummy_user"
+    ):
         return True
     return False
 

--- a/tests/test_evaluate_trajectories.py
+++ b/tests/test_evaluate_trajectories.py
@@ -24,6 +24,7 @@ from tau2.scripts import evaluate_trajectories as evaluate_trajectories_module
 from tau2.scripts.evaluate_trajectories import (
     compute_simulation_rewards,
     get_communication_mode,
+    is_solo_mode,
 )
 
 # ---- Fixtures ----
@@ -32,6 +33,7 @@ from tau2.scripts.evaluate_trajectories import (
 def _make_info(
     user_implementation: str = "user_simulator",
     audio_native_config: AudioNativeConfig = None,
+    agent_implementation: str = "llm_agent",
 ) -> Info:
     return Info(
         git_commit="abc123",
@@ -39,7 +41,7 @@ def _make_info(
         max_steps=100,
         max_errors=10,
         user_info=UserInfo(implementation=user_implementation),
-        agent_info={"implementation": "llm_agent"},
+        agent_info={"implementation": agent_implementation},
         environment_info=EnvironmentInfo(domain_name="mock", policy="test policy"),
         audio_native_config=audio_native_config,
     )
@@ -78,6 +80,35 @@ def _make_full_duplex_sim(task_id: str, ticks: list[Tick] = None) -> SimulationR
         ticks=ticks if ticks is not None else [],
         mode=CommunicationMode.FULL_DUPLEX.value,
     )
+
+
+# ---- Solo mode detection ----
+
+
+class TestIsSoloMode:
+    def _results(self, agent_implementation: str, user_implementation: str) -> Results:
+        return Results(
+            info=_make_info(
+                user_implementation=user_implementation,
+                agent_implementation=agent_implementation,
+            ),
+            tasks=[_make_task("t0")],
+            simulations=[],
+        )
+
+    def test_llm_agent_solo_is_solo(self):
+        assert is_solo_mode(self._results("llm_agent_solo", "dummy_user")) is True
+
+    def test_llm_agent_solo_gt_is_solo(self):
+        # Ground-truth solo files also run with a dummy user and must be detected as solo, so replay keeps
+        # the user-side tools. Regression for #502, where these files silently re-graded from 0.72 to 0.10.
+        assert is_solo_mode(self._results("llm_agent_solo_gt", "dummy_user")) is True
+
+    def test_regular_agent_is_not_solo(self):
+        assert is_solo_mode(self._results("llm_agent", "user_simulator")) is False
+
+    def test_solo_agent_with_real_user_is_not_solo(self):
+        assert is_solo_mode(self._results("llm_agent_solo", "user_simulator")) is False
 
 
 # ---- Mode detection ----


### PR DESCRIPTION
## What

Addresses the solo-mode detection part (finding 1) of #502.

`evaluate-trajs` decides solo mode with `is_solo_mode()` (`src/tau2/scripts/evaluate_trajectories.py`), which matched only `agent_implementation == "llm_agent_solo"`. The four repository telecom files recorded with the ground-truth solo variant `llm_agent_solo_gt` (paired with `dummy_user`) fell through to `solo_mode=False`, so `telecom.get_environment(solo_mode=False)` never called `set_solo_mode(True)` and the user-side `TelecomUserTools` were absent from the replay environment. Under the lenient replay that `compute_simulation_rewards` uses, every replayed user-side tool call then returned `Error: Tool '...' not found` and was swallowed, so DB state was never mutated and the scores collapsed. The four files re-grade from their recorded `0.7478, 0.7215, 0.9035, 0.9890` down to about `0.1601, 0.0965, 0.1754, 0.1732`.

## Fix

Recognize both solo implementations in `is_solo_mode` through a `SOLO_AGENT_IMPLEMENTATIONS` tuple. `llm_agent_solo_gt` is the ground-truth solo variant used to record several result files; it runs with a dummy user just like `llm_agent_solo`, so its trajectories must be replayed in solo mode.

## Tests

Adds a `TestIsSoloMode` class in `tests/test_evaluate_trajectories.py`: `llm_agent_solo` and `llm_agent_solo_gt` with `dummy_user` are solo, a regular agent is not, and a solo agent paired with a real user is not. `_make_info` gains an `agent_implementation` argument (default unchanged). Full file: 18 tests pass; `ruff check` and `ruff format --check` are clean on the changed files.

## Scope

This PR covers only the solo-mode detection in finding 1. The other items in #502 (a CLI flag to restore strict re-grading, the `--fresh-tasks` criteria drift, and the unparseable leaderboard files) are separate and can follow.
