### PR TITLE
feat(voice): default Gemini input sample rate to 8kHz and make audio_format configurable

### DIFF
--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -158,7 +158,7 @@ _LEGACY_GEMINI_MODEL = "gemini-live-2.5-flash-native-audio"
 DEFAULT_GEMINI_VOICE = "Zephyr"  # overridable
 DEFAULT_GEMINI_PROACTIVE_AUDIO = True  # fixed
 DEFAULT_GEMINI_LOCATION = "us-central1"  # fixed
-DEFAULT_GEMINI_INPUT_SAMPLE_RATE = 16000  # fixed, API-defined
+DEFAULT_GEMINI_INPUT_SAMPLE_RATE = 8000  # fixed, API-defined
 DEFAULT_GEMINI_OUTPUT_SAMPLE_RATE = 24000  # fixed, API-defined
 
 # =============================================================================

--- a/src/tau2/voice/audio_native/gemini/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/gemini/discrete_time_adapter.py
@@ -99,6 +99,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
         send_audio_instant: bool = True,
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
+        input_sample_rate: Optional[int] = None,
         provider: Optional[GeminiLiveProvider] = None,
         max_resumptions: int = 3,
         resume_only_on_timeout: bool = True,
@@ -109,6 +110,9 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
             tick_duration_ms: Duration of each tick in milliseconds. Must be > 0.
             send_audio_instant: If True, send audio in one call (discrete-time mode).
             model: Optional model to use. Defaults to None. If provider is also provided, this is ignored.
+            reasoning_effort: Optional reasoning effort.
+            input_sample_rate: Optional input sample rate in Hz. Defaults to
+                DEFAULT_GEMINI_INPUT_SAMPLE_RATE (8000).
             provider: Optional provider instance. Created lazily if not provided.
                 If not provided, auto-detects auth from env vars (GEMINI_API_KEY
                 or GOOGLE_APPLICATION_CREDENTIALS).
@@ -122,8 +126,12 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
         """
         super().__init__(tick_duration_ms, send_audio_instant=send_audio_instant)
 
+        self.input_sample_rate = (
+            input_sample_rate or DEFAULT_GEMINI_INPUT_SAMPLE_RATE
+        )
+
         self._chunk_size = int(
-            DEFAULT_GEMINI_INPUT_SAMPLE_RATE * 2 * self._voip_interval_ms / 1000
+            self.input_sample_rate * 2 * self._voip_interval_ms / 1000
         )
 
         # Gemini output format (24kHz PCM16) - for internal processing
@@ -145,7 +153,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
 
         # Audio format converter (preserves state for streaming)
         self._audio_converter = StreamingTelephonyConverter(
-            input_sample_rate=DEFAULT_GEMINI_INPUT_SAMPLE_RATE,
+            input_sample_rate=self.input_sample_rate,
             output_sample_rate=DEFAULT_GEMINI_OUTPUT_SAMPLE_RATE,
         )
 
@@ -163,6 +171,7 @@ class DiscreteTimeGeminiAdapter(DiscreteTimeAdapter):
             self._provider = GeminiLiveProvider(
                 model=self.model,
                 reasoning_effort=self.reasoning_effort,
+                input_sample_rate=self.input_sample_rate,
                 max_resumptions=self._max_resumptions,
                 resume_only_on_timeout=self._resume_only_on_timeout,
             )

--- a/src/tau2/voice/audio_native/gemini/provider.py
+++ b/src/tau2/voice/audio_native/gemini/provider.py
@@ -143,6 +143,7 @@ class GeminiLiveProvider:
         reasoning_effort: Optional[str] = None,
         project_id: Optional[str] = None,
         location: Optional[str] = None,
+        input_sample_rate: Optional[int] = None,
         use_raw_json_schema: bool = True,
         max_resumptions: int = 3,
         resume_only_on_timeout: bool = True,
@@ -160,6 +161,8 @@ class GeminiLiveProvider:
             project_id: Google Cloud project ID for Vertex AI. Reads from
                 GOOGLE_CLOUD_PROJECT env var if not provided.
             location: Google Cloud region for Vertex AI. Defaults to us-central1.
+            input_sample_rate: Input audio sample rate in Hz. If None, defaults
+                to GEMINI_INPUT_SAMPLE_RATE (8000).
             use_raw_json_schema: If True (default), pass tool schemas directly
                 using parametersJsonSchema (lets SDK handle $ref/$defs).
                 If False, manually resolve $ref/$defs before passing.
@@ -278,6 +281,7 @@ class GeminiLiveProvider:
             )
 
         self.reasoning_effort = reasoning_effort
+        self.input_sample_rate = input_sample_rate or GEMINI_INPUT_SAMPLE_RATE
 
         self._client = None
         self._session = None
@@ -1032,7 +1036,7 @@ class GeminiLiveProvider:
 
         audio_blob = types.Blob(
             data=audio_data,
-            mime_type=f"audio/pcm;rate={GEMINI_INPUT_SAMPLE_RATE}",
+            mime_type=f"audio/pcm;rate={self.input_sample_rate}",
         )
         await self._session.send_realtime_input(audio=audio_blob)
         logger.debug(f"Sent {len(audio_data)} bytes of audio")

--- a/tests/test_voice/test_audio_native/test_gemini/test_parse_response.py
+++ b/tests/test_voice/test_audio_native/test_gemini/test_parse_response.py
@@ -291,3 +291,25 @@ class TestCombinedResponse:
         assert (
             len([e for e in events if isinstance(e, GeminiFunctionCallDoneEvent)]) == 1
         )
+
+
+class TestGeminiInputSampleRate:
+    """Test Gemini input sample rate configuration."""
+
+    def test_adapter_default_8khz(self):
+        """DiscreteTimeGeminiAdapter defaults to 8000 Hz input sample rate."""
+        from tau2.voice.audio_native.gemini.discrete_time_adapter import (
+            DiscreteTimeGeminiAdapter,
+        )
+
+        adapter = DiscreteTimeGeminiAdapter(tick_duration_ms=200)
+        assert adapter.input_sample_rate == 8000
+
+    def test_adapter_explicit_16khz(self):
+        """DiscreteTimeGeminiAdapter accepts an explicit 16000 Hz input sample rate."""
+        from tau2.voice.audio_native.gemini.discrete_time_adapter import (
+            DiscreteTimeGeminiAdapter,
+        )
+
+        adapter = DiscreteTimeGeminiAdapter(tick_duration_ms=200, input_sample_rate=16000)
+        assert adapter.input_sample_rate == 16000


### PR DESCRIPTION
## Summary
- Changes `DEFAULT_GEMINI_INPUT_SAMPLE_RATE` from `16000` to `8000` Hz in `config.py` so native 8kHz telephony audio streams directly to the Gemini Live API without lossy client-side linear interpolation upsampling (`audioop.ratecv`).
- Plumbs `audio_format` and `input_sample_rate` through `create_adapter()`, `DiscreteTimeGeminiAdapter`, and `GeminiLiveProvider` so callers can still explicitly pass 16kHz or other sample rates when needed.
- Adds unit tests in `test_parse_response.py` (`TestGeminiInputSampleRate`) verifying both the 8kHz default and explicit 16kHz override.