### PR TITLE
fix: validate and coerce tool kwargs via Pydantic schema in Tool and ToolKitBase

### DIFF
--- a/src/tau2/environment/tool.py
+++ b/src/tau2/environment/tool.py
@@ -178,8 +178,9 @@ class Tool(BaseTool):
 
     @override
     def _call(self, *args: Any, **kwargs: Any) -> Any:
-        kwargs.update(self._predefined)  # use predefined kwargs
-        return self._func(*args, **kwargs)
+        validated_kwargs = self.params.model_validate(kwargs).model_dump()
+        validated_kwargs.update(self._predefined)  # use predefined kwargs
+        return self._func(*args, **validated_kwargs)
 
 
 def as_tool(func: Callable, **kwargs: Any) -> Tool:

--- a/src/tau2/environment/toolkit.py
+++ b/src/tau2/environment/toolkit.py
@@ -139,7 +139,7 @@ class ToolKitBase(metaclass=ToolKitType):
         """Use a tool."""
         if tool_name not in self.tools:
             raise ValueError(f"Tool '{tool_name}' not found.")
-        return self.tools[tool_name](**kwargs)
+        return as_tool(self.tools[tool_name])(**kwargs)
 
     def get_tools(self, include: Optional[list[str]] = None) -> Dict[str, Tool]:
         """Get the non-discoverable tools available in the ToolKit.

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -659,3 +659,19 @@ def test_environment_set_state_strict_flag(
             arguments={"user_id": "user_1", "expected_number": 2},
         )
     )
+
+
+def test_tool_call_coerces_float_to_int(mock_toolkit_class):
+    toolkit = mock_toolkit_class()
+    tools = toolkit.get_tools()
+    tool1 = tools["tool1"]
+    res = tool1(param1=5.0)
+    assert res == "5"
+    assert toolkit.val == 5
+    assert isinstance(toolkit.val, int)
+
+    # Test that toolkit.use_tool also coerces float to int
+    res2 = toolkit.use_tool("tool1", param1=3.0)
+    assert res2 == "8"
+    assert toolkit.val == 8
+    assert isinstance(toolkit.val, int)


### PR DESCRIPTION
Tool arguments can arrive as floats (e.g. `2.0`) due to serialisation and wire-format artifacts (e.g. JSON or Protobuf numeric deserialisation across API boundaries). Without runtime coercion, these floats persist into database records, causing state hash mismatches against golden databases and reward loss.

Validate and coerce incoming kwargs against the tool's Pydantic schema prior to invocation in both `Tool._call` and `ToolKitBase.use_tool`.