### PR TITLE
feat: add V3 integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+live = [
+    "tau2[voice]",
+    "aiortc==1.15.0",
+    "httpx[socks]>=0.24.0",
+]
 voice = [
     "elevenlabs>=1.54.0",
     "deepgram-sdk>=3.7.3",
@@ -75,7 +80,7 @@ experiments = [
     "scikit-learn>=1.6.1",
 ]
 all = [
-    "tau2[voice,knowledge,gym,dev,experiments]",
+    "tau2[voice,live,knowledge,gym,dev,experiments]",
 ]
 [project.urls]
 Homepage = "https://taubench.com/"

--- a/src/tau2/agent/base/streaming.py
+++ b/src/tau2/agent/base/streaming.py
@@ -264,7 +264,7 @@ class StreamingState(BaseModel, Generic[InputMessageType, OutputMessageType]):
         tick_duration_seconds: Optional[float] = None,
     ) -> list[Message]:
         """
-        Convert tick-based history to sequential messages for LLM context.
+        Convert tick-based history to text-only messages for LLM context.
 
         This bridges the gap between full-duplex tick-based storage and the
         sequential message format that LLMs expect.
@@ -326,6 +326,21 @@ class StreamingState(BaseModel, Generic[InputMessageType, OutputMessageType]):
                     other_chunk=temp_other_chunk,
                 )
                 ticks_to_process.append(temp_tick)
+
+        # LLM callers consume transcripts and tools, not concatenated recordings.
+        # Keep speech flags/timing for segmentation and leave stored ticks intact.
+        for index, tick in enumerate(ticks_to_process):
+            updates = {}
+            for field in ("self_chunk", "other_chunk"):
+                chunk = getattr(tick, field)
+                if isinstance(chunk, ParticipantMessageBase) and (
+                    chunk.audio_content or chunk.audio_script_gold
+                ):
+                    updates[field] = chunk.model_copy(
+                        update={"audio_content": None, "audio_script_gold": None}
+                    )
+            if updates:
+                ticks_to_process[index] = tick.model_copy(update=updates)
 
         # Expand ticks with env_chunk into old-format ticks before linearization.
         # This ensures linearization sees the same tick structure as the base branch.
@@ -1369,6 +1384,11 @@ def _has_meaningful_content(chunk: Message) -> bool:
     if hasattr(chunk, "is_tool_call") and chunk.is_tool_call():
         return True
 
+    # Streaming transcripts can arrive before or after their audible frames.
+    # Keep their text in LLM history without treating them as speech activity.
+    if hasattr(chunk, "content") and chunk.content:
+        return True
+
     # Check contains_speech flag if available
     # Return True if contains_speech=True (audio content, even without transcript)
     # Return False if contains_speech=False (explicitly marked as no speech)
@@ -1377,10 +1397,6 @@ def _has_meaningful_content(chunk: Message) -> bool:
             return True
         if chunk.contains_speech is False:
             return False
-
-    # Check for actual content
-    if hasattr(chunk, "content") and chunk.content:
-        return True
 
     return False
 

--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -78,11 +78,14 @@ from tau2.data_model.usage import UsageRecord
 from tau2.environment.tool import Tool
 from tau2.utils.utils import get_now
 from tau2.voice.audio_native.adapter import DiscreteTimeAdapter, create_adapter
+from tau2.voice.audio_native.openai.live_config import LiveConfig
 from tau2.voice.audio_native.tick_result import TickResult
 from tau2.voice.pricing import compute_tick_cost
 
 # Provider type alias
-AudioNativeProvider = Literal["openai", "gemini", "xai", "nova", "qwen", "livekit"]
+AudioNativeProvider = Literal[
+    "openai", "openai_live", "gemini", "xai", "nova", "qwen", "livekit"
+]
 
 # VAD config union type (string annotations for lazy resolution)
 VADConfig = Union[
@@ -213,6 +216,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         use_xml_prompt: bool = False,
         cascaded_config: Optional["CascadedConfig"] = None,
         audio_taps_dir: Optional[Path] = None,
+        live_config: Optional[LiveConfig] = None,
     ):
         """Initialize the discrete-time audio native agent.
 
@@ -256,6 +260,10 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         self.reasoning_effort = reasoning_effort
         self.max_inactive_seconds = max_inactive_seconds
         self.cascaded_config = cascaded_config
+        self.live_config = live_config
+        self._live_trace_path = (
+            audio_taps_dir / "live.jsonl" if audio_taps_dir else None
+        )
 
         # Audio format (defaults to telephony)
         self.audio_format = audio_format or TELEPHONY_AUDIO_FORMAT
@@ -268,7 +276,7 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         # pulling in websockets/aiohttp when voice extras aren't installed)
         if vad_config is not None:
             self.vad_config = vad_config
-        elif provider == "openai":
+        elif provider in {"openai", "openai_live"}:
             from tau2.voice.audio_native.openai.provider import (
                 OpenAIVADConfig,
                 OpenAIVADMode,
@@ -369,6 +377,8 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
                 reasoning_effort=self.reasoning_effort,
                 audio_format=self.audio_format,
                 cascaded_config=self.cascaded_config,
+                live_config=self.live_config,
+                trace_path=self._live_trace_path,
             )
         return self._adapter
 
@@ -632,7 +642,11 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         audio_format = self.audio_format
 
         # Check if there was actual speech (not just silence padding)
-        has_speech = len(tick_result.agent_audio_data) > 0
+        has_speech = (
+            tick_result.contains_speech
+            if tick_result.contains_speech is not None
+            else len(tick_result.agent_audio_data) > 0
+        )
 
         audio_content = base64.b64encode(agent_audio).decode("utf-8")
         content = transcript if transcript else None
@@ -845,6 +859,7 @@ def create_discrete_time_audio_native_agent(tools, domain_policy, **kwargs):
             use_xml_prompt=audio_native_config.use_xml_prompt,
             cascaded_config=getattr(audio_native_config, "cascaded_config", None),
             audio_taps_dir=audio_taps_dir,
+            live_config=audio_native_config.live_config,
         )
     else:
         # Fallback: use individual kwargs or defaults

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -257,7 +257,7 @@ def add_run_args(parser):
     parser.add_argument(
         "--audio-native-provider",
         type=str,
-        choices=["openai", "gemini", "xai", "nova", "qwen", "livekit"],
+        choices=["openai", "openai_live", "gemini", "xai", "nova", "qwen", "livekit"],
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
         help=f"Audio native API provider. Default is '{DEFAULT_AUDIO_NATIVE_PROVIDER}'.",
     )
@@ -274,6 +274,12 @@ def add_run_args(parser):
         type=str,
         default=None,
         help="Audio native model to use. If not specified, uses the default model for the selected provider.",
+    )
+    parser.add_argument(
+        "--live-config",
+        type=json.loads,
+        default=None,
+        help="JSON config for openai_live: backend_model (required), voice, frontend_prompt, backend_prompt.",
     )
     parser.add_argument(
         "--reasoning-effort",
@@ -613,6 +619,8 @@ def main():
             # Resolve model based on provider if not specified
             audio_native_model = args.audio_native_model
             if audio_native_model is None:
+                if args.audio_native_provider == "openai_live":
+                    parser.error("openai_live requires --audio-native-model")
                 audio_native_model = DEFAULT_AUDIO_NATIVE_MODELS[
                     args.audio_native_provider
                 ]
@@ -628,6 +636,7 @@ def main():
                 model=audio_native_model,
                 cascaded_config_name=args.cascaded_config,
                 reasoning_effort=args.reasoning_effort,
+                live_config=args.live_config,
                 # Timing
                 tick_duration_seconds=args.tick_duration,
                 max_steps_seconds=args.max_steps_seconds,

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -59,6 +59,7 @@ from tau2.environment.environment import EnvironmentInfo
 from tau2.environment.toolkit import ToolType
 from tau2.orchestrator.modes import CommunicationMode
 from tau2.utils.utils import get_now
+from tau2.voice.audio_native.openai.live_config import LiveConfig
 
 SIMULATIONS_DIR = "simulations"
 
@@ -71,9 +72,11 @@ class AudioNativeConfig(BaseModel):
     """
 
     # Provider selection
-    provider: Literal["openai", "gemini", "xai", "nova", "qwen", "livekit"] = Field(
+    provider: Literal[
+        "openai", "openai_live", "gemini", "xai", "nova", "qwen", "livekit"
+    ] = Field(
         default=DEFAULT_AUDIO_NATIVE_PROVIDER,
-        description="Audio native API provider: 'openai' (OpenAI Realtime), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
+        description="Audio native API provider: 'openai' (OpenAI Realtime), 'openai_live' (OpenAI Live), 'gemini' (Gemini Live), 'xai' (xAI Grok Voice Agent), 'nova' (Amazon Nova Sonic), 'qwen' (Alibaba Qwen Omni), or 'livekit' (LiveKit cascaded STT→LLM→TTS)",
     )
 
     # Cascaded config (for livekit provider)
@@ -90,6 +93,18 @@ class AudioNativeConfig(BaseModel):
         default=None,
         description="Reasoning effort for thinking models: 'minimal', 'low', 'medium', 'high'. If None, not sent.",
     )
+    live_config: Optional[LiveConfig] = Field(
+        default=None,
+        description="Backend, voice and split prompts for the openai_live provider",
+    )
+
+    @model_validator(mode="after")
+    def validate_live_config(self):
+        if (self.provider == "openai_live") != (self.live_config is not None):
+            raise ValueError(
+                "live_config is required for openai_live and only valid for that provider"
+            )
+        return self
 
     # Timing configuration
     tick_duration_seconds: float = Field(
@@ -443,7 +458,7 @@ class BaseRunConfig(BaseModel):
     review_model: Annotated[
         str,
         Field(
-            description="LLM model to use for review calls when auto_review is enabled.",
+            description="LLM model for conversation review and hallucination checks.",
             default=DEFAULT_LLM_EVAL_USER_SIMULATOR,
         ),
     ]

--- a/src/tau2/evaluator/hallucination_reviewer.py
+++ b/src/tau2/evaluator/hallucination_reviewer.py
@@ -134,7 +134,10 @@ def _parse_hallucination_response(
     summary = result_data.get("summary", "")
 
     errors: list[HallucinationCheckError] = []
-    for h in result_data.get("hallucinations", []):
+    hallucinations = result_data["hallucinations"]
+    if not isinstance(hallucinations, list):
+        raise ValueError("Reviewer hallucinations must be a list")
+    for h in hallucinations:
         errors.append(
             HallucinationCheckError(
                 reasoning=h.get("reasoning", ""),
@@ -163,6 +166,7 @@ class FullDuplexHallucinationReviewer:
         cls,
         task: Task,
         full_trajectory: list[Tick],
+        review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
     ) -> HallucinationCheck:
         """
         Check whether the user simulator hallucinated information.
@@ -170,6 +174,7 @@ class FullDuplexHallucinationReviewer:
         Args:
             task: The task containing user scenario instructions.
             full_trajectory: List of Tick objects from full-duplex simulation.
+            review_model: Explicit judge model; defaults to the stock reviewer.
 
         Returns:
             HallucinationCheck with any hallucinations found.
@@ -194,32 +199,19 @@ class FullDuplexHallucinationReviewer:
         ]
 
         assistant_message = generate(
-            model=DEFAULT_LLM_EVAL_USER_SIMULATOR,
+            model=review_model,
             messages=messages,
             call_name="llm_judge_hallucination_check",
         )
 
-        try:
-            reasoning, hallucination_found, errors, summary = (
-                _parse_hallucination_response(assistant_message.content)
-            )
-            return HallucinationCheck(
-                reasoning=reasoning,
-                hallucination_found=hallucination_found,
-                errors=errors,
-                summary=summary,
-                cost=assistant_message.cost,
-            )
-        except Exception as e:
-            # If parsing fails, return a safe result (no hallucination detected)
-            return HallucinationCheck(
-                reasoning=f"Failed to parse LLM response: {e}",
-                hallucination_found=False,
-                errors=[
-                    HallucinationCheckError(
-                        reasoning=f"Failed to parse LLM response: {e}. Response: {assistant_message.content}",
-                    )
-                ],
-                summary="",
-                cost=assistant_message.cost,
-            )
+        # Invalid judge output is a review failure, never evidence of a clean user.
+        reasoning, hallucination_found, errors, summary = _parse_hallucination_response(
+            assistant_message.content
+        )
+        return HallucinationCheck(
+            reasoning=reasoning,
+            hallucination_found=hallucination_found,
+            errors=errors,
+            summary=summary,
+            cost=assistant_message.cost,
+        )

--- a/src/tau2/evaluator/reviewer.py
+++ b/src/tau2/evaluator/reviewer.py
@@ -154,6 +154,7 @@ def review_simulation(
 def check_hallucination(
     simulation: SimulationRun,
     task: Task,
+    review_model: str = DEFAULT_LLM_EVAL_USER_SIMULATOR,
 ) -> HallucinationCheck:
     """
     Check a simulation for user simulator hallucinations.
@@ -180,6 +181,7 @@ def check_hallucination(
     return FullDuplexHallucinationReviewer.review(
         task=task,
         full_trajectory=simulation.ticks,
+        review_model=review_model,
     )
 
 

--- a/src/tau2/orchestrator/full_duplex_orchestrator.py
+++ b/src/tau2/orchestrator/full_duplex_orchestrator.py
@@ -219,7 +219,6 @@ class FullDuplexOrchestrator(BaseOrchestrator[StreamingAgentT, StreamingUserT, T
         self.current_agent_chunk = first_agent_message
 
         # Get first user chunk
-        self.user_state = self.user.get_init_state()
         self.current_user_chunk, self.user_state = self.user.get_next_chunk(
             self.user_state, participant_chunk=dummy_agent_message
         )

--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -480,7 +480,6 @@ class _BatchContext:
     info: Info
     console_display: bool = True
     save_fn: Optional[Callable] = None
-    replace_fn: Optional[Callable] = None
     monitor: Optional[StatusMonitor] = None
     shutdown_event: Optional[threading.Event] = None
     llm_log_mode_value: Optional[str] = None
@@ -493,7 +492,7 @@ def make_voice_run_settings(
     from the config (so a worker process re-derives the same values)."""
     if not isinstance(config, VoiceRunConfig):
         return None, None
-    user_voice_settings = VoiceSettings(
+    user_voice_settings = config.user_voice_settings or VoiceSettings(
         transcription_config=None,
         synthesis_config=SynthesisConfig(),
     )
@@ -579,7 +578,6 @@ def run_unit(
             max_retries=config.max_retries,
             retry_delay=config.retry_delay,
             console_display=ctx.console_display,
-            save_fn=ctx.save_fn,
             on_retry=(lambda: monitor.task_restarted(task_key)) if monitor else None,
             shutdown_event=ctx.shutdown_event,
         )
@@ -588,11 +586,16 @@ def run_unit(
         is_full_duplex = result.ticks is not None and len(result.ticks) > 0
         if hallucination_retries > 0 and is_full_duplex:
             hallucination_retry_count = 0
-            while hallucination_retry_count < hallucination_retries:
-                h_check = check_hallucination(result, task)
+            while True:
+                h_check = check_hallucination(
+                    result, task, review_model=config.review_model
+                )
                 result.hallucination_check = h_check
 
-                if not h_check.hallucination_found:
+                if (
+                    not h_check.hallucination_found
+                    or hallucination_retry_count >= hallucination_retries
+                ):
                     break
 
                 hallucination_retry_count += 1
@@ -609,27 +612,17 @@ def run_unit(
                 if save_dir is not None:
                     discarded_dir = save_dir / "hallucination_discarded"
                     discarded_dir.mkdir(parents=True, exist_ok=True)
-                    discarded_path = discarded_dir / "results_user_hallucination.json"
-
-                    if discarded_path.exists():
-                        with open(discarded_path, "r") as fp:
-                            discarded_data = json.load(fp)
-                        discarded_data["simulations"].append(
-                            result.model_dump(mode="json")
-                        )
-                        existing_task_ids = {t["id"] for t in discarded_data["tasks"]}
-                        if task.id not in existing_task_ids:
-                            discarded_data["tasks"].append(task.model_dump(mode="json"))
-                        with open(discarded_path, "w") as fp:
-                            json.dump(discarded_data, fp, indent=2)
-                    else:
-                        discarded_results = Results(
-                            info=ctx.info,
-                            tasks=[task],
-                            simulations=[result],
-                        )
-                        with open(discarded_path, "w") as fp:
-                            fp.write(discarded_results.model_dump_json(indent=2))
+                    # One owner per file: retry workers must not rewrite a
+                    # shared archive concurrently.
+                    discarded_path = discarded_dir / f"{result.id}.json"
+                    discarded_results = Results(
+                        info=ctx.info,
+                        tasks=[task],
+                        simulations=[result],
+                    )
+                    discarded_path.write_text(
+                        discarded_results.model_dump_json(indent=2)
+                    )
 
                     logger.info(
                         f"Saved discarded hallucination run to {discarded_path} "
@@ -668,12 +661,13 @@ def run_unit(
             result.hallucination_retries_used = hallucination_retry_count
 
             if hallucination_retry_count > 0:
-                # Replace the eagerly-saved hallucinated result in the
-                # checkpoint with the clean retry.  Use the original seed
-                # so resume matching stays consistent.
+                # Use the original seed so resume matching stays consistent.
                 result.seed = seed
-                if ctx.replace_fn:
-                    ctx.replace_fn((trial, task.id, seed), result)
+
+        # A failed reviewer must not leave an unreviewed success checkpoint.
+        # Raw attempt artifacts are already retained by the simulation runner.
+        if ctx.save_fn:
+            ctx.save_fn(result)
 
         # Mark the final sim as the one used in results
         if save_dir is not None:
@@ -971,7 +965,6 @@ def run_tasks(
         info=simulation_results.info,
         console_display=console_display,
         save_fn=prep.save_fn,
-        replace_fn=prep.replace_fn,
         monitor=monitor,
         shutdown_event=shutdown_event,
         # Capture ContextVar values from the main thread so worker threads
@@ -1136,6 +1129,7 @@ def run_domains(
     workers: int,
     provider_limits: Optional[dict[str, int]] = None,
     global_limit: Optional[int] = None,
+    partition_cpus: bool = False,
 ) -> dict[str, Results]:
     """Run several configs concurrently under one controller.
 
@@ -1187,6 +1181,7 @@ def run_domains(
             provider_limits=provider_limits,
             global_limit=global_limit,
             monitor=monitor,
+            partition_cpus=partition_cpus,
         )
     finally:
         monitor.stop()

--- a/src/tau2/runner/build.py
+++ b/src/tau2/runner/build.py
@@ -299,6 +299,7 @@ def build_voice_user(
         tick_duration_seconds=audio_native_config.tick_duration_seconds,
         persona_config=persona_config,
         audio_taps_dir=audio_taps_dir,
+        realtime_generation=audio_native_config.provider == "openai_live",
     )
 
 

--- a/src/tau2/runner/controller.py
+++ b/src/tau2/runner/controller.py
@@ -20,6 +20,7 @@ import sys
 import threading
 import time
 import uuid
+from itertools import zip_longest
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -161,7 +162,12 @@ class Controller:
             raise ValueError("Controller runs must have unique run_ids")
         self.runs = {run.run_id: run for run in runs}
         self.queue = WorkQueue(
-            [unit for run in runs for unit in run.units],
+            [
+                unit
+                for group in zip_longest(*(run.units for run in runs))
+                for unit in group
+                if unit is not None
+            ],
             max_attempts=max_attempts,
             lease_ttl_seconds=lease_ttl_seconds,
             provider_limits=provider_limits,
@@ -357,11 +363,14 @@ def _start_server(app, host: str, port: int):
 
 
 def _spawn_worker(
-    controller_url: str, slots: int, index: int, log_dir: Path
+    controller_url: str,
+    slots: int,
+    index: int,
+    log_dir: Path,
+    cpu_ids: Optional[list[int]] = None,
 ) -> subprocess.Popen:
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"worker_{index}.log"
-    log_file = open(log_path, "w")
     cmd = [
         sys.executable,
         "-m",
@@ -373,10 +382,13 @@ def _spawn_worker(
         "--worker-id",
         f"local-{index}",
     ]
+    if cpu_ids is not None:
+        cmd = ["taskset", "--cpu-list", ",".join(map(str, cpu_ids)), *cmd]
     logger.info(f"Spawning worker {index}: {' '.join(cmd)} (log: {log_path})")
-    return subprocess.Popen(
-        cmd, stdout=log_file, stderr=subprocess.STDOUT, env=os.environ.copy()
-    )
+    with open(log_path, "w") as log_file:
+        return subprocess.Popen(
+            cmd, stdout=log_file, stderr=subprocess.STDOUT, env=os.environ.copy()
+        )
 
 
 def drive_batches(
@@ -389,6 +401,7 @@ def drive_batches(
     monitor: Optional[StatusMonitor] = None,
     worker_log_dir: Optional[Path] = None,
     host: str = "127.0.0.1",
+    partition_cpus: bool = False,
 ) -> Controller:
     """Drive prepared runs to completion with locally-spawned worker processes.
 
@@ -397,6 +410,16 @@ def drive_batches(
     """
     if workers <= 0:
         raise ValueError("drive_batches needs workers >= 1")
+
+    cpu_sets = [None] * workers
+    if partition_cpus:
+        if not hasattr(os, "sched_getaffinity"):
+            raise ValueError("CPU partitioning requires Linux affinity support")
+        cpus = sorted(os.sched_getaffinity(0))
+        # Bound FFmpeg pools even when isolating more I/O-bound sims than CPUs.
+        # Oversubscribed workers share a CPU, not a Python interpreter/GIL.
+        partitions = min(workers, len(cpus))
+        cpu_sets = [cpus[index % partitions :: partitions] for index in range(workers)]
 
     runs = [ControllerRun.from_prep(prep.run_id, prep) for prep in preps]
     controller = Controller(
@@ -425,7 +448,8 @@ def drive_batches(
         )
 
     procs = [
-        _spawn_worker(controller_url, slots, i, worker_log_dir) for i in range(workers)
+        _spawn_worker(controller_url, slots, i, worker_log_dir, cpu_sets[i])
+        for i in range(workers)
     ]
     ConsoleDisplay.console.print(
         Text(

--- a/src/tau2/user/user_simulator_streaming.py
+++ b/src/tau2/user/user_simulator_streaming.py
@@ -1,5 +1,7 @@
 import random
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextvars import copy_context
 from copy import deepcopy
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -446,6 +448,7 @@ class VoiceStreamingUserSimulator(
         tick_duration_seconds: float = 0.05,
         persona_config: Optional[PersonaConfig] = None,
         audio_taps_dir: Optional["Path"] = None,
+        realtime_generation: bool = False,
     ):
         """
         Initialize the streaming user simulator.
@@ -499,6 +502,18 @@ class VoiceStreamingUserSimulator(
         self.backchannel_poisson_rate = backchannel_poisson_rate
         self.use_llm_backchannel = use_llm_backchannel
         self.interruption_check_interval = interruption_check_interval
+        self.realtime_generation = realtime_generation
+        self._generation: Future | None = None
+        self._generation_action = "generate_message"
+        self._listener: Future | None = None
+        self._generation_input_count = 0
+        self._generation_from_tool = False
+        self._last_generation_tick = 0
+        self._user_executor = (
+            ThreadPoolExecutor(max_workers=2, thread_name_prefix="voice-user")
+            if realtime_generation
+            else None
+        )
 
         # Default yield_threshold_when_interrupting to yield_threshold_when_interrupted if not set
         if (
@@ -678,6 +693,8 @@ class VoiceStreamingUserSimulator(
         tool_results: Optional[EnvironmentMessage] = None,
     ) -> None:
         """Stop the user simulator, close timeline events, and save audio taps."""
+        if self._user_executor is not None:
+            self._user_executor.shutdown(wait=True, cancel_futures=True)
         # Close any open timeline events at the final time
         if state is not None:
             end_ms = int(state.elapsed_samples * 1000 / PCM_SAMPLE_RATE)
@@ -778,6 +795,80 @@ class VoiceStreamingUserSimulator(
         return chunk.contains_speech if chunk.contains_speech is not None else True
 
     def _next_turn_taking_action(
+        self, state: UserAudioStreamingState
+    ) -> TurnTakingAction:
+        if not self.realtime_generation:
+            return self._compute_turn_taking_action(state)
+        if self._generation is not None:
+            return TurnTakingAction(
+                action=self._generation_action if self._generation.done() else "wait",
+                info="Customer generation pending",
+            )
+        if state.is_talking:
+            return self._compute_turn_taking_action(state)
+        if state.input_ongoing_speech_duration() > 0:
+            if self._listener is not None and self._listener.done():
+                action = self._listener.result()
+                self._listener = None
+                return action
+            if self._listener is None and (
+                self.interruption_check_interval is None
+                or state.tick_count % self.interruption_check_interval == 0
+            ):
+                self._listener = self._user_executor.submit(
+                    copy_context().run,
+                    self._compute_turn_taking_action,
+                    self._generation_snapshot(state),
+                )
+            return TurnTakingAction(action="wait", info="Listening")
+        if self._listener is not None and self._listener.done():
+            self._listener.result()  # Surface errors, but do not apply a stale reaction.
+            self._listener = None
+        if (
+            state.input_total_speech_duration() == 0
+            and state.tick_count - self._last_generation_tick
+            < self.wait_to_respond_threshold_self
+        ):
+            return TurnTakingAction(
+                action="wait", info="Waiting before next generation"
+            )
+        return self._compute_turn_taking_action(state)
+
+    @staticmethod
+    def _generation_snapshot(state: UserAudioStreamingState) -> UserAudioStreamingState:
+        # History messages are immutable here; isolate the lists the tick loop updates.
+        return state.model_copy(
+            update={
+                "ticks": list(state.ticks),
+                "input_turn_taking_buffer": list(state.input_turn_taking_buffer),
+                "output_streaming_queue": list(state.output_streaming_queue),
+            }
+        )
+
+    def _start_generation(self, state, tool_result=None) -> None:
+        snapshot = self._generation_snapshot(state)
+        self._generation_input_count = len(state.input_turn_taking_buffer)
+        self._generation_from_tool = tool_result is not None
+        self._generation_action = "generate_message"
+        self._last_generation_tick = state.tick_count
+        if self._listener is not None:
+            self._listener.cancel()
+            self._listener = None
+        if tool_result is not None:
+            snapshot.input_turn_taking_buffer = [tool_result]
+        message = (
+            snapshot.input_turn_taking_buffer[-1]
+            if snapshot.input_turn_taking_buffer
+            else None
+        )
+        self._generation = self._user_executor.submit(
+            copy_context().run,
+            self._generate_full_duplex_voice_message,
+            message,
+            snapshot,
+        )
+
+    def _compute_turn_taking_action(
         self, state: UserAudioStreamingState
     ) -> TurnTakingAction:
         """
@@ -1075,11 +1166,31 @@ class VoiceStreamingUserSimulator(
             state.output_streaming_queue = []
             state.is_backchanneling = False
         elif action.action == "generate_message":
-            merged_message = merge_homogeneous_chunks(state.input_turn_taking_buffer)
-            full_message, new_state = self._generate_full_duplex_voice_message(
-                merged_message, state
-            )
-            state.input_turn_taking_buffer = []
+            if self.realtime_generation:
+                if self._generation is None:
+                    self._start_generation(state)
+                    return self._emit_waiting_chunk(state)
+                if not self._generation.done():
+                    return self._emit_waiting_chunk(state)
+                full_message, generated_state = self._generation.result()
+                self._generation = None
+                state.user_utterance_count = generated_state.user_utterance_count
+                for name in ("_llm_generation_seconds", "_tts_synthesis_seconds"):
+                    setattr(state, name, getattr(generated_state, name, None))
+                fresh_input = state.input_turn_taking_buffer[
+                    self._generation_input_count :
+                ]
+                state.input_turn_taking_buffer = fresh_input
+                state.delivering_tool_result_speech = self._generation_from_tool
+                new_state = state
+            else:
+                merged_message = merge_homogeneous_chunks(
+                    state.input_turn_taking_buffer
+                )
+                full_message, new_state = self._generate_full_duplex_voice_message(
+                    merged_message, state
+                )
+                state.input_turn_taking_buffer = []
             if full_message.is_tool_call():
                 logger.debug("Generating message: Tool call detected")
                 noise_chunk = self._apply_chunk_effects(
@@ -1096,6 +1207,11 @@ class VoiceStreamingUserSimulator(
                 logger.debug("Generating message: Stop message detected")
                 full_message.turn_taking_action = action
                 return full_message, new_state
+            elif not full_message.has_text_content():
+                logger.info(
+                    "Customer returned no speech or tools; continuing to listen"
+                )
+                return self._emit_waiting_chunk(state)
             else:
                 logger.debug("Generating message: Creating chunk messages")
                 chunk_messages = self._create_chunk_messages(full_message)
@@ -1110,7 +1226,22 @@ class VoiceStreamingUserSimulator(
             logger.debug("Waiting: No action required")
         elif action.action == "backchannel":
             logger.debug("Backchannel: Generating backchannel message")
-            backchannel_message = self._generate_backchannel_message(state)
+            if self.realtime_generation:
+                if self._generation is None:
+                    self._generation_action = "backchannel"
+                    self._generation = self._user_executor.submit(
+                        copy_context().run,
+                        self._generate_backchannel_result,
+                        self._generation_snapshot(state),
+                    )
+                    return self._emit_waiting_chunk(state)
+                if not self._generation.done():
+                    return self._emit_waiting_chunk(state)
+                backchannel_message, generated_state = self._generation.result()
+                self._generation = None
+                state.user_utterance_count = generated_state.user_utterance_count
+            else:
+                backchannel_message = self._generate_backchannel_message(state)
             chunk_messages = self._create_chunk_messages(backchannel_message)
             logger.debug(f"Backchannel: Created {len(chunk_messages)} chunk messages")
             state.output_streaming_queue.extend(chunk_messages)
@@ -1162,6 +1293,13 @@ class VoiceStreamingUserSimulator(
         state: UserAudioStreamingState,
     ) -> Tuple[UserMessage, UserAudioStreamingState]:
         """Process a tool result by calling the LLM and returning the response."""
+        if self.realtime_generation:
+            if self._generation is not None:
+                raise RuntimeError(
+                    "Tool result arrived while customer generation is pending"
+                )
+            self._start_generation(state, tool_result)
+            return self._emit_waiting_chunk(state)
         # Temporarily set buffer so get_linearized_messages(include_pending_input=True)
         # picks up the tool result for LLM context
         saved_buffer = state.input_turn_taking_buffer
@@ -1232,7 +1370,9 @@ class VoiceStreamingUserSimulator(
         )
 
         # Check that last message is a valid user input message
-        if not isinstance(linearized_messages[-1], (ValidUserInputMessage)):
+        if linearized_messages and not isinstance(
+            linearized_messages[-1], (ValidUserInputMessage)
+        ):
             if isinstance(linearized_messages[-1], SystemMessage):
                 # SystemMessage at end is expected (e.g., silence annotations)
                 logger.debug(
@@ -1243,7 +1383,9 @@ class VoiceStreamingUserSimulator(
                     f"Last message is not a valid user input message: {type(linearized_messages[-1]).__name__}"
                 )
 
-        if isinstance(linearized_messages[-1], (AssistantMessage)):
+        if linearized_messages and isinstance(
+            linearized_messages[-1], (AssistantMessage)
+        ):
             if linearized_messages[-1].content is None:
                 logger.warning(
                     f"Last message is an assistant message with no content: {linearized_messages[-1]}"
@@ -1308,6 +1450,9 @@ class VoiceStreamingUserSimulator(
 
         # Check for stop
         if self.is_stop(user_message):
+            return user_message, state
+
+        if not user_message.has_text_content():
             return user_message, state
 
         # Synthesize voice (without background noise - added per chunk) with timing
@@ -1422,6 +1567,9 @@ class VoiceStreamingUserSimulator(
             add_telephony_format=False,
             add_channel_effects=False,
         )
+
+    def _generate_backchannel_result(self, state):
+        return self._generate_backchannel_message(state), state
 
 
 def _format_conversation_history(messages: list[Message]) -> str:

--- a/src/tau2/utils/display.py
+++ b/src/tau2/utils/display.py
@@ -2919,10 +2919,9 @@ class MarkdownDisplay:
 
             user_results_str = ""
             if user_results:
-                results_preview = [
-                    r[:100] + "..." if len(r) > 100 else r for r in user_results
-                ]
-                user_results_str = escape_table("; ".join(results_preview))
+                # This Markdown is also judge input: hiding fields can turn
+                # grounded customer claims into apparent hallucinations.
+                user_results_str = escape_table("; ".join(user_results))
 
             # Build row
             row = [tick_label, agent_content]

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -10,7 +10,8 @@ create_adapter(): Factory function that validates parameters and constructs
 
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Any, Awaitable, Callable, List, Optional, Tuple
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Optional, Tuple
 
 from loguru import logger
 
@@ -30,6 +31,9 @@ from tau2.voice.audio_native.tick_result import (
     buffer_excess_audio,
     get_proportional_transcript,
 )
+
+if TYPE_CHECKING:
+    from tau2.voice.audio_native.openai.live_config import LiveConfig
 
 
 class DiscreteTimeAdapter(ABC):
@@ -91,6 +95,8 @@ class DiscreteTimeAdapter(ABC):
             self.audio_format.bytes_per_second * tick_duration_ms / 1000
         )
         self.send_audio_instant = send_audio_instant
+        self.realtime_pacing = False
+        self._next_tick_start: float | None = None
         self._voip_interval_ms = DEFAULT_AUDIO_NATIVE_VOIP_PACKET_INTERVAL_MS
 
         # Shared tick state (managed by _async_run_tick template)
@@ -181,6 +187,7 @@ class DiscreteTimeAdapter(ABC):
         survive disconnect() so it can be collected at simulation end.
         """
         self._buffered_agent_audio.clear()
+        self._next_tick_start = None
         self._utterance_transcripts.clear()
         self._pending_tool_results.clear()
         self._skip_item_id = None
@@ -227,6 +234,10 @@ class DiscreteTimeAdapter(ABC):
         Subclasses implement _execute_tick() and _flush_pending_tool_results().
         """
         tick_start = asyncio.get_running_loop().time()
+        if self.realtime_pacing:
+            if self._next_tick_start is not None:
+                tick_start = self._next_tick_start
+            self._next_tick_start = tick_start + self.tick_duration_ms / 1000
         self._current_tick_number = tick_number
 
         # 1. Flush pending tool results
@@ -248,9 +259,8 @@ class DiscreteTimeAdapter(ABC):
         )
 
         # 3. Prepend buffered audio from previous tick
-        for chunk_data, item_id in self._buffered_agent_audio:
-            result.agent_audio_chunks.append((chunk_data, item_id))
-        self._buffered_agent_audio.clear()
+        result.agent_audio_chunks = self._buffered_agent_audio
+        self._buffered_agent_audio = []
 
         # 4. Carry over skip state
         result.skip_item_id = self._skip_item_id
@@ -377,6 +387,8 @@ def create_adapter(
     reasoning_effort: Optional[str] = None,
     audio_format: Optional[AudioFormat] = None,
     cascaded_config: Any = None,
+    live_config: Optional["LiveConfig"] = None,
+    trace_path: Optional[Path] = None,
 ) -> Tuple[DiscreteTimeAdapter, str]:
     """Create a discrete-time adapter for the given provider.
 
@@ -393,6 +405,8 @@ def create_adapter(
         audio_format: Audio format for external communication. Defaults to
             telephony (8kHz μ-law).
         cascaded_config: Configuration for cascaded providers (livekit).
+        live_config: Frontend and delegated backend configuration for OpenAI Live.
+        trace_path: Optional private protocol trace for OpenAI Live.
 
     Returns:
         Tuple of (adapter, resolved_model).
@@ -406,6 +420,8 @@ def create_adapter(
 
     # --- Resolve model default ---
     if model is None:
+        if provider == "openai_live":
+            raise ValueError("openai_live requires an explicit frontend model")
         if provider == "livekit":
             from tau2.voice.audio_native.livekit.config import CascadedConfig
 
@@ -435,6 +451,22 @@ def create_adapter(
             model=model,
             reasoning_effort=reasoning_effort,
             audio_format=audio_format,
+        )
+    elif provider == "openai_live":
+        from tau2.voice.audio_native.openai.live_adapter import (
+            DiscreteTimeOpenAILiveAdapter,
+        )
+
+        if live_config is None:
+            raise ValueError("openai_live requires live_config with a backend model")
+        adapter = DiscreteTimeOpenAILiveAdapter(
+            tick_duration_ms=tick_duration_ms,
+            model=model,
+            config=live_config,
+            reasoning_effort=reasoning_effort,
+            send_audio_instant=send_audio_instant,
+            audio_format=audio_format,
+            trace_path=trace_path,
         )
     elif provider == "gemini":
         from tau2.voice.audio_native.gemini.discrete_time_adapter import (

--- a/src/tau2/voice/audio_native/async_loop.py
+++ b/src/tau2/voice/audio_native/async_loop.py
@@ -10,6 +10,7 @@ layer.  This module provides a thin helper that manages a dedicated
 import asyncio
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional, TypeVar
 
 T = TypeVar("T")
@@ -28,9 +29,10 @@ class BackgroundAsyncLoop:
         bg.stop()
     """
 
-    def __init__(self) -> None:
+    def __init__(self, executor_workers: Optional[int] = None) -> None:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[threading.Thread] = None
+        self._executor_workers = executor_workers
 
     @property
     def loop(self) -> Optional[asyncio.AbstractEventLoop]:
@@ -51,9 +53,17 @@ class BackgroundAsyncLoop:
             return
 
         def _run_loop() -> None:
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
-            self._loop.run_forever()
+            # Closing the runner also cancels tasks and joins codec executors.
+            with asyncio.Runner() as runner:
+                self._loop = runner.get_loop()
+                if self._executor_workers is not None:
+                    self._loop.set_default_executor(
+                        ThreadPoolExecutor(
+                            max_workers=self._executor_workers,
+                            thread_name_prefix="tau2-audio",
+                        )
+                    )
+                self._loop.run_forever()
 
         self._thread = threading.Thread(target=_run_loop, daemon=True)
         self._thread.start()

--- a/src/tau2/voice/audio_native/openai/live_adapter.py
+++ b/src/tau2/voice/audio_native/openai/live_adapter.py
@@ -1,0 +1,169 @@
+"""Connect Live media to Sierra's voice simulator tick interface."""
+
+import audioop
+import base64
+import hashlib
+from collections import deque
+from pathlib import Path
+
+from tau2.config import DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
+from tau2.data_model.audio import TELEPHONY_AUDIO_FORMAT, AudioFormat
+from tau2.voice.audio_native.async_loop import BackgroundAsyncLoop
+from tau2.voice.audio_native.audio_converter import StreamingTelephonyConverter
+from tau2.voice.audio_native.openai.discrete_time_adapter import (
+    DiscreteTimeOpenAIAdapter,
+)
+from tau2.voice.audio_native.openai.events import AudioDeltaEvent
+from tau2.voice.audio_native.openai.live_config import LiveConfig
+from tau2.voice.audio_native.openai.live_provider import (
+    LiveTranscriptDelta,
+    OpenAILiveProvider,
+)
+from tau2.voice.audio_native.tick_result import TickResult
+
+
+class DiscreteTimeOpenAILiveAdapter(DiscreteTimeOpenAIAdapter):
+    def __init__(
+        self,
+        *,
+        tick_duration_ms: int,
+        model: str,
+        config: LiveConfig,
+        reasoning_effort: str | None = None,
+        send_audio_instant: bool = False,
+        audio_format: AudioFormat | None = None,
+        trace_path: Path | None = None,
+    ) -> None:
+        if audio_format is not None and audio_format != TELEPHONY_AUDIO_FORMAT:
+            raise ValueError("The Live adapter expects 8 kHz mu-law telephony audio")
+        super().__init__(
+            tick_duration_ms=tick_duration_ms,
+            # Queue the tick once; the WebRTC track already clocks its 20 ms frames.
+            send_audio_instant=True,
+            provider=OpenAILiveProvider(
+                model=model,
+                config=config,
+                reasoning_effort=reasoning_effort,
+                trace_path=trace_path,
+            ),
+            audio_format=audio_format,
+        )
+        self.model = model
+        self.realtime_pacing = True
+        # One encoder runs at a time; leave a second slot for DNS/setup work.
+        self._bg_loop = BackgroundAsyncLoop(executor_workers=2)
+        self._live_config = config
+        self._live_reasoning_effort = reasoning_effort
+        self._trace_path = trace_path
+        self._owns_provider = True
+        self._transcript_deltas: deque[LiveTranscriptDelta] = deque()
+        self._played_audio_bytes = 0
+        self._received_audio_bytes = 0
+        self._received_audio_hash = hashlib.sha256()
+        self._played_audio_hash = hashlib.sha256()
+        self._max_buffered_audio_bytes = 0
+        self._converter = StreamingTelephonyConverter(
+            input_sample_rate=DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE,
+            output_sample_rate=DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE,
+        )
+        self._chunk_size = int(
+            DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE * 2 * self._voip_interval_ms / 1000
+        )
+
+    def connect(self, system_prompt, tools, vad_config=None, modality="audio") -> None:
+        if self.is_connected:
+            self.disconnect()
+        if self.provider._closing:
+            self._provider = OpenAILiveProvider(
+                model=self.model,
+                config=self._live_config,
+                reasoning_effort=self._live_reasoning_effort,
+                trace_path=self._trace_path,
+            )
+        super().connect(system_prompt, tools, vad_config, modality)
+
+    async def _execute_tick(
+        self, user_audio: bytes, tick_number: int, result: TickResult, tick_start: float
+    ) -> None:
+        await super()._execute_tick(
+            self._converter.convert_input(user_audio), tick_number, result, tick_start
+        )
+
+    async def _process_event(self, result: TickResult, event: object) -> None:
+        if isinstance(event, LiveTranscriptDelta):
+            result.events.append(event)
+            self._transcript_deltas.append(event)
+            return
+        if isinstance(event, AudioDeltaEvent):
+            audio = self._converter.convert_output(base64.b64decode(event.delta))
+            self._received_audio_bytes += len(audio)
+            self._received_audio_hash.update(audio)
+            event = event.model_copy(
+                update={"delta": base64.b64encode(audio).decode("ascii")}
+            )
+        await super()._process_event(result, event)
+
+    def run_tick(self, user_audio: bytes, tick_number: int | None = None) -> TickResult:
+        result = super().run_tick(user_audio, tick_number)
+        self._played_audio_bytes += len(result.agent_audio_data)
+        self._played_audio_hash.update(result.agent_audio_data)
+        self._max_buffered_audio_bytes = max(
+            self._max_buffered_audio_bytes,
+            self._received_audio_bytes - self._played_audio_bytes,
+        )
+        # Compare sample durations across PCM16 ingress and mu-law playback.
+        played_pcm_bytes = (
+            self._played_audio_bytes
+            * DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
+            * 2
+            // self.audio_format.bytes_per_second
+        )
+        text = []
+        while (
+            self._transcript_deltas
+            and self._transcript_deltas[0].audio_position_bytes <= played_pcm_bytes
+        ):
+            text.append(self._transcript_deltas.popleft().delta)
+        result.proportional_transcript = "".join(text)
+        # WebRTC also transports silence. Classify the delivered audio, without
+        # deleting quiet frames or changing the shared tick buffering lifecycle.
+        pcm = audioop.ulaw2lin(result.agent_audio_data, 2)
+        result.contains_speech = bool(pcm) and audioop.max(pcm, 2) > 32
+        return result
+
+    async def _async_disconnect(self) -> None:
+        delivered_and_pending = self._played_audio_hash.copy()
+        buffered_bytes = 0
+        for audio, _ in self._buffered_agent_audio:
+            delivered_and_pending.update(audio)
+            buffered_bytes += len(audio)
+        self.provider._record(
+            "audio_delivery",
+            {
+                "received_bytes": self._received_audio_bytes,
+                "played_bytes": self._played_audio_bytes,
+                "buffered_bytes": buffered_bytes,
+                "audio_preserved_in_order": (
+                    delivered_and_pending.digest() == self._received_audio_hash.digest()
+                    and self._played_audio_bytes + buffered_bytes
+                    == self._received_audio_bytes
+                ),
+                "max_buffer_ms": self._max_buffered_audio_bytes
+                * 1000
+                / self.audio_format.bytes_per_second,
+            },
+        )
+        await super()._async_disconnect()
+
+    def disconnect(self) -> None:
+        super().disconnect()
+        self._converter.reset()
+
+    def clear_buffers(self) -> None:
+        super().clear_buffers()
+        self._transcript_deltas.clear()
+        self._played_audio_bytes = 0
+        self._received_audio_bytes = 0
+        self._received_audio_hash = hashlib.sha256()
+        self._played_audio_hash = hashlib.sha256()
+        self._max_buffered_audio_bytes = 0

--- a/src/tau2/voice/audio_native/openai/live_config.py
+++ b/src/tau2/voice/audio_native/openai/live_config.py
@@ -1,0 +1,16 @@
+"""Configuration for the OpenAI Live voice frontend and delegated backend."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class LiveConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    backend_model: str
+    voice: str = "marin"
+    append_system_prompt: bool = True
+    frontend_prompt: str = (
+        "Listen and speak to the customer. Delegate support decisions and "
+        "tool use to SpawnThinking. Speak the delegated answer to the customer."
+    )
+    backend_prompt: str = ""

--- a/src/tau2/voice/audio_native/openai/live_provider.py
+++ b/src/tau2/voice/audio_native/openai/live_provider.py
@@ -1,0 +1,517 @@
+"""OpenAI Live V3 over WebRTC, with server-owned Responses delegation."""
+
+import asyncio
+import audioop
+import base64
+import contextlib
+import json
+import time
+from fractions import Fraction
+from pathlib import Path
+from typing import AsyncGenerator
+
+import aiohttp
+import numpy as np
+from aiortc import (
+    AudioStreamTrack,
+    RTCConfiguration,
+    RTCPeerConnection,
+    RTCSessionDescription,
+)
+from aiortc.mediastreams import MediaStreamError
+from aiortc.rtcrtpparameters import RTCRtcpFeedback
+from aiortc.rtcrtpreceiver import NackGenerator
+from aiortc.sdp import SessionDescription
+from av import AudioFrame
+from av.audio.resampler import AudioResampler
+from loguru import logger
+
+from tau2.config import DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
+from tau2.data_model.audio import AudioEncoding, AudioFormat
+from tau2.environment.tool import Tool
+from tau2.voice.audio_native.openai.events import (
+    AudioTranscriptDeltaEvent,
+    BaseRealtimeEvent,
+    TimeoutEvent,
+    parse_realtime_event,
+)
+from tau2.voice.audio_native.openai.live_config import LiveConfig
+from tau2.voice.audio_native.openai.provider import (
+    OpenAIRealtimeProvider,
+    OpenAIVADConfig,
+)
+
+
+class LiveTranscriptDelta(AudioTranscriptDeltaEvent):
+    """A native transcript delta located on the received PCM timeline."""
+
+    audio_position_bytes: int
+    start_ms: int
+    end_ms: int
+
+
+class _LiveInputAudioTrack(AudioStreamTrack):
+    """Clock queued PCM at 20 ms intervals; never gate it on transcript events."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._buffer = bytearray()
+        self._resample_state = None
+        self._timestamp = 0
+        self._started_at: float | None = None
+        self.sample_rate = 48_000
+        self.samples_per_frame = 960
+        self.max_schedule_lag_ms = 0.0
+        self.max_buffer_ms = 0.0
+        self.frames_sent = 0
+        self.frames_late_100ms = 0
+
+    def append(
+        self, audio: bytes, sample_rate: int = DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
+    ) -> None:
+        if not audio:
+            return
+        resampled, self._resample_state = audioop.ratecv(
+            audio, 2, 1, sample_rate, self.sample_rate, self._resample_state
+        )
+        self._buffer.extend(resampled)
+        self.max_buffer_ms = max(
+            self.max_buffer_ms, len(self._buffer) * 500 / self.sample_rate
+        )
+
+    async def recv(self) -> AudioFrame:
+        loop = asyncio.get_running_loop()
+        if self._started_at is None:
+            self._started_at = loop.time()
+        target = self._started_at + self._timestamp / self.sample_rate
+        await asyncio.sleep(max(0.0, target - loop.time()))
+        lag_ms = (loop.time() - target) * 1000
+        self.max_schedule_lag_ms = max(self.max_schedule_lag_ms, lag_ms)
+        self.frames_sent += 1
+        self.frames_late_100ms += lag_ms > 100
+        size = self.samples_per_frame * 2
+        audio = bytes(self._buffer[:size]).ljust(size, b"\x00")
+        del self._buffer[:size]
+        frame = AudioFrame.from_ndarray(
+            np.frombuffer(audio, dtype=np.int16).reshape(1, self.samples_per_frame),
+            format="s16",
+            layout="mono",
+        )
+        frame.sample_rate = self.sample_rate
+        frame.time_base = Fraction(1, self.sample_rate)
+        frame.pts = self._timestamp
+        self._timestamp += self.samples_per_frame
+        return frame
+
+
+class OpenAILiveProvider(OpenAIRealtimeProvider):
+    """Keep media continuous while exposing the existing agent event contract.
+
+    V3 tool continuations are client-triggered. A response is continued only
+    after its complete batch of function calls has been returned. Speech and
+    transcript arrival never trigger a response or truncate the media track.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        config: LiveConfig,
+        reasoning_effort: str | None = None,
+        api_key: str | None = None,
+        trace_path: Path | None = None,
+    ) -> None:
+        super().__init__(
+            api_key=api_key, model=model, reasoning_effort=reasoning_effort
+        )
+        self.config = config
+        self.trace_path = trace_path
+        self._trace = None
+        self.session_id: str | None = None
+        self._peer: RTCPeerConnection | None = None
+        self._channel = None
+        self._input_track: _LiveInputAudioTrack | None = None
+        self._channel_open = asyncio.Event()
+        self._started = asyncio.Event()
+        self._closed = asyncio.Event()
+        self._closing = False
+        self._events: asyncio.Queue[dict] = asyncio.Queue()
+        self._received_audio_bytes = 0
+        self._received_audio_gap_ms = 0.0
+        self._received_audio_overlap_ms = 0.0
+        self._audio_tasks: set[asyncio.Task] = set()
+        self._response_ids: dict[str, str] = {}
+        self._tool_calls: dict[str, set[str]] = {}
+        self._pending: dict[str, set[str]] = {}
+        self._returned: set[str] = set()
+        self._continued: set[str] = set()
+        self._surfaced: set[str] = set()
+        self.delegation_count = 0
+
+    def _record(self, direction: str, event: dict) -> None:
+        if self._trace is not None:
+            self._trace.write(
+                json.dumps(
+                    {"timestamp": time.time(), "direction": direction, "event": event}
+                )
+                + "\n"
+            )
+
+    def _send_event(self, event: dict) -> None:
+        if self._channel is None or self._channel.readyState != "open":
+            raise ConnectionError("Live data channel is not open")
+        self._channel.send(json.dumps(event))
+        self._record("sent", event)
+
+    def _accept_event(self, event: dict) -> None:
+        self._record("received", event)
+        if event["type"] == "session.started":
+            self._started.set()
+        elif event["type"] == "session.closed":
+            self._closed.set()
+        elif event["type"] == "session.output_transcript.delta":
+            # Capture at arrival, not when a delayed tick drains the event queue.
+            event = dict(event, audio_position_bytes=self._received_audio_bytes)
+            self._record("transcript_ingress", event)
+        self._events.put_nowait(event)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._peer is not None and self._peer.connectionState not in {
+            "closed",
+            "failed",
+        }
+
+    async def connect(self) -> None:
+        if self._peer is not None or self._closing:
+            raise RuntimeError("Create a new Live provider for each session")
+        peer = RTCPeerConnection(configuration=RTCConfiguration(iceServers=[]))
+        self._peer = peer
+        self._input_track = _LiveInputAudioTrack()
+        peer.addTrack(self._input_track)
+        # aiortc 1.15 has no public audio NACK switch. Enable its existing
+        # recovery mechanism on this receiver without changing other providers.
+        peer.getReceivers()[0]._RTCRtpReceiver__nack_generator = NackGenerator()
+        self._channel = peer.createDataChannel("")
+
+        @self._channel.on("open")
+        def on_open() -> None:
+            self._channel_open.set()
+
+        @self._channel.on("message")
+        def on_message(message: str | bytes) -> None:
+            self._accept_event(json.loads(message))
+
+        @peer.on("connectionstatechange")
+        def on_state() -> None:
+            if not self._closing and peer.connectionState in {"failed", "closed"}:
+                self._events.put_nowait(
+                    {
+                        "type": "error",
+                        "error": {
+                            "code": "webrtc_connection_closed",
+                            "message": peer.connectionState,
+                        },
+                    }
+                )
+
+        @peer.on("track")
+        def on_track(track: AudioStreamTrack) -> None:
+            if track.kind == "audio":
+                task = asyncio.create_task(self._receive_audio(track))
+                self._audio_tasks.add(task)
+                task.add_done_callback(on_audio_finished)
+
+        def on_audio_finished(task: asyncio.Task) -> None:
+            self._audio_tasks.discard(task)
+            if not task.cancelled() and (error := task.exception()) is not None:
+                self._events.put_nowait(
+                    {
+                        "type": "error",
+                        "error": {
+                            "code": "webrtc_audio_failed",
+                            "message": str(error),
+                        },
+                    }
+                )
+
+    async def _receive_audio(self, track: AudioStreamTrack) -> None:
+        resampler = AudioResampler(
+            format="s16", layout="mono", rate=DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE
+        )
+        expected_audio_time = None
+        while not self._closing:
+            try:
+                frame = await track.recv()
+            except MediaStreamError:
+                if not self._closing:
+                    raise ConnectionError("Live remote audio track ended") from None
+                return
+            audio_time = frame.pts * frame.time_base
+            if expected_audio_time is not None:
+                gap_ms = float(audio_time - expected_audio_time) * 1000
+                self._received_audio_gap_ms += max(0, gap_ms)
+                self._received_audio_overlap_ms += max(0, -gap_ms)
+            expected_audio_time = audio_time + Fraction(
+                frame.samples, frame.sample_rate
+            )
+            for converted in resampler.resample(frame):
+                pcm = (
+                    converted.to_ndarray()
+                    .reshape(-1)
+                    .astype(np.int16, copy=False)
+                    .tobytes()
+                )
+                self._received_audio_bytes += len(pcm)
+                self._events.put_nowait(
+                    {
+                        "type": "live.media.audio",
+                        "audio": base64.b64encode(pcm).decode("ascii"),
+                    }
+                )
+
+    def _build_session(self, system_prompt: str, tools: list[Tool]) -> dict:
+        responses = {
+            "model": self.config.backend_model,
+            "instructions": self.config.backend_prompt
+            + ("\n\n" + system_prompt if self.config.append_system_prompt else ""),
+            "tools": self._format_tools_for_api(tools),
+            "tool_choice": "auto",
+            "parallel_tool_calls": False,
+        }
+        if self.reasoning_effort is not None:
+            responses["reasoning"] = {"effort": self.reasoning_effort}
+        return {
+            "model": self.model,
+            "instructions": self.config.frontend_prompt,
+            "audio": {"output": {"voice": self.config.voice}},
+            "delegation": {"type": "responses", "responses": responses},
+        }
+
+    async def _create_offer(self) -> RTCSessionDescription:
+        offer = await self._peer.createOffer()
+        description = SessionDescription.parse(offer.sdp)
+        for media in description.media:
+            if media.kind == "audio":
+                for codec in media.rtp.codecs:
+                    codec.rtcpFeedback.append(RTCRtcpFeedback(type="nack"))
+        return RTCSessionDescription(sdp=str(description), type=offer.type)
+
+    async def configure_session(
+        self,
+        system_prompt: str,
+        tools: list[Tool],
+        vad_config: OpenAIVADConfig,
+        modality: str = "audio",
+        audio_format: AudioFormat | None = None,
+    ) -> None:
+        if modality != "audio":
+            raise ValueError("OpenAI Live requires audio modality")
+        if self._peer is None:
+            raise RuntimeError("Call connect before configuring Live")
+        self._audio_format = AudioFormat(
+            encoding=AudioEncoding.PCM_S16LE,
+            sample_rate=DEFAULT_OPENAI_OUTPUT_SAMPLE_RATE,
+        )
+        if self.trace_path is not None:
+            self.trace_path.parent.mkdir(parents=True, exist_ok=True)
+            self._trace = self.trace_path.open("a", encoding="utf-8", buffering=1)
+        try:
+            session = self._build_session(system_prompt, tools)
+            self._record("configuration", session)
+            offer = await self._create_offer()
+            await self._peer.setLocalDescription(offer)
+            headers = {
+                "Authorization": f"Bearer {self.api_key}",
+                "OpenAI-Alpha": "quicksilver=v3",
+            }
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=25)
+            ) as client:
+                async with client.post(
+                    "https://api.openai.com/v1/live/sessions",
+                    headers=headers,
+                    json={
+                        "session": session,
+                        "transport": {
+                            "type": "webrtc",
+                            "sdp": self._peer.localDescription.sdp,
+                        },
+                    },
+                ) as response:
+                    if not 200 <= response.status < 300:
+                        raise RuntimeError(
+                            f"Live session creation failed (HTTP {response.status}): {(await response.text())[:600]}"
+                        )
+                    created = await response.json()
+            self.session_id = created["session"]["id"]
+            self._record("created", {"session": created["session"]})
+            await self._peer.setRemoteDescription(
+                RTCSessionDescription(sdp=created["transport"]["sdp"], type="answer")
+            )
+            await asyncio.wait_for(self._channel_open.wait(), timeout=20)
+            await asyncio.wait_for(self._started.wait(), timeout=20)
+        except BaseException:
+            await self.disconnect()
+            raise
+
+    async def send_audio(self, audio_data: bytes) -> None:
+        if not self.is_connected or self._input_track is None:
+            raise ConnectionError("Live audio track is not connected")
+        self._input_track.append(audio_data)
+
+    async def send_tool_result(
+        self, call_id: str, result: str, request_response: bool = True
+    ) -> None:
+        self._send_event(
+            {
+                "type": "response.item.create",
+                "item": {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": result,
+                },
+            }
+        )
+        self._returned.add(call_id)
+        if request_response:
+            self._continue_tool_batches()
+
+    def _continue_tool_batches(self) -> None:
+        for response_id, required in list(self._pending.items()):
+            if required <= self._returned:
+                self._send_event({"type": "response.create"})
+                self._continued.add(response_id)
+                del self._pending[response_id]
+
+    def _normalize_event(self, data: dict) -> list[BaseRealtimeEvent]:
+        event_type = data["type"]
+        if event_type == "live.media.audio":
+            return [
+                parse_realtime_event(
+                    {
+                        "type": "response.output_audio.delta",
+                        "delta": data["audio"],
+                    }
+                )
+            ]
+        if event_type == "session.output_transcript.delta":
+            return [
+                LiveTranscriptDelta(
+                    type="response.output_audio_transcript.delta",
+                    delta=data["delta"],
+                    audio_position_bytes=data["audio_position_bytes"],
+                    start_ms=data["start_ms"],
+                    end_ms=data["end_ms"],
+                )
+            ]
+        if event_type == "session.delegation.created":
+            self.delegation_count += 1
+        elif event_type == "session.closed" and not self._closing:
+            raise ConnectionError(
+                f"Live session closed during conversation: {self.session_id}"
+            )
+        elif event_type == "error":
+            raise RuntimeError(f"Live API error: {data['error']}")
+        elif event_type == "response.event":
+            delegation_id = data["delegation_id"]
+            event = data["event"]
+            inner_type = event["type"]
+            if inner_type == "response.created":
+                self._response_ids[delegation_id] = event["response"]["id"]
+            elif (
+                inner_type == "response.output_item.done"
+                and event["item"]["type"] == "function_call"
+            ):
+                item = event["item"]
+                response_id = self._response_ids[delegation_id]
+                self._tool_calls.setdefault(response_id, set()).add(item["call_id"])
+                if item["call_id"] not in self._surfaced:
+                    self._surfaced.add(item["call_id"])
+                    return [
+                        parse_realtime_event(
+                            {
+                                "type": "response.function_call_arguments.done",
+                                "call_id": item["call_id"],
+                                "name": item["name"],
+                                "arguments": item["arguments"],
+                            }
+                        )
+                    ]
+            elif inner_type == "response.completed":
+                response_id = event["response"]["id"]
+                # Live compacts response.output; item.done events define the batch.
+                required = self._tool_calls.pop(response_id, set())
+                if required and response_id not in self._continued:
+                    self._pending[response_id] = required
+                    self._continue_tool_batches()
+            elif inner_type in {"response.failed", "response.incomplete", "error"}:
+                raise RuntimeError(f"Live backend failed: {event}")
+        return [parse_realtime_event(data)]
+
+    async def receive_events(self) -> AsyncGenerator[BaseRealtimeEvent, None]:
+        while self.is_connected:
+            try:
+                event = await asyncio.wait_for(self._events.get(), timeout=0.01)
+            except TimeoutError:
+                yield TimeoutEvent(type="timeout")
+                continue
+            for normalized in self._normalize_event(event):
+                yield normalized
+
+    async def disconnect(self) -> None:
+        self._closing = True
+        try:
+            if self._started.is_set() and not self._closed.is_set():
+                try:
+                    self._send_event({"type": "session.close"})
+                    await asyncio.wait_for(self._closed.wait(), timeout=5)
+                except (TimeoutError, ConnectionError):
+                    # Missing close acknowledgement must not invalidate a scored task.
+                    logger.warning("Live close not confirmed: {}", self.session_id)
+            for task in list(self._audio_tasks):
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+            if self._peer is not None:
+                try:
+                    stats = await self._peer.getStats()
+                    for stat in stats.values():
+                        if stat.type == "inbound-rtp" and stat.kind == "audio":
+                            self._record(
+                                "media_rtp",
+                                {
+                                    "packets_received": stat.packetsReceived,
+                                    "packets_lost": stat.packetsLost,
+                                    "jitter_samples": stat.jitter,
+                                },
+                            )
+                        elif stat.type == "remote-inbound-rtp" and stat.kind == "audio":
+                            self._record(
+                                "media_rtp_remote",
+                                {
+                                    "packets_received": stat.packetsReceived,
+                                    "packets_lost": stat.packetsLost,
+                                    "jitter_samples": stat.jitter,
+                                    "round_trip_time_s": stat.roundTripTime,
+                                },
+                            )
+                finally:
+                    await self._peer.close()
+                    self._peer = None
+        finally:
+            if self._input_track is not None:
+                self._record(
+                    "media",
+                    {
+                        "max_schedule_lag_ms": self._input_track.max_schedule_lag_ms,
+                        "max_buffer_ms": self._input_track.max_buffer_ms,
+                        "frames_sent": self._input_track.frames_sent,
+                        "frames_late_100ms": self._input_track.frames_late_100ms,
+                        "received_audio_gap_ms": self._received_audio_gap_ms,
+                        "received_audio_overlap_ms": self._received_audio_overlap_ms,
+                    },
+                )
+            if self._trace is not None:
+                self._trace.close()
+                self._trace = None

--- a/src/tau2/voice/audio_native/tick_result.py
+++ b/src/tau2/voice/audio_native/tick_result.py
@@ -129,6 +129,10 @@ class TickResult(BaseModel):
     )
 
     # --- Raw agent audio (unpadded) ---
+    contains_speech: Optional[bool] = Field(
+        default=None,
+        description="Speech activity for continuous media; None uses the legacy audio-presence rule",
+    )
     # These store the actual audio received from the API, without padding.
     # Use these to detect if agent actually spoke.
     agent_audio_chunks: List[Tuple[bytes, Optional[str]]] = Field(
@@ -443,7 +447,7 @@ def buffer_excess_audio(
     keep_chunks: List[Tuple[bytes, Optional[str]]] = []
     buffer_chunks: List[Tuple[bytes, Optional[str]]] = []
 
-    for chunk_data, item_id in result.agent_audio_chunks:
+    for index, (chunk_data, item_id) in enumerate(result.agent_audio_chunks):
         if total_bytes + len(chunk_data) <= bytes_per_tick:
             keep_chunks.append((chunk_data, item_id))
             total_bytes += len(chunk_data)
@@ -454,7 +458,9 @@ def buffer_excess_audio(
                 buffer_chunks.append((chunk_data[space_left:], item_id))
             else:
                 buffer_chunks.append((chunk_data, item_id))
-            total_bytes = bytes_per_tick
+            # The rest is already buffered; don't rescan a growing audio backlog.
+            buffer_chunks.extend(result.agent_audio_chunks[index + 1 :])
+            break
 
     result.agent_audio_chunks = keep_chunks
     return buffer_chunks

--- a/tests/test_streaming/test_voice_streaming_user_simulator.py
+++ b/tests/test_streaming/test_voice_streaming_user_simulator.py
@@ -10,10 +10,17 @@ This test suite verifies that the voice streaming user simulator works correctly
 - Time counters
 """
 
+from threading import Event
+
 import pytest
 
 from tau2.data_model.audio import AudioEncoding, AudioFormat
-from tau2.data_model.message import AssistantMessage, ToolCall, UserMessage
+from tau2.data_model.message import (
+    AssistantMessage,
+    ToolCall,
+    TurnTakingAction,
+    UserMessage,
+)
 from tau2.data_model.voice import SynthesisConfig, VoiceSettings
 from tau2.user.user_simulator_streaming import VoiceStreamingUserSimulator
 
@@ -208,6 +215,55 @@ def test_voice_streaming_user_chunk_accumulation(
 
     assert response_1 is not None
     assert len(state.input_turn_taking_buffer) >= 2
+
+
+def test_audio_ticks_continue_while_caller_generation_is_pending(
+    user_instructions, voice_settings, monkeypatch
+):
+    user = VoiceStreamingUserSimulator(
+        llm="gpt-4.1-2025-04-14",
+        instructions=user_instructions,
+        tools=None,
+        voice_settings=voice_settings,
+        chunk_size=1600,
+        realtime_generation=True,
+    )
+    state = user.get_init_state()
+    state.input_turn_taking_buffer.append(
+        AssistantMessage(role="assistant", content="Ready?", contains_speech=True)
+    )
+    started, release = Event(), Event()
+
+    def generate(message, snapshot):
+        started.set()
+        assert release.wait(5), "Caller generation blocked the audio tick loop"
+        snapshot.user_utterance_count += 1
+        return UserMessage(role="user", content="###STOP###"), snapshot
+
+    monkeypatch.setattr(user, "_generate_full_duplex_voice_message", generate)
+    action = TurnTakingAction(action="generate_message")
+    try:
+        waiting, state = user._perform_turn_taking_action(state, action)
+        assert started.wait(1)
+        assert waiting.contains_speech is False
+        for text in ("Your ", "order ", "shipped."):
+            waiting, state = user.get_next_chunk(
+                state,
+                AssistantMessage(role="assistant", content=text, contains_speech=True),
+            )
+            assert waiting.contains_speech is False
+        assert state.tick_count == 3
+        release.set()
+        user._generation.result(timeout=1)
+        reply, state = user._perform_turn_taking_action(state, action)
+        assert reply.content == "###STOP###"
+        assert state.user_utterance_count == 1
+        assert "".join(chunk.content for chunk in state.input_turn_taking_buffer) == (
+            "Your order shipped."
+        )
+    finally:
+        release.set()
+        user.stop(state)
 
 
 def test_voice_streaming_user_contains_speech_on_all_responses(

--- a/tests/test_voice/test_audio_native/test_live_provider.py
+++ b/tests/test_voice/test_audio_native/test_live_provider.py
@@ -1,0 +1,281 @@
+import asyncio
+import audioop
+import base64
+import json
+from copy import deepcopy
+from unittest.mock import AsyncMock, Mock
+
+import numpy as np
+import pytest
+from aiortc.rtcpeerconnection import CODECS
+from aiortc.sdp import SessionDescription
+
+from tau2.agent.base.streaming import _has_meaningful_content
+from tau2.data_model.message import AssistantMessage
+from tau2.data_model.simulation import AudioNativeConfig
+from tau2.voice.audio_native.audio_converter import StreamingTelephonyConverter
+from tau2.voice.audio_native.openai.discrete_time_adapter import (
+    DiscreteTimeOpenAIAdapter,
+)
+from tau2.voice.audio_native.openai.events import (
+    AudioDeltaEvent,
+    FunctionCallArgumentsDoneEvent,
+)
+from tau2.voice.audio_native.openai.live_adapter import DiscreteTimeOpenAILiveAdapter
+from tau2.voice.audio_native.openai.live_config import LiveConfig
+from tau2.voice.audio_native.openai.live_provider import (
+    LiveTranscriptDelta,
+    OpenAILiveProvider,
+    _LiveInputAudioTrack,
+)
+from tau2.voice.audio_native.tick_result import TickResult
+
+
+@pytest.fixture
+def provider():
+    result = OpenAILiveProvider(
+        model="test-live",
+        config=LiveConfig(backend_model="test-backend"),
+        reasoning_effort="low",
+        api_key="test-only",
+    )
+    result._channel = Mock(readyState="open")
+    return result
+
+
+def test_policy_and_tools_are_backend_only(provider):
+    tool = Mock(
+        openai_schema={
+            "function": {
+                "name": "lookup",
+                "description": "Read a record",
+                "parameters": {"type": "object"},
+            }
+        }
+    )
+    session = provider._build_session("ORIGINAL DOMAIN POLICY", [tool])
+    assert "ORIGINAL DOMAIN POLICY" not in session["instructions"]
+    backend = session["delegation"]["responses"]
+    assert backend["instructions"].endswith("ORIGINAL DOMAIN POLICY")
+    assert backend["model"] == "test-backend"
+    assert backend["reasoning"] == {"effort": "low"}
+    assert backend["tools"][0]["name"] == "lookup"
+    assert "tools" not in session
+    assert session["audio"]["output"]["voice"] == "marin"
+
+
+def test_config_rejects_missing_or_misrouted_backend():
+    with pytest.raises(ValueError, match="live_config is required"):
+        AudioNativeConfig(provider="openai_live", model="test-live")
+    with pytest.raises(ValueError, match="live_config is required"):
+        AudioNativeConfig(provider="openai", live_config={"backend_model": "test"})
+
+
+def test_offer_advertises_audio_recovery_without_changing_other_providers(provider):
+    original_codecs = deepcopy(CODECS)
+
+    async def check():
+        await provider.connect()
+        try:
+            offer = SessionDescription.parse((await provider._create_offer()).sdp)
+            audio = next(media for media in offer.media if media.kind == "audio")
+            assert all(
+                any(feedback.type == "nack" for feedback in codec.rtcpFeedback)
+                for codec in audio.rtp.codecs
+            )
+            assert CODECS == original_codecs
+        finally:
+            await provider.disconnect()
+
+    asyncio.run(check())
+
+
+def test_audio_arrives_without_any_turn_or_transcript_marker(provider):
+    pcm = b"\x00\x00" * 960 + b"\x01\x00" * 960
+    events = provider._normalize_event(
+        {"type": "live.media.audio", "audio": base64.b64encode(pcm).decode()}
+    )
+    assert len(events) == 1
+    assert isinstance(events[0], AudioDeltaEvent)
+    assert base64.b64decode(events[0].delta) == pcm
+
+
+def response_event(provider, event):
+    return provider._normalize_event(
+        {"type": "response.event", "delegation_id": "d1", "event": event}
+    )
+
+
+@pytest.mark.parametrize("results_before_completion", [False, True])
+def test_tool_batch_continues_once_after_all_outputs(
+    provider, results_before_completion
+):
+    response_event(provider, {"type": "response.created", "response": {"id": "r1"}})
+    for call_id in ("c1", "c2"):
+        event = {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "call_id": call_id,
+                "name": "lookup",
+                "arguments": "{}",
+            },
+        }
+        assert isinstance(
+            response_event(provider, event)[0], FunctionCallArgumentsDoneEvent
+        )
+        assert not any(
+            isinstance(e, FunctionCallArgumentsDoneEvent)
+            for e in response_event(provider, event)
+        )
+    complete = {"type": "response.completed", "response": {"id": "r1", "output": []}}
+    if not results_before_completion:
+        response_event(provider, complete)
+    asyncio.run(provider.send_tool_result("c1", "first", request_response=False))
+    sent = [json.loads(c.args[0]) for c in provider._channel.send.call_args_list]
+    assert [e["type"] for e in sent] == ["response.item.create"]
+    asyncio.run(provider.send_tool_result("c2", "second"))
+    if results_before_completion:
+        response_event(provider, complete)
+    assert not any(
+        isinstance(e, FunctionCallArgumentsDoneEvent)
+        for e in response_event(provider, event)
+    )
+    response_event(provider, complete)
+    sent = [json.loads(c.args[0]) for c in provider._channel.send.call_args_list]
+    assert [e["type"] for e in sent] == [
+        "response.item.create",
+        "response.item.create",
+        "response.create",
+    ]
+    assert [e["item"]["call_id"] for e in sent[:2]] == ["c1", "c2"]
+
+
+def test_quiet_pcm_is_not_removed_at_chunk_boundaries():
+    async def check():
+        track = _LiveInputAudioTrack()
+        pcm = np.arange(1920, dtype=np.int16).tobytes()
+        # Use the track's rate to isolate queue integrity from resampling.
+        track.append(pcm[:1700], sample_rate=48_000)
+        track.append(pcm[1700:], sample_rate=48_000)
+        frames = [await track.recv(), await track.recv()]
+        assert b"".join(f.to_ndarray().tobytes() for f in frames) == pcm
+        assert [f.pts for f in frames] == [0, 960]
+
+    asyncio.run(check())
+
+
+def test_buffered_audio_is_preserved_in_order(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-only")
+    adapter = DiscreteTimeOpenAILiveAdapter(
+        tick_duration_ms=200,
+        model="test-live",
+        config=LiveConfig(backend_model="test-backend"),
+    )
+    provider = adapter.provider
+    provider._peer = Mock(connectionState="connected")
+    provider.send_audio = AsyncMock()
+    provider.disconnect = AsyncMock()
+    provider._record = Mock()
+    pcm = np.concatenate(
+        [np.zeros(4800, dtype=np.int16), np.arange(4800, dtype=np.int16)]
+    ).tobytes()
+    expected = StreamingTelephonyConverter(
+        input_sample_rate=24000, output_sample_rate=24000
+    ).convert_output(pcm)
+
+    async def receive_burst():
+        for offset in range(0, len(pcm), 960):
+            provider._events.put_nowait(
+                {
+                    "type": "live.media.audio",
+                    "audio": base64.b64encode(pcm[offset : offset + 960]).decode(),
+                }
+            )
+
+    adapter._bg_loop.start()
+    adapter._connected = True
+    try:
+        adapter._bg_loop.run_coroutine(receive_burst())
+        played = b"".join(
+            adapter.run_tick(b"\xff" * 1600).agent_audio_data for _ in range(3)
+        )
+        assert played == expected
+    finally:
+        adapter.disconnect()
+    audit = next(
+        call.args[1]
+        for call in provider._record.call_args_list
+        if call.args[0] == "audio_delivery"
+    )
+    assert audit["audio_preserved_in_order"] is True
+    assert audit["received_bytes"] == audit["played_bytes"] == len(expected)
+    assert audit["buffered_bytes"] == 0
+
+
+@pytest.mark.parametrize("amplitude,speech", [(0, False), (1000, True)])
+def test_stock_activity_does_not_confuse_continuous_silence_with_speech(
+    monkeypatch, amplitude, speech
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-only")
+    adapter = DiscreteTimeOpenAILiveAdapter(
+        tick_duration_ms=200,
+        model="test-live",
+        config=LiveConfig(backend_model="test-backend"),
+    )
+    audio = audioop.lin2ulaw(np.full(1600, amplitude, dtype=np.int16).tobytes(), 2)
+    result = TickResult(
+        tick_number=1,
+        audio_sent_bytes=1600,
+        audio_sent_duration_ms=200,
+        agent_audio_chunks=[(audio, "speech")],
+    )
+    monkeypatch.setattr(DiscreteTimeOpenAIAdapter, "run_tick", lambda *args: result)
+    assert adapter.run_tick(b"\xff" * 1600).contains_speech is speech
+    assert result.agent_audio_data == audio
+    if not speech:
+        # Native text can arrive on a quiet PCM boundary. The stock caller
+        # must retain it, then resume treating transport silence as silence.
+        asyncio.run(
+            adapter._process_event(
+                result,
+                LiveTranscriptDelta(
+                    type="response.output_audio_transcript.delta",
+                    delta="Your order shipped.",
+                    audio_position_bytes=0,
+                    start_ms=0,
+                    end_ms=200,
+                ),
+            )
+        )
+        late = adapter.run_tick(b"\xff" * 1600)
+        message = AssistantMessage(
+            role="assistant",
+            content=late.proportional_transcript,
+            contains_speech=late.contains_speech,
+        )
+        assert message.content == "Your order shipped."
+        assert late.contains_speech is False
+        assert _has_meaningful_content(message)
+        assert late.agent_audio_data == audio
+        assert adapter.run_tick(b"\xff" * 1600).contains_speech is False
+
+
+def test_missing_close_ack_does_not_invalidate_completed_task(provider, monkeypatch):
+    provider._started.set()
+    provider._peer = Mock(close=AsyncMock(), getStats=AsyncMock(return_value={}))
+    peer = provider._peer
+
+    async def timed_out(awaitable, timeout):
+        awaitable.close()
+        raise TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", timed_out)
+    asyncio.run(provider.disconnect())
+    peer.close.assert_awaited_once()
+    assert json.loads(provider._channel.send.call_args.args[0]) == {
+        "type": "session.close"
+    }
+    with pytest.raises(ConnectionError, match="during conversation"):
+        provider._closing = False
+        provider._normalize_event({"type": "session.closed"})

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -58,6 +58,7 @@ import pytest
 from tau2.config import TELEPHONY_ULAW_SILENCE
 from tau2.environment.tool import Tool
 from tau2.voice.audio_native.adapter import DiscreteTimeAdapter, create_adapter
+from tau2.voice.audio_native.openai.live_config import LiveConfig
 from tau2.voice.audio_native.tick_result import TickResult
 
 pytestmark = pytest.mark.full_duplex_integration
@@ -72,6 +73,20 @@ TESTDATA_DIR = Path(__file__).parent / "testdata"
 # Each provider is gated by its env var so the suite only runs providers you
 # have credentials for.
 PROVIDERS = [
+    pytest.param(
+        "openai_live",
+        marks=pytest.mark.skipif(
+            not all(
+                os.environ.get(key)
+                for key in (
+                    "OPENAI_API_KEY",
+                    "OPENAI_LIVE_MODEL",
+                    "OPENAI_LIVE_BACKEND_MODEL",
+                )
+            ),
+            reason="OpenAI Live credentials and model names are required",
+        ),
+    ),
     pytest.param(
         "gemini",
         marks=pytest.mark.skipif(
@@ -339,6 +354,12 @@ def adapter(provider_name: str):
     """Create, yield, and teardown a DiscreteTimeAdapter."""
     real_provider = provider_name
     cascaded_config = None
+    live_config = None
+    model = None
+
+    if provider_name == "openai_live":
+        model = os.environ["OPENAI_LIVE_MODEL"]
+        live_config = LiveConfig(backend_model=os.environ["OPENAI_LIVE_BACKEND_MODEL"])
 
     if provider_name in CASCADED_CONFIG_ALIASES:
         from tau2.voice.audio_native.livekit.config import CASCADED_CONFIGS
@@ -350,6 +371,8 @@ def adapter(provider_name: str):
         real_provider,
         tick_duration_ms=TICK_DURATION_MS,
         cascaded_config=cascaded_config,
+        model=model,
+        live_config=live_config,
     )
     yield adapter
     if adapter.is_connected:

--- a/uv.lock
+++ b/uv.lock
@@ -85,6 +85,37 @@ wheels = [
 ]
 
 [[package]]
+name = "aioice"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/04/df7286233f468e19e9bedff023b6b246182f0b2ccb04ceeb69b2994021c6/aioice-0.10.2.tar.gz", hash = "sha256:bf236c6829ee33c8e540535d31cd5a066b531cb56de2be94c46be76d68b1a806", size = 44307, upload-time = "2025-11-28T15:56:48.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e3/0d23b1f930c17d371ce1ec36ee529f22fd19ebc2a07fe3418e3d1d884ce2/aioice-0.10.2-py3-none-any.whl", hash = "sha256:14911c15ab12d096dd14d372ebb4aecbb7420b52c9b76fdfcf54375dec17fcbf", size = 24875, upload-time = "2025-11-28T15:56:47.847Z" },
+]
+
+[[package]]
+name = "aiortc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aioice" },
+    { name = "av" },
+    { name = "cryptography" },
+    { name = "google-crc32c" },
+    { name = "pyee" },
+    { name = "pylibsrtp" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/42/af1e5755f4cdeb5926ef4aee4bd99d2fbc04b497dfe09f036d359219993e/aiortc-1.15.0.tar.gz", hash = "sha256:ee6c0757ca070cf6d6bee441936d6ede24eef51211bbff6653409c540f72e625", size = 1182039, upload-time = "2026-07-13T19:26:43.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/5f/8435ba02c9278b6cec6f168db92e1d3280dd3af8f2225e20dc7c3be5ab22/aiortc-1.15.0-py3-none-any.whl", hash = "sha256:4e1e54bff31a9c2cb654c7b7edc068085a7df53365e5df24a5cb24168e3f95f7", size = 93678, upload-time = "2026-07-13T19:26:42.241Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -396,6 +427,43 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -448,6 +516,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -977,6 +1054,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
+]
+
 [[package]]
 name = "huggingface-hub"
 version = "1.1.4"
@@ -1014,6 +1096,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
 ]
 
 [[package]]
@@ -2144,6 +2235,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/f1/fdedc2c75c3e31a330659c85e5793bb18b3397981fbf0844c6dee5b18926/pyee-14.0.0.tar.gz", hash = "sha256:76dd0f4314ecd27f02dc73589dea7fd3853f9b6176d8ef9b122860657e3602de", size = 98760, upload-time = "2026-08-13T04:26:11.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/12/5347938b1f9a6453f0dbdfcc3e2388a1320ef9b9ec17fbefbc4ab647ea98/pyee-14.0.0-py3-none-any.whl", hash = "sha256:3ac2d3229a9677f7de2c33d7f52fe25b638a46b19c413fea2edc8c6d0a644e4d", size = 15553, upload-time = "2026-08-13T04:26:09.916Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2159,6 +2262,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
+name = "pylibsrtp"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a6/6e532bec974aaecbf9fe4e12538489fb1c28456e65088a50f305aeab9f89/pylibsrtp-1.0.0.tar.gz", hash = "sha256:b39dff075b263a8ded5377f2490c60d2af452c9f06c4d061c7a2b640612b34d4", size = 10858, upload-time = "2025-10-13T16:12:31.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/af/89e61a62fa3567f1b7883feb4d19e19564066c2fcd41c37e08d317b51881/pylibsrtp-1.0.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:822c30ea9e759b333dc1f56ceac778707c51546e97eb874de98d7d378c000122", size = 1865017, upload-time = "2025-10-13T16:12:15.62Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0e/8d215484a9877adcf2459a8b28165fc89668b034565277fd55d666edd247/pylibsrtp-1.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:aaad74e5c8cbc1c32056c3767fea494c1e62b3aea2c908eda2a1051389fdad76", size = 2182739, upload-time = "2025-10-13T16:12:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/57/3f/76a841978877ae13eac0d4af412c13bbd5d83b3df2c1f5f2175f2e0f68e5/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9209b86e662ebbd17c8a9e8549ba57eca92a3e87fb5ba8c0e27b8c43cd08a767", size = 2732922, upload-time = "2025-10-13T16:12:18.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/14/cf5d2a98a66fdfe258f6b036cda570f704a644fa861d7883a34bc359501e/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:293c9f2ac21a2bd689c477603a1aa235d85cf252160e6715f0101e42a43cbedc", size = 2434534, upload-time = "2025-10-13T16:12:20.074Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/08/a3f6e86c04562f7dce6717cd2206a0f84ca85c5e38121d998e0e330194c3/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:81fb8879c2e522021a7cbd3f4bda1b37c192e1af939dfda3ff95b4723b329663", size = 2345818, upload-time = "2025-10-13T16:12:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d5/130c2b5b4b51df5631684069c6f0a6761c59d096a33d21503ac207cf0e47/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4ddb562e443cf2e557ea2dfaeef0d7e6b90e96dd38eb079b4ab2c8e34a79f50b", size = 2774490, upload-time = "2025-10-13T16:12:22.659Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e3/715a453bfee3bea92a243888ad359094a7727cc6d393f21281320fe7798c/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:f02e616c9dfab2b03b32d8cc7b748f9d91814c0211086f987629a60f05f6e2cc", size = 2372603, upload-time = "2025-10-13T16:12:24.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/56/52fa74294254e1f53a4ff170ee2006e57886cf4bb3db46a02b4f09e1d99f/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c134fa09e7b80a5b7fed626230c5bc257fd771bd6978e754343e7a61d96bc7e6", size = 2451269, upload-time = "2025-10-13T16:12:25.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/51/2e9b34f484cbdd3bac999bf1f48b696d7389433e900639089e8fc4e0da0d/pylibsrtp-1.0.0-cp310-abi3-win32.whl", hash = "sha256:bae377c3b402b17b9bbfbfe2534c2edba17aa13bea4c64ce440caacbe0858b55", size = 1247503, upload-time = "2025-10-13T16:12:27.39Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/70/43db21af194580aba2d9a6d4c7bd8c1a6e887fa52cd810b88f89096ecad2/pylibsrtp-1.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:8d6527c4a78a39a8d397f8862a8b7cdad4701ee866faf9de4ab8c70be61fd34d", size = 1601659, upload-time = "2025-10-13T16:12:29.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ec/6e02b2561d056ea5b33046e3cad21238e6a9097b97d6ccc0fbe52b50c858/pylibsrtp-1.0.0-cp310-abi3-win_arm64.whl", hash = "sha256:2696bdb2180d53ac55d0eb7b58048a2aa30cd4836dd2ca683669889137a94d2a", size = 1159246, upload-time = "2025-10-13T16:12:30.285Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/e8/7325d258199b159eb2c03fe32107533e2832e70e63f4fb88a6aa00023201/pyopenssl-26.4.0.tar.gz", hash = "sha256:28dfcce0162b9211413e26dfbfdf1d24317fbeba18fc93c12400a1856b2a0bc7", size = 182046, upload-time = "2026-08-01T19:50:50.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ad/2cf6d3fa2fae5c79e1ed9960c0d42badd0f94d81dd12b50604cdc839e648/pyopenssl-26.4.0-py3-none-any.whl", hash = "sha256:f0eb0cb2d581d3ad2b9c489468485e7f2ab6727d08401bcf9d824c3caddf3c1c", size = 56026, upload-time = "2026-08-01T19:50:48.94Z" },
 ]
 
 [[package]]
@@ -2702,6 +2840,15 @@ wheels = [
 ]
 
 [[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
 name = "sounddevice"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2741,7 +2888,7 @@ wheels = [
 
 [[package]]
 name = "tau2"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },
@@ -2768,6 +2915,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "aiohttp" },
+    { name = "aiortc" },
     { name = "aws-sdk-bedrock-runtime" },
     { name = "boto3" },
     { name = "deepgram-sdk" },
@@ -2776,6 +2924,7 @@ all = [
     { name = "google-cloud-aiplatform" },
     { name = "google-genai" },
     { name = "gymnasium" },
+    { name = "httpx", extra = ["socks"] },
     { name = "jiwer" },
     { name = "livekit-agents" },
     { name = "livekit-plugins-deepgram" },
@@ -2815,6 +2964,27 @@ knowledge = [
     { name = "openai" },
     { name = "rank-bm25" },
 ]
+live = [
+    { name = "aiohttp" },
+    { name = "aiortc" },
+    { name = "aws-sdk-bedrock-runtime" },
+    { name = "boto3" },
+    { name = "deepgram-sdk" },
+    { name = "elevenlabs" },
+    { name = "google-auth" },
+    { name = "google-cloud-aiplatform" },
+    { name = "google-genai" },
+    { name = "httpx", extra = ["socks"] },
+    { name = "jiwer" },
+    { name = "livekit-agents" },
+    { name = "livekit-plugins-deepgram" },
+    { name = "livekit-plugins-openai" },
+    { name = "pyaudio" },
+    { name = "pydub" },
+    { name = "scipy" },
+    { name = "tqdm" },
+    { name = "websockets" },
+]
 voice = [
     { name = "aiohttp" },
     { name = "aws-sdk-bedrock-runtime" },
@@ -2839,6 +3009,7 @@ voice = [
 requires-dist = [
     { name = "addict", specifier = ">=2.4.0" },
     { name = "aiohttp", marker = "extra == 'voice'", specifier = ">=3.0" },
+    { name = "aiortc", marker = "extra == 'live'", specifier = "==1.15.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "extra == 'voice'", specifier = ">=0.3.0" },
     { name = "boto3", marker = "extra == 'voice'", specifier = ">=1.35.0" },
     { name = "deepdiff", specifier = ">=8.4.2" },
@@ -2851,6 +3022,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'voice'", specifier = ">=1.0.0" },
     { name = "gymnasium", marker = "extra == 'gym'", specifier = ">=1.2.2" },
     { name = "httpx", specifier = ">=0.24.0" },
+    { name = "httpx", extras = ["socks"], marker = "extra == 'live'", specifier = ">=0.24.0" },
     { name = "jiwer", marker = "extra == 'voice'", specifier = ">=3.0.0" },
     { name = "litellm", specifier = ">=1.80.15,<1.82.7" },
     { name = "livekit-agents", marker = "extra == 'voice'", specifier = ">=1.5.0" },
@@ -2878,7 +3050,8 @@ requires-dist = [
     { name = "scipy", marker = "extra == 'voice'", specifier = ">=1.10.0" },
     { name = "seaborn", marker = "extra == 'experiments'", specifier = ">=0.13.2" },
     { name = "tabulate", specifier = ">=0.9.0" },
-    { name = "tau2", extras = ["voice", "knowledge", "gym", "dev", "experiments"], marker = "extra == 'all'" },
+    { name = "tau2", extras = ["voice"], marker = "extra == 'live'" },
+    { name = "tau2", extras = ["voice", "live", "knowledge", "gym", "dev", "experiments"], marker = "extra == 'all'" },
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tqdm", marker = "extra == 'voice'", specifier = ">=4.0" },
@@ -2886,7 +3059,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.34.0" },
     { name = "websockets", marker = "extra == 'voice'", specifier = ">=13.0" },
 ]
-provides-extras = ["voice", "knowledge", "gym", "dev", "experiments", "all"]
+provides-extras = ["live", "voice", "knowledge", "gym", "dev", "experiments", "all"]
 
 [[package]]
 name = "tenacity"


### PR DESCRIPTION
Applies the OpenAI Live V3 WebRTC integration supplied with the standard GPT Live submission against its documented tau2-bench base commit. This adds the openai_live provider, split frontend/backend configuration, continuous WebRTC audio transport, runner and caller-review changes, locked dependencies, and focused tests.\n\nVerification: patch identity matches the supplied archive; 37 focused Live and streaming tests pass; make check-all passes. The core suite reached 215 passed with 17 credential-dependent failures because this isolated worktree has no OpenAI API key. make test-voice is blocked during collection by an existing main-branch import of the absent openai.tick_runner module in an untouched test file.