### PR TITLE
Add florin-tau2-retail-30b retail submission (pass^1 82.46 / pass^4 59.65, open-weight LoRA)

### DIFF
--- a/web/leaderboard/public/submissions/florin-tau2-retail-30b_florin_2026-09-04/submission.json
+++ b/web/leaderboard/public/submissions/florin-tau2-retail-30b_florin_2026-09-04/submission.json
@@ -1,0 +1,48 @@
+{
+  "model_name": "Florin-tau2-Retail-30B (Qwen3-30B-A3B-Thinking LoRA)",
+  "model_organization": "Florin",
+  "submitting_organization": "Florin",
+  "submission_date": "2026-09-04",
+  "submission_type": "custom",
+  "modality": "text",
+  "contact_info": {
+    "email": "shaurya@florin.inc",
+    "name": "Amol Pant",
+    "github": "ammoman21"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 82.45614035087719,
+      "pass_2": 71.9298245614035,
+      "pass_3": 64.91228070175438,
+      "pass_4": 59.64912280701754,
+      "cost": 0.0
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "retail": "results.json"
+  },
+  "references": [
+    {
+      "title": "Florin tau2-retail fine-tune (LoRA adapter, private until approval)",
+      "url": "https://huggingface.co/florin-inc/florin-tau2-retail-30b",
+      "type": "model"
+    },
+    {
+      "title": "Official-run trajectories (private until approval)",
+      "url": "https://huggingface.co/datasets/florin-inc/tau2-retail-trajectories",
+      "type": "dataset"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-09-04",
+    "user_simulator": "gpt-5.2",
+    "notes": "Qwen3-30B-A3B-Thinking-2507 with an attention-only LoRA adapter (r=64, alpha=128, q/k/v/o across all 48 layers) fine-tuned on 2,117 synthetic retail conversations generated entirely with open-weight teachers (agent: Qwen3.5-397B-A17B; user sim: Qwen3-235B-A22B-2507) on a fully synthetic retail database whose entities (users, products, orders) are disjoint from the tau-bench evaluation database. Trajectories filtered by tau2's deterministic DB-state check before training. Evaluation: 114 retail tasks x 4 trials, seed 300, max_steps 200, tau2-bench commit a2c0247 (v1.0.1 task set), agent served via vLLM (temperature 1.0, top_p 0.95, max_tokens 8192). User simulator ran with reasoning_effort=low.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -28,7 +28,8 @@
     "grok-4-5_sierra_2026-08-04",
     "inkling_sierra_2026-08-04",
     "claude-opus-5_sierra_2026-08-04",
-    "qwen3-8-max_sierra_2026-08-04"
+    "qwen3-8-max_sierra_2026-08-04",
+    "florin-tau2-retail-30b_florin_2026-09-04"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",


### PR DESCRIPTION
## Add τ²-bench retail submission: Florin-tau2-Retail-30B

This PR adds a retail-domain submission for **Florin-tau2-Retail-30B**, a LoRA fine-tune
of Qwen3-30B-A3B-Thinking-2507.

### Results (114 retail tasks × 4 trials, seed 300, commit a2c0247, v1.0.1 task set)

| domain | pass^1 | pass^2 | pass^3 | pass^4 |
|---|---|---|---|---|
| retail | **82.46** | 71.93 | 64.91 | **59.65** |

Metrics computed with this repo's own `tau2.metrics.agent_metrics.compute_metrics`;
456/456 simulations completed with zero infrastructure errors (all terminations
`user_stop`). User simulator: gpt-5.2 with `reasoning_effort=low`, per
`docs/leaderboard-submission.md`.

### Placement, stated plainly

- **pass^1 82.46 exactly ties RAFT-30B-A3B** — the merged precedent for a fine-tuned
  30B-class model — and sits above every frontier API model with a current full 4-trial
  retail entry (GPT-5.2: 81.58, GPT-5: 81.58).
- **We are behind RAFT on the stability metrics**: pass^2 71.93 vs 72.95, pass^3 64.91
  vs 66.23, pass^4 59.65 vs 61.40. RAFT keeps the best pass^4 among 30B-class entries.
- Larger models rank higher on pass^1: Qwen3.5-397B-A17B holds 84.43 (13× the active
  parameter budget; it is also our data-generation teacher). Rows above that in raw
  pass^1 (e.g. 86.20) are legacy-version entries without pass^2–4 fields.

### Method (SFT only, open-weight data pipeline, ≈$60)

Attention-only LoRA (r=64, α=128, q/k/v/o × 48 layers; 53.5M trainable params) on
2,117 synthetic retail conversations. The data pipeline uses **open-weight models
end-to-end**: teacher agent Qwen3.5-397B-A17B and user simulator Qwen3-235B-A22B-2507,
run through tau2's own orchestrator against a fully synthetic retail database whose
entities are disjoint from the evaluation database (the bar the RAFT merge set).
Trajectories enter training only if they pass tau2's deterministic DB-state check.
Checkpoint selection used a held-out synthetic dev split only; the 114 evaluation tasks
were never run before this single preregistered official evaluation. Total iteration
cost ≈$60 of GPU + API spend (campaign-tracked estimate; itemized in our training log).
No reinforcement-learning stage: this is 2 epochs of SFT on one H100.

### Reproducibility

- Adapter (base attribution to Qwen): https://huggingface.co/florin-inc/florin-tau2-retail-30b
  *(private during review — will be made public on approval)*
- Full official-run trajectories: https://huggingface.co/datasets/florin-inc/tau2-retail-trajectories
  *(private during review — will be made public on approval;
  sha256 of results.json: 1120aa1272848c30ad8c04d939f11d1b66f10a76db673d582dc2ec3ddc14d806)*
- Serving: vLLM, hermes tool parser, qwen3 reasoning parser, temperature 1.0 / top_p 0.95 /
  max_tokens 8192 (full command in the model card).

### Checklist

- [x] `submission.json` follows the merged RAFT-30B-A3B format
- [x] `tau2 submit validate` passes (one expected warning: display model name vs the
      `hosted_vllm/ep2` serving alias recorded in trajectories — same class of mismatch
      as the merged RAFT entry)
- [x] Manifest entry added: `florin-tau2-retail-30b_florin_2026-09-04`
- [x] Trajectories NOT committed to the repo (external link, per submission docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
