### PR TITLE
Leaderboard submission: custom_agent v6, airline (Andrea Migliavacca, Politecnico di Milano)

### DIFF
--- a/web/leaderboard/public/submissions/custom-agent-gemini-3-5-flash-lite-noreasoning_andrea-migliavacca-polimi_2026-09-09/submission.json
+++ b/web/leaderboard/public/submissions/custom-agent-gemini-3-5-flash-lite-noreasoning_andrea-migliavacca-polimi_2026-09-09/submission.json
@@ -1,0 +1,51 @@
+{
+  "model_name": "custom_agent_gemini-3.5.flash-lite-noReasoning",
+  "model_organization": "Andrea Migliavacca, Politecnico di Milano",
+  "submitting_organization": "Andrea Migliavacca, Politecnico di Milano",
+  "submission_date": "2026-09-09",
+  "submission_type": "custom",
+  "modality": "text",
+  "reasoning_effort": "no reasoning",
+  "contact_info": {
+    "email": "andrea.migliavacca04@gmail.com",
+    "name": "Andrea Migliavacca",
+    "github": "Migliaa"
+  },
+  "results": {
+    "airline": {
+      "pass_1": 80.5,
+      "pass_2": 73.33333333333333,
+      "pass_3": 68.0,
+      "pass_4": 64.0,
+      "cost": 0.04180436345000001
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_results.json"
+  },
+  "references": [
+    {
+      "title": "Project Tassonomia -- implementation, prompts, and full methodology",
+      "url": "https://github.com/Migliaa/Project_Tassonomia",
+      "type": "github"
+    },
+    {
+      "title": "tau2-bench issue #514 -- DB hash comparison sorts dict keys but not list elements",
+      "url": "https://github.com/sierra-research/tau2-bench/issues/514",
+      "type": "other"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-09-05",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "gemini/gemini-3.5-flash-lite",
+    "notes": "The user simulator is gemini/gemini-3.5-flash-lite, the same model as the agent -- not gpt-5.2 as recommended in this guide, so these pass rates are not directly comparable to submissions that use gpt-5.2 as the user simulator. Custom agent: only the system prompt of the built-in custom_agent was rewritten, across 6 iterations (v1-v6), with the base model and temperature (gemini/gemini-3.5-flash-lite, temperature 0, no reasoning effort) held fixed for both agent and user simulator throughout. 4 trials on all 50 airline tasks per the leaderboard's stated preference; per-trial pass_1 was 82%, 74%, 80%, 86% (mean 80.5%). The 68% baseline for comparison is a single run of the benchmark's own unmodified llm_agent, not an average -- not directly comparable in reliability to our 4-trial mean, though the two are close on shared tasks (pass_1 74.3% and pass_2 67.6% for the baseline vs 78.4% and 67.6% for our agent, on the 37 tasks where both have two runs). pass^4 for our agent is 64%. Full prompt versions, per-task failure diagnosis, and pre-registered predictions for each change are documented in the linked repository. While doing this work we found and reported a benchmark defect (see reference below): the database-hash comparison used to score a task sorts dictionary keys but not list elements, so two databases that differ only in list ordering (e.g. a booking's payment history) are scored as different even when identical in content. The attached trajectory file combines individual per-task retries made necessary by daily API quota limits; as a result the 200 runs span six commits of the upstream tau2-bench repository, all captured on 2026-09-05 (task/domain content and agent/user configuration verified identical across all of them; the exact commit breakdown is in this project's repository, DIARIO.md).",
+    "verification": {
+      "modified_prompts": true,
+      "omitted_questions": false,
+      "details": "Only the system prompt of custom_agent was modified (6 iterations, v1-v6); same tools, same environment, same model/temperature for agent and user simulator across every run. Prompt diffs and rationale for each version are in the linked repository (patches/ and DIARIO.md)."
+    }
+  }
+}

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -28,7 +28,8 @@
     "grok-4-5_sierra_2026-08-04",
     "inkling_sierra_2026-08-04",
     "claude-opus-5_sierra_2026-08-04",
-    "qwen3-8-max_sierra_2026-08-04"
+    "qwen3-8-max_sierra_2026-08-04",
+    "custom-agent-gemini-3-5-flash-lite-noreasoning_andrea-migliavacca-polimi_2026-09-09"
   ],
   "voice_submissions": [
     "gpt-realtime-1.5_sierra_2026-03-03",


### PR DESCRIPTION
## Summary

Custom submission on the **airline** domain. Base model held fixed for both the agent and the
user simulator (`gemini/gemini-3.5-flash-lite`); only the system prompt of the built-in
`custom_agent` was rewritten, across 6 iterations. 4 trials, all 50 tasks:

| | pass^1 | pass^2 | pass^3 | pass^4 |
|---|---|---|---|---|
| this submission | **80.5%** (82/74/80/86) | 73.3% | 68.0% | 64.0% |
| default `llm_agent` (single run) | 68.0% | — | — | — |

**The user simulator is `gemini/gemini-3.5-flash-lite`, the same model as the agent — not
`gpt-5.2`** as recommended in the submission guide. These pass rates are therefore not directly
comparable to submissions that use `gpt-5.2` as the user simulator.

Full methodology, prompt diffs (v1-v6), per-task failure analysis, and pre-registered
predictions for each change: https://github.com/Migliaa/Project_Tassonomia

## Benchmark defect found during this work

While building a failure taxonomy for this agent, we found that `Environment.get_db_hash()`
sorts dictionary keys but not list elements, so two database states that differ only in list
ordering (e.g. a booking's `payment_history`) are scored as different even when equivalent.
Reported as issue #514, with a minimal two-run reproduction. Filed against airline; likely the
same mechanism behind the previously-reported #325 on retail.

## Trajectories

Full trajectory file (200 simulations, 24.9 MB) is hosted externally:
https://drive.google.com/drive/folders/1wO4lVQOUg3uLW1p3-Co5tyox_vKEaHhZ?usp=drive_link

## Checklist

- [x] All 50 airline tasks, no `--task-ids` filter
- [x] 4 trials (meets the stated preference)
- [x] `submission_type: custom` with detailed `methodology.notes` and `references`
- [x] `methodology.verification.modified_prompts: true`, with details of what changed
- [x] `tau2 submit validate` passes (one expected warning: declared model name differs from the
      literal base model string, since this names the custom agent, not the underlying LLM)
- [x] PR description includes a link to the externally hosted trajectory files

🤖 Generated with [Claude Code](https://claude.com/claude-code)