### PR TITLE
Configure real-time user generation

### DIFF
--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -106,6 +106,7 @@ def build_command(
     user_llm_args: dict | None = None,
     max_concurrency: int = 8,
     max_steps_seconds: int | None = None,
+    realtime_generation: bool | None = None,
 ) -> list[str]:
     cmd = [
         sys.executable,
@@ -143,6 +144,12 @@ def build_command(
         cmd.extend(["--num-tasks", str(num_tasks)])
     if max_steps_seconds is not None:
         cmd.extend(["--max-steps-seconds", str(max_steps_seconds)])
+    if realtime_generation is not None:
+        cmd.append(
+            "--realtime-generation"
+            if realtime_generation
+            else "--no-realtime-generation"
+        )
     return cmd
 
 
@@ -158,6 +165,7 @@ def build_config(
     user_llm_args: dict | None = None,
     max_concurrency: int = 8,
     max_steps_seconds: int | None = None,
+    realtime_generation: bool | None = None,
 ):
     """The same run build_command() shells out for, as a VoiceRunConfig —
     used by --workers mode to register combos with one controller."""
@@ -168,6 +176,7 @@ def build_config(
         model=spec.model,
         cascaded_config_name=spec.cascaded_config,
         reasoning_effort=spec.reasoning_effort,
+        realtime_generation=realtime_generation,
     )
     if max_steps_seconds is not None:
         audio_kwargs["max_steps_seconds"] = max_steps_seconds
@@ -218,6 +227,13 @@ def main():
         type=int,
         default=None,
         help="Cap conversation duration in seconds (passed through to tau2 run).",
+    )
+    parser.add_argument(
+        "--realtime-generation",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Run user LLM/TTS generation without blocking audio ticks. "
+        "Defaults to enabled for openai_live and disabled for other providers.",
     )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--user-llm", type=str, default=DEFAULT_LLM_USER)
@@ -271,6 +287,7 @@ def main():
         user_llm_args=args.user_llm_args,
         max_concurrency=args.max_concurrency,
         max_steps_seconds=args.max_steps_seconds,
+        realtime_generation=args.realtime_generation,
     )
 
     def combo_save_to(domain, spec, complexity) -> str:

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -282,6 +282,14 @@ def add_run_args(parser):
         help="JSON config for openai_live: backend_model (required), voice, frontend_prompt, backend_prompt.",
     )
     parser.add_argument(
+        "--realtime-generation",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Run user LLM/TTS generation without blocking audio ticks. "
+        "Defaults to enabled for openai_live and disabled for other providers. "
+        "Use --no-realtime-generation to disable.",
+    )
+    parser.add_argument(
         "--reasoning-effort",
         type=str,
         choices=["minimal", "low", "medium", "high", "xhigh"],
@@ -637,6 +645,7 @@ def main():
                 cascaded_config_name=args.cascaded_config,
                 reasoning_effort=args.reasoning_effort,
                 live_config=args.live_config,
+                realtime_generation=args.realtime_generation,
                 # Timing
                 tick_duration_seconds=args.tick_duration,
                 max_steps_seconds=args.max_steps_seconds,

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -97,6 +97,18 @@ class AudioNativeConfig(BaseModel):
         default=None,
         description="Backend, voice and split prompts for the openai_live provider",
     )
+    realtime_generation: Optional[bool] = Field(
+        default=None,
+        description="Whether user LLM and TTS generation run without blocking audio ticks. "
+        "Defaults to enabled for openai_live and disabled for other providers.",
+    )
+
+    @property
+    def realtime_generation_enabled(self) -> bool:
+        """Resolve the provider-aware default for real-time user generation."""
+        if self.realtime_generation is not None:
+            return self.realtime_generation
+        return self.provider == "openai_live"
 
     @model_validator(mode="after")
     def validate_live_config(self):

--- a/src/tau2/runner/build.py
+++ b/src/tau2/runner/build.py
@@ -299,7 +299,7 @@ def build_voice_user(
         tick_duration_seconds=audio_native_config.tick_duration_seconds,
         persona_config=persona_config,
         audio_taps_dir=audio_taps_dir,
-        realtime_generation=audio_native_config.provider == "openai_live",
+        realtime_generation=audio_native_config.realtime_generation_enabled,
     )
 
 

--- a/tests/test_experiments/test_tau_voice_run_multiple.py
+++ b/tests/test_experiments/test_tau_voice_run_multiple.py
@@ -1,11 +1,16 @@
+import argparse
 import json
 import sys
+
+import pytest
 
 from experiments.tau_voice.run_multiple import (
     ProviderSpec,
     build_command,
     build_config,
 )
+from tau2.cli import add_run_args
+from tau2.data_model.simulation import AudioNativeConfig
 
 
 def test_build_command_uses_current_python_and_user_llm_args():
@@ -33,3 +38,85 @@ def test_build_config_sets_user_llm_args():
     )
 
     assert config.llm_args_user == {"reasoning_effort": "xhigh"}
+
+
+@pytest.mark.parametrize(
+    ("realtime_generation", "expected_flag"),
+    [
+        (True, "--realtime-generation"),
+        (False, "--no-realtime-generation"),
+        (None, None),
+    ],
+)
+def test_build_command_sets_realtime_generation_override(
+    realtime_generation, expected_flag
+):
+    command = build_command(
+        "retail",
+        ProviderSpec(provider="xai", model="grok-voice-think-fast-2.0"),
+        "regular",
+        "/tmp/results",
+        realtime_generation=realtime_generation,
+    )
+
+    flags = {"--realtime-generation", "--no-realtime-generation"}
+    actual_flags = flags.intersection(command)
+    assert actual_flags == ({expected_flag} if expected_flag else set())
+
+
+@pytest.mark.parametrize("realtime_generation", [True, False, None])
+def test_build_config_sets_realtime_generation_override(realtime_generation):
+    config = build_config(
+        "retail",
+        ProviderSpec(provider="xai", model="grok-voice-think-fast-2.0"),
+        "regular",
+        "/tmp/results",
+        realtime_generation=realtime_generation,
+    )
+
+    assert config.audio_native_config.realtime_generation is realtime_generation
+
+
+@pytest.mark.parametrize(
+    ("flag", "expected"),
+    [
+        ([], None),
+        (["--realtime-generation"], True),
+        (["--no-realtime-generation"], False),
+    ],
+)
+def test_cli_parses_realtime_generation_override(flag, expected):
+    parser = argparse.ArgumentParser()
+    add_run_args(parser)
+
+    args = parser.parse_args(flag)
+
+    assert args.realtime_generation is expected
+
+
+def test_realtime_generation_has_provider_aware_default():
+    assert not AudioNativeConfig(provider="xai").realtime_generation_enabled
+    assert AudioNativeConfig(
+        provider="openai_live",
+        model="test-live",
+        live_config={"backend_model": "test-backend"},
+    ).realtime_generation_enabled
+
+
+@pytest.mark.parametrize("override", [True, False])
+def test_realtime_generation_override_wins_over_provider_default(override):
+    assert (
+        AudioNativeConfig(
+            provider="xai", realtime_generation=override
+        ).realtime_generation_enabled
+        is override
+    )
+    assert (
+        AudioNativeConfig(
+            provider="openai_live",
+            model="test-live",
+            live_config={"backend_model": "test-backend"},
+            realtime_generation=override,
+        ).realtime_generation_enabled
+        is override
+    )


### PR DESCRIPTION
Adds an explicit tri-state real-time user-generation setting for audio-native evaluations. Unspecified preserves the current behavior (enabled for OpenAI Live and disabled for other providers), while the CLI and run_multiple support --realtime-generation and --no-realtime-generation overrides in both sequential and worker modes.

Tests cover provider defaults, override precedence, CLI parsing, and run_multiple command/config construction.

Validation:
- 25 focused tests passed
- 277 broader offline voice/streaming tests passed (3 skipped, 102 deselected)
- Ruff check and format check passed

One unchanged streaming test file remains excluded because it imports the removed tau2.voice.audio_native.openai.tick_runner module; this is pre-existing on the base branch.