### PR TITLE
fix(voice): specify SlidingWindow in ContextWindowCompressionConfig

### DIFF
--- a/src/tau2/voice/audio_native/gemini/provider.py
+++ b/src/tau2/voice/audio_native/gemini/provider.py
@@ -448,7 +448,9 @@ class GeminiLiveProvider:
                 # Enable context window compression for long sessions.
                 # Leave parameters unset so the API uses model-dependent defaults.
                 config_kwargs["context_window_compression"] = (
-                    types.ContextWindowCompressionConfig()
+                    types.ContextWindowCompressionConfig(
+                        sliding_window=types.SlidingWindow()
+                    )
                 )
 
             # Add session resumption config (enables receiving resumption handles)


### PR DESCRIPTION
## Summary
- Newer versions of the `google-genai` SDK require an explicit compression strategy (such as `sliding_window=types.SlidingWindow()`) when constructing `types.ContextWindowCompressionConfig()`. Passing an empty `ContextWindowCompressionConfig()` can raise validation errors when connecting long-running sessions.