### PR TITLE
feat(voice): set Gemini start_of_speech_sensitivity to HIGH for 8kHz telephony traffic

### DIFF
--- a/src/tau2/voice/audio_native/gemini/provider.py
+++ b/src/tau2/voice/audio_native/gemini/provider.py
@@ -488,6 +488,14 @@ class GeminiLiveProvider:
                     thinking_level=self.reasoning_effort.upper(),
                 )
 
+            config_kwargs["realtime_input_config"] = types.RealtimeInputConfig(
+                automatic_activity_detection=types.AutomaticActivityDetection(
+                    start_of_speech_sensitivity=(
+                        types.StartSensitivity.START_SENSITIVITY_HIGH
+                    ),
+                )
+            )
+
             config = types.LiveConnectConfig(**config_kwargs)
 
             # Connect to the API - IMPORTANT: keep reference to context manager


### PR DESCRIPTION
Tau-Voice streams narrowband 8kHz telephony audio (`audio/pcm;rate=8000`). Configuring `start_of_speech_sensitivity` to `START_SENSITIVITY_HIGH` in `GeminiLiveProvider.connect()` ensures responsive start-of-speech voice activity detection for 8kHz telephony streams.