### PR TITLE
fix: harden full-duplex audio streaming runtime

### DIFF
--- a/src/tau2/agent/base/streaming.py
+++ b/src/tau2/agent/base/streaming.py
@@ -264,7 +264,7 @@ class StreamingState(BaseModel, Generic[InputMessageType, OutputMessageType]):
         tick_duration_seconds: Optional[float] = None,
     ) -> list[Message]:
         """
-        Convert tick-based history to sequential messages for LLM context.
+        Convert tick-based history to text-only messages for LLM context.
 
         This bridges the gap between full-duplex tick-based storage and the
         sequential message format that LLMs expect.
@@ -326,6 +326,21 @@ class StreamingState(BaseModel, Generic[InputMessageType, OutputMessageType]):
                     other_chunk=temp_other_chunk,
                 )
                 ticks_to_process.append(temp_tick)
+
+        # LLM callers consume transcripts and tools, not concatenated recordings.
+        # Keep speech flags/timing for segmentation and leave stored ticks intact.
+        for index, tick in enumerate(ticks_to_process):
+            updates = {}
+            for field in ("self_chunk", "other_chunk"):
+                chunk = getattr(tick, field)
+                if isinstance(chunk, ParticipantMessageBase) and (
+                    chunk.audio_content or chunk.audio_script_gold
+                ):
+                    updates[field] = chunk.model_copy(
+                        update={"audio_content": None, "audio_script_gold": None}
+                    )
+            if updates:
+                ticks_to_process[index] = tick.model_copy(update=updates)
 
         # Expand ticks with env_chunk into old-format ticks before linearization.
         # This ensures linearization sees the same tick structure as the base branch.
@@ -1369,6 +1384,11 @@ def _has_meaningful_content(chunk: Message) -> bool:
     if hasattr(chunk, "is_tool_call") and chunk.is_tool_call():
         return True
 
+    # Streaming transcripts can arrive before or after their audible frames.
+    # Keep their text in LLM history without treating them as speech activity.
+    if hasattr(chunk, "content") and chunk.content:
+        return True
+
     # Check contains_speech flag if available
     # Return True if contains_speech=True (audio content, even without transcript)
     # Return False if contains_speech=False (explicitly marked as no speech)
@@ -1377,10 +1397,6 @@ def _has_meaningful_content(chunk: Message) -> bool:
             return True
         if chunk.contains_speech is False:
             return False
-
-    # Check for actual content
-    if hasattr(chunk, "content") and chunk.content:
-        return True
 
     return False
 

--- a/src/tau2/agent/discrete_time_audio_native_agent.py
+++ b/src/tau2/agent/discrete_time_audio_native_agent.py
@@ -632,7 +632,11 @@ class DiscreteTimeAudioNativeAgent(FullDuplexAgent[DiscreteTimeAgentState]):
         audio_format = self.audio_format
 
         # Check if there was actual speech (not just silence padding)
-        has_speech = len(tick_result.agent_audio_data) > 0
+        has_speech = (
+            tick_result.contains_speech
+            if tick_result.contains_speech is not None
+            else len(tick_result.agent_audio_data) > 0
+        )
 
         audio_content = base64.b64encode(agent_audio).decode("utf-8")
         content = transcript if transcript else None

--- a/src/tau2/orchestrator/full_duplex_orchestrator.py
+++ b/src/tau2/orchestrator/full_duplex_orchestrator.py
@@ -219,7 +219,6 @@ class FullDuplexOrchestrator(BaseOrchestrator[StreamingAgentT, StreamingUserT, T
         self.current_agent_chunk = first_agent_message
 
         # Get first user chunk
-        self.user_state = self.user.get_init_state()
         self.current_user_chunk, self.user_state = self.user.get_next_chunk(
             self.user_state, participant_chunk=dummy_agent_message
         )

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -91,6 +91,8 @@ class DiscreteTimeAdapter(ABC):
             self.audio_format.bytes_per_second * tick_duration_ms / 1000
         )
         self.send_audio_instant = send_audio_instant
+        self.realtime_pacing = False
+        self._next_tick_start: float | None = None
         self._voip_interval_ms = DEFAULT_AUDIO_NATIVE_VOIP_PACKET_INTERVAL_MS
 
         # Shared tick state (managed by _async_run_tick template)
@@ -181,6 +183,7 @@ class DiscreteTimeAdapter(ABC):
         survive disconnect() so it can be collected at simulation end.
         """
         self._buffered_agent_audio.clear()
+        self._next_tick_start = None
         self._utterance_transcripts.clear()
         self._pending_tool_results.clear()
         self._skip_item_id = None
@@ -227,6 +230,10 @@ class DiscreteTimeAdapter(ABC):
         Subclasses implement _execute_tick() and _flush_pending_tool_results().
         """
         tick_start = asyncio.get_running_loop().time()
+        if self.realtime_pacing:
+            if self._next_tick_start is not None:
+                tick_start = self._next_tick_start
+            self._next_tick_start = tick_start + self.tick_duration_ms / 1000
         self._current_tick_number = tick_number
 
         # 1. Flush pending tool results
@@ -248,9 +255,8 @@ class DiscreteTimeAdapter(ABC):
         )
 
         # 3. Prepend buffered audio from previous tick
-        for chunk_data, item_id in self._buffered_agent_audio:
-            result.agent_audio_chunks.append((chunk_data, item_id))
-        self._buffered_agent_audio.clear()
+        result.agent_audio_chunks = self._buffered_agent_audio
+        self._buffered_agent_audio = []
 
         # 4. Carry over skip state
         result.skip_item_id = self._skip_item_id

--- a/src/tau2/voice/audio_native/async_loop.py
+++ b/src/tau2/voice/audio_native/async_loop.py
@@ -10,6 +10,7 @@ layer.  This module provides a thin helper that manages a dedicated
 import asyncio
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional, TypeVar
 
 T = TypeVar("T")
@@ -28,9 +29,10 @@ class BackgroundAsyncLoop:
         bg.stop()
     """
 
-    def __init__(self) -> None:
+    def __init__(self, executor_workers: Optional[int] = None) -> None:
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._thread: Optional[threading.Thread] = None
+        self._executor_workers = executor_workers
 
     @property
     def loop(self) -> Optional[asyncio.AbstractEventLoop]:
@@ -51,9 +53,17 @@ class BackgroundAsyncLoop:
             return
 
         def _run_loop() -> None:
-            self._loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._loop)
-            self._loop.run_forever()
+            # Closing the runner also cancels tasks and joins codec executors.
+            with asyncio.Runner() as runner:
+                self._loop = runner.get_loop()
+                if self._executor_workers is not None:
+                    self._loop.set_default_executor(
+                        ThreadPoolExecutor(
+                            max_workers=self._executor_workers,
+                            thread_name_prefix="tau2-audio",
+                        )
+                    )
+                self._loop.run_forever()
 
         self._thread = threading.Thread(target=_run_loop, daemon=True)
         self._thread.start()

--- a/src/tau2/voice/audio_native/tick_result.py
+++ b/src/tau2/voice/audio_native/tick_result.py
@@ -129,6 +129,10 @@ class TickResult(BaseModel):
     )
 
     # --- Raw agent audio (unpadded) ---
+    contains_speech: Optional[bool] = Field(
+        default=None,
+        description="Speech activity for continuous media; None uses the legacy audio-presence rule",
+    )
     # These store the actual audio received from the API, without padding.
     # Use these to detect if agent actually spoke.
     agent_audio_chunks: List[Tuple[bytes, Optional[str]]] = Field(
@@ -443,7 +447,7 @@ def buffer_excess_audio(
     keep_chunks: List[Tuple[bytes, Optional[str]]] = []
     buffer_chunks: List[Tuple[bytes, Optional[str]]] = []
 
-    for chunk_data, item_id in result.agent_audio_chunks:
+    for index, (chunk_data, item_id) in enumerate(result.agent_audio_chunks):
         if total_bytes + len(chunk_data) <= bytes_per_tick:
             keep_chunks.append((chunk_data, item_id))
             total_bytes += len(chunk_data)
@@ -454,7 +458,9 @@ def buffer_excess_audio(
                 buffer_chunks.append((chunk_data[space_left:], item_id))
             else:
                 buffer_chunks.append((chunk_data, item_id))
-            total_bytes = bytes_per_tick
+            # The rest is already buffered; don't rescan a growing audio backlog.
+            buffer_chunks.extend(result.agent_audio_chunks[index + 1 :])
+            break
 
     result.agent_audio_chunks = keep_chunks
     return buffer_chunks


### PR DESCRIPTION
Stack 1 of 5 extracted from #519. Adds provider-neutral full-duplex prerequisites: text-only LLM history, transcript handling independent of speech flags, explicit speech activity, stable excess-audio buffering, optional real-time tick pacing, clean async-loop shutdown, and removal of duplicate user initialization.

Verified with Ruff lint and format checks plus streaming linearization, chunking, and tool-flow tests: 94 passed.