### PR TITLE
Add default OpenAI Live prompt templates

### DIFF
--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -7,6 +7,7 @@ Provider syntax: "provider", "provider:model", or "provider:model:reasoning"
   - openai:gpt-realtime-1.5          (specific model)
   - openai:gpt-realtime-1.5:high     (model + reasoning effort)
   - openai:pine-voice-preview        (Pine's OpenAI-compatible model)
+  - openai_live:gpt-live:medium      (GPT Live frontend + reasoning effort)
   - livekit                           (default cascaded config)
   - livekit::openai-thinking          (default model + cascaded config)
 
@@ -40,7 +41,9 @@ from tau2.config import DEFAULT_AUDIO_NATIVE_MODELS, DEFAULT_LLM_USER, DEFAULT_S
 
 DEFAULT_DOMAINS = ["airline", "retail"]
 DEFAULT_COMPLEXITIES = ["control", "regular"]
-DEFAULT_PROVIDER_LIMITS = "gemini=40,openai=40,xai=40,livekit=10,nova=5,qwen=5"
+DEFAULT_PROVIDER_LIMITS = (
+    "gemini=40,openai=40,openai_live=40,xai=40,livekit=10,nova=5,qwen=5"
+)
 
 
 @dataclass
@@ -64,6 +67,8 @@ def parse_provider(spec: str) -> ProviderSpec:
     """
     parts = spec.split(":")
     provider = parts[0]
+    if provider == "openai_live" and (len(parts) == 1 or not parts[1]):
+        raise ValueError("openai_live requires an explicit frontend model")
     model = DEFAULT_AUDIO_NATIVE_MODELS.get(provider, "dummy")
 
     if len(parts) == 1:
@@ -107,6 +112,8 @@ def build_command(
     max_concurrency: int = 8,
     max_steps_seconds: int | None = None,
     realtime_generation: bool | None = None,
+    live_backend_model: str | None = None,
+    live_voice: str = "marin",
 ) -> list[str]:
     cmd = [
         sys.executable,
@@ -150,6 +157,15 @@ def build_command(
             if realtime_generation
             else "--no-realtime-generation"
         )
+    if spec.provider == "openai_live":
+        if live_backend_model is None:
+            raise ValueError("openai_live requires --live-backend-model")
+        cmd.extend(
+            [
+                "--live-config",
+                json.dumps({"backend_model": live_backend_model, "voice": live_voice}),
+            ]
+        )
     return cmd
 
 
@@ -166,6 +182,8 @@ def build_config(
     max_concurrency: int = 8,
     max_steps_seconds: int | None = None,
     realtime_generation: bool | None = None,
+    live_backend_model: str | None = None,
+    live_voice: str = "marin",
 ):
     """The same run build_command() shells out for, as a VoiceRunConfig —
     used by --workers mode to register combos with one controller."""
@@ -180,6 +198,13 @@ def build_config(
     )
     if max_steps_seconds is not None:
         audio_kwargs["max_steps_seconds"] = max_steps_seconds
+    if spec.provider == "openai_live":
+        if live_backend_model is None:
+            raise ValueError("openai_live requires --live-backend-model")
+        audio_kwargs["live_config"] = {
+            "backend_model": live_backend_model,
+            "voice": live_voice,
+        }
 
     config_kwargs = dict(
         domain=domain,
@@ -235,6 +260,18 @@ def main():
         help="Run user LLM/TTS generation without blocking audio ticks. "
         "Defaults to enabled for openai_live and disabled for other providers.",
     )
+    parser.add_argument(
+        "--live-backend-model",
+        type=str,
+        default=None,
+        help="Delegated backend model for openai_live (required when selected).",
+    )
+    parser.add_argument(
+        "--live-voice",
+        type=str,
+        default="marin",
+        help="Output voice for openai_live. Default: marin.",
+    )
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
     parser.add_argument("--user-llm", type=str, default=DEFAULT_LLM_USER)
     parser.add_argument(
@@ -288,6 +325,8 @@ def main():
         max_concurrency=args.max_concurrency,
         max_steps_seconds=args.max_steps_seconds,
         realtime_generation=args.realtime_generation,
+        live_backend_model=args.live_backend_model,
+        live_voice=args.live_voice,
     )
 
     def combo_save_to(domain, spec, complexity) -> str:

--- a/src/experiments/tau_voice/run_multiple.py
+++ b/src/experiments/tau_voice/run_multiple.py
@@ -7,7 +7,7 @@ Provider syntax: "provider", "provider:model", or "provider:model:reasoning"
   - openai:gpt-realtime-1.5          (specific model)
   - openai:gpt-realtime-1.5:high     (model + reasoning effort)
   - openai:pine-voice-preview        (Pine's OpenAI-compatible model)
-  - openai_live:gpt-live:medium      (GPT Live frontend + reasoning effort)
+  - openai_live::medium              (default GPT Live frontend + reasoning effort)
   - livekit                           (default cascaded config)
   - livekit::openai-thinking          (default model + cascaded config)
 
@@ -67,8 +67,6 @@ def parse_provider(spec: str) -> ProviderSpec:
     """
     parts = spec.split(":")
     provider = parts[0]
-    if provider == "openai_live" and (len(parts) == 1 or not parts[1]):
-        raise ValueError("openai_live requires an explicit frontend model")
     model = DEFAULT_AUDIO_NATIVE_MODELS.get(provider, "dummy")
 
     if len(parts) == 1:

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -279,7 +279,7 @@ def add_run_args(parser):
         "--live-config",
         type=json.loads,
         default=None,
-        help="JSON config for openai_live: backend_model (required), voice, frontend_prompt, backend_prompt.",
+        help="JSON config for openai_live: backend_model (required), voice, and optional frontend_prompt/backend_prompt overrides.",
     )
     parser.add_argument(
         "--realtime-generation",

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -627,8 +627,6 @@ def main():
             # Resolve model based on provider if not specified
             audio_native_model = args.audio_native_model
             if audio_native_model is None:
-                if args.audio_native_provider == "openai_live":
-                    parser.error("openai_live requires --audio-native-model")
                 audio_native_model = DEFAULT_AUDIO_NATIVE_MODELS[
                     args.audio_native_provider
                 ]

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -136,7 +136,9 @@ DEFAULT_AUDIO_NATIVE_MAX_INACTIVE_SECONDS = 40.0  # fixed, stall detection
 # OPENAI PROVIDER (overridable model/voice, fixed API constants)
 # =============================================================================
 DEFAULT_OPENAI_REALTIME_MODEL = "gpt-realtime-1.5"  # overridable
-DEFAULT_OPENAI_LIVE_MODEL = "gpt-live-submission"  # overridable, limited-access alias
+DEFAULT_OPENAI_LIVE_MODEL = (
+    "gpt-live-1-diamond-alpha"  # overridable, limited-access alias
+)
 _LEGACY_OPENAI_REALTIME_MODEL = "gpt-realtime-2025-08-28"
 DEFAULT_OPENAI_REALTIME_BASE_URL = "wss://api.openai.com/v1/realtime"  # fixed
 DEFAULT_OPENAI_VOICE = "alloy"  # overridable

--- a/src/tau2/config.py
+++ b/src/tau2/config.py
@@ -99,7 +99,7 @@ DEFAULT_SPEECH_COMPLEXITY = "regular"  # overridable: "control", "regular"
 DEFAULT_AUDIO_NATIVE_AGENT_IMPLEMENTATION = "discrete_time_audio_native_agent"
 DEFAULT_AUDIO_NATIVE_USER_IMPLEMENTATION = "voice_streaming_user_simulator"
 DEFAULT_AUDIO_NATIVE_PROVIDER = (
-    "openai"  # overridable: openai, gemini, xai, nova, qwen, livekit
+    "openai"  # overridable: openai, openai_live, gemini, xai, nova, qwen, livekit
 )
 DEFAULT_TICK_DURATION_SECONDS = 0.20  # overridable
 DEFAULT_MAX_STEPS_SECONDS = 1200  # overridable
@@ -136,6 +136,7 @@ DEFAULT_AUDIO_NATIVE_MAX_INACTIVE_SECONDS = 40.0  # fixed, stall detection
 # OPENAI PROVIDER (overridable model/voice, fixed API constants)
 # =============================================================================
 DEFAULT_OPENAI_REALTIME_MODEL = "gpt-realtime-1.5"  # overridable
+DEFAULT_OPENAI_LIVE_MODEL = "gpt-live-submission"  # overridable, limited-access alias
 _LEGACY_OPENAI_REALTIME_MODEL = "gpt-realtime-2025-08-28"
 DEFAULT_OPENAI_REALTIME_BASE_URL = "wss://api.openai.com/v1/realtime"  # fixed
 DEFAULT_OPENAI_VOICE = "alloy"  # overridable
@@ -203,6 +204,7 @@ DEFAULT_QWEN_OUTPUT_SAMPLE_RATE = 24000  # fixed, API-defined
 # =============================================================================
 DEFAULT_AUDIO_NATIVE_MODELS = {
     "openai": DEFAULT_OPENAI_REALTIME_MODEL,
+    "openai_live": DEFAULT_OPENAI_LIVE_MODEL,
     "gemini": DEFAULT_GEMINI_MODEL,
     "xai": DEFAULT_XAI_MODEL,
     "nova": DEFAULT_NOVA_MODEL,
@@ -212,6 +214,7 @@ DEFAULT_AUDIO_NATIVE_MODELS = {
 
 DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
     "openai": None,
+    "openai_live": None,
     "gemini": "high",
     "xai": "high",
     "nova": None,
@@ -221,6 +224,7 @@ DEFAULT_AUDIO_NATIVE_REASONING_EFFORT: dict[str, str | None] = {
 
 AUDIO_NATIVE_PROVIDER_TYPES = {
     "openai": "audio_native",
+    "openai_live": "audio_native",
     "gemini": "audio_native",
     "xai": "audio_native",
     "nova": "audio_native",

--- a/src/tau2/data_model/simulation.py
+++ b/src/tau2/data_model/simulation.py
@@ -95,7 +95,7 @@ class AudioNativeConfig(BaseModel):
     )
     live_config: Optional[LiveConfig] = Field(
         default=None,
-        description="Backend, voice and split prompts for the openai_live provider",
+        description="Backend model, voice, and optional prompt overrides for the openai_live provider",
     )
     realtime_generation: Optional[bool] = Field(
         default=None,

--- a/src/tau2/voice/audio_native/adapter.py
+++ b/src/tau2/voice/audio_native/adapter.py
@@ -420,8 +420,6 @@ def create_adapter(
 
     # --- Resolve model default ---
     if model is None:
-        if provider == "openai_live":
-            raise ValueError("openai_live requires an explicit frontend model")
         if provider == "livekit":
             from tau2.voice.audio_native.livekit.config import CascadedConfig
 

--- a/src/tau2/voice/audio_native/openai/live_config.py
+++ b/src/tau2/voice/audio_native/openai/live_config.py
@@ -2,6 +2,25 @@
 
 from pydantic import BaseModel, ConfigDict
 
+DEFAULT_LIVE_FRONTEND_PROMPT_TEMPLATE = (
+    "{system_prompt}\n\n"
+    "You are the spoken interface for a live support conversation. You control "
+    "how and when to speak, listen, stop, interrupt, and delegate. Listen to the "
+    "user's complete turn. For every substantive request, clarification, answer, "
+    "or reported action, delegate to the backend and remain silent until the "
+    "backend result arrives. The backend owns task reasoning, policy decisions, "
+    "tool execution, and the substance of your reply. Naturally rephrase only its "
+    "concise customer-facing answer, question, or requested customer action. Do "
+    "not independently diagnose, invent tool results, repeat the user, or narrate "
+    "delegation. Stop speaking immediately when the user speaks."
+)
+
+DEFAULT_LIVE_BACKEND_PROMPT_TEMPLATE = (
+    "{system_prompt}\n\n"
+    "Normalize ten spoken phone-number digits as XXX-XXX-XXXX before calling a "
+    "phone lookup."
+)
+
 
 class LiveConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -9,8 +28,21 @@ class LiveConfig(BaseModel):
     backend_model: str
     voice: str = "marin"
     append_system_prompt: bool = True
-    frontend_prompt: str = (
-        "Listen and speak to the customer. Delegate support decisions and "
-        "tool use to SpawnThinking. Speak the delegated answer to the customer."
-    )
-    backend_prompt: str = ""
+    frontend_prompt: str | None = None
+    backend_prompt: str | None = None
+
+    def render_frontend_prompt(self, system_prompt: str) -> str:
+        """Build frontend instructions, using an explicit override when provided."""
+        if self.frontend_prompt is not None:
+            return self.frontend_prompt
+        return DEFAULT_LIVE_FRONTEND_PROMPT_TEMPLATE.format(system_prompt=system_prompt)
+
+    def render_backend_prompt(self, system_prompt: str) -> str:
+        """Build backend instructions, using an explicit override when provided."""
+        if self.backend_prompt is None:
+            return DEFAULT_LIVE_BACKEND_PROMPT_TEMPLATE.format(
+                system_prompt=system_prompt
+            )
+        if self.append_system_prompt:
+            return self.backend_prompt + "\n\n" + system_prompt
+        return self.backend_prompt

--- a/src/tau2/voice/audio_native/openai/live_provider.py
+++ b/src/tau2/voice/audio_native/openai/live_provider.py
@@ -273,8 +273,7 @@ class OpenAILiveProvider(OpenAIRealtimeProvider):
     def _build_session(self, system_prompt: str, tools: list[Tool]) -> dict:
         responses = {
             "model": self.config.backend_model,
-            "instructions": self.config.backend_prompt
-            + ("\n\n" + system_prompt if self.config.append_system_prompt else ""),
+            "instructions": self.config.render_backend_prompt(system_prompt),
             "tools": self._format_tools_for_api(tools),
             "tool_choice": "auto",
             "parallel_tool_calls": False,
@@ -283,7 +282,7 @@ class OpenAILiveProvider(OpenAIRealtimeProvider):
             responses["reasoning"] = {"effort": self.reasoning_effort}
         return {
             "model": self.model,
-            "instructions": self.config.frontend_prompt,
+            "instructions": self.config.render_frontend_prompt(system_prompt),
             "audio": {"output": {"voice": self.config.voice}},
             "delegation": {"type": "responses", "responses": responses},
         }

--- a/tests/test_experiments/test_tau_voice_run_multiple.py
+++ b/tests/test_experiments/test_tau_voice_run_multiple.py
@@ -12,6 +12,7 @@ from experiments.tau_voice.run_multiple import (
     parse_provider,
 )
 from tau2.cli import add_run_args
+from tau2.config import DEFAULT_OPENAI_LIVE_MODEL
 from tau2.data_model.simulation import AudioNativeConfig
 from tau2.runner.work import parse_provider_limits
 
@@ -90,9 +91,10 @@ def test_default_provider_limits_include_openai_live():
 
 
 @pytest.mark.parametrize("spec", ["openai_live", "openai_live::medium"])
-def test_openai_live_requires_explicit_frontend_model(spec):
-    with pytest.raises(ValueError, match="explicit frontend model"):
-        parse_provider(spec)
+def test_openai_live_uses_default_frontend_model(spec):
+    parsed = parse_provider(spec)
+
+    assert parsed.model == DEFAULT_OPENAI_LIVE_MODEL == "gpt-live-submission"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_experiments/test_tau_voice_run_multiple.py
+++ b/tests/test_experiments/test_tau_voice_run_multiple.py
@@ -5,12 +5,15 @@ import sys
 import pytest
 
 from experiments.tau_voice.run_multiple import (
+    DEFAULT_PROVIDER_LIMITS,
     ProviderSpec,
     build_command,
     build_config,
+    parse_provider,
 )
 from tau2.cli import add_run_args
 from tau2.data_model.simulation import AudioNativeConfig
+from tau2.runner.work import parse_provider_limits
 
 
 def test_build_command_uses_current_python_and_user_llm_args():
@@ -38,6 +41,58 @@ def test_build_config_sets_user_llm_args():
     )
 
     assert config.llm_args_user == {"reasoning_effort": "xhigh"}
+
+
+def test_build_command_sets_openai_live_backend_config():
+    command = build_command(
+        "retail",
+        ProviderSpec(provider="openai_live", model="gpt-live"),
+        "regular",
+        "/tmp/results",
+        live_backend_model="gpt-backend",
+        live_voice="cedar",
+    )
+
+    config_index = command.index("--live-config")
+    assert json.loads(command[config_index + 1]) == {
+        "backend_model": "gpt-backend",
+        "voice": "cedar",
+    }
+
+
+def test_build_config_sets_openai_live_backend_config():
+    config = build_config(
+        "retail",
+        ProviderSpec(provider="openai_live", model="gpt-live"),
+        "regular",
+        "/tmp/results",
+        live_backend_model="gpt-backend",
+        live_voice="cedar",
+    )
+
+    assert config.audio_native_config.live_config.backend_model == "gpt-backend"
+    assert config.audio_native_config.live_config.voice == "cedar"
+
+
+@pytest.mark.parametrize("builder", [build_command, build_config])
+def test_openai_live_requires_backend_model(builder):
+    with pytest.raises(ValueError, match="--live-backend-model"):
+        builder(
+            "retail",
+            ProviderSpec(provider="openai_live", model="gpt-live"),
+            "regular",
+            "/tmp/results",
+        )
+
+
+def test_default_provider_limits_include_openai_live():
+    assert parse_provider_limits(DEFAULT_PROVIDER_LIMITS)["openai_live"] == 40
+
+
+@pytest.mark.parametrize("spec", ["openai_live", "openai_live::medium"])
+def test_openai_live_requires_explicit_frontend_model(spec):
+    with pytest.raises(ValueError, match="explicit frontend model"):
+        parse_provider(spec)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_experiments/test_tau_voice_run_multiple.py
+++ b/tests/test_experiments/test_tau_voice_run_multiple.py
@@ -94,7 +94,7 @@ def test_default_provider_limits_include_openai_live():
 def test_openai_live_uses_default_frontend_model(spec):
     parsed = parse_provider(spec)
 
-    assert parsed.model == DEFAULT_OPENAI_LIVE_MODEL == "gpt-live-submission"
+    assert parsed.model == DEFAULT_OPENAI_LIVE_MODEL == "gpt-live-1-diamond-alpha"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_voice/test_audio_native/test_live_provider.py
+++ b/tests/test_voice/test_audio_native/test_live_provider.py
@@ -43,7 +43,7 @@ def provider():
     return result
 
 
-def test_policy_and_tools_are_backend_only(provider):
+def test_default_templates_slot_system_prompt_and_keep_tools_backend_only(provider):
     tool = Mock(
         openai_schema={
             "function": {
@@ -54,14 +54,52 @@ def test_policy_and_tools_are_backend_only(provider):
         }
     )
     session = provider._build_session("ORIGINAL DOMAIN POLICY", [tool])
-    assert "ORIGINAL DOMAIN POLICY" not in session["instructions"]
+    assert session["instructions"] == (
+        "ORIGINAL DOMAIN POLICY\n\n"
+        "You are the spoken interface for a live support conversation. You "
+        "control how and when to speak, listen, stop, interrupt, and delegate. "
+        "Listen to the user's complete turn. For every substantive request, "
+        "clarification, answer, or reported action, delegate to the backend and "
+        "remain silent until the backend result arrives. The backend owns task "
+        "reasoning, policy decisions, tool execution, and the substance of your "
+        "reply. Naturally rephrase only its concise customer-facing answer, "
+        "question, or requested customer action. Do not independently diagnose, "
+        "invent tool results, repeat the user, or narrate delegation. Stop "
+        "speaking immediately when the user speaks."
+    )
     backend = session["delegation"]["responses"]
-    assert backend["instructions"].endswith("ORIGINAL DOMAIN POLICY")
+    assert backend["instructions"] == (
+        "ORIGINAL DOMAIN POLICY\n\n"
+        "Normalize ten spoken phone-number digits as XXX-XXX-XXXX before "
+        "calling a phone lookup."
+    )
     assert backend["model"] == "test-backend"
     assert backend["reasoning"] == {"effort": "low"}
     assert backend["tools"][0]["name"] == "lookup"
     assert "tools" not in session
     assert session["audio"]["output"]["voice"] == "marin"
+
+
+def test_explicit_prompts_preserve_existing_override_behavior():
+    config = LiveConfig(
+        backend_model="test-backend",
+        frontend_prompt="CUSTOM FRONTEND",
+        backend_prompt="CUSTOM BACKEND",
+    )
+    provider = OpenAILiveProvider(
+        model="test-live",
+        config=config,
+        api_key="test-only",
+    )
+    session = provider._build_session("ORIGINAL DOMAIN POLICY", [])
+    assert session["instructions"] == "CUSTOM FRONTEND"
+    assert session["delegation"]["responses"]["instructions"] == (
+        "CUSTOM BACKEND\n\nORIGINAL DOMAIN POLICY"
+    )
+
+    config.append_system_prompt = False
+    session = provider._build_session("ORIGINAL DOMAIN POLICY", [])
+    assert session["delegation"]["responses"]["instructions"] == "CUSTOM BACKEND"
 
 
 def test_config_rejects_missing_or_misrouted_backend():

--- a/tests/test_voice/test_audio_native/test_live_provider.py
+++ b/tests/test_voice/test_audio_native/test_live_provider.py
@@ -120,7 +120,7 @@ def test_create_adapter_uses_default_live_frontend_model(monkeypatch):
         live_config=LiveConfig(backend_model="test-backend"),
     )
 
-    assert model == DEFAULT_OPENAI_LIVE_MODEL == "gpt-live-submission"
+    assert model == DEFAULT_OPENAI_LIVE_MODEL == "gpt-live-1-diamond-alpha"
     assert adapter.model == DEFAULT_OPENAI_LIVE_MODEL
 
 

--- a/tests/test_voice/test_audio_native/test_live_provider.py
+++ b/tests/test_voice/test_audio_native/test_live_provider.py
@@ -11,8 +11,10 @@ from aiortc.rtcpeerconnection import CODECS
 from aiortc.sdp import SessionDescription
 
 from tau2.agent.base.streaming import _has_meaningful_content
+from tau2.config import DEFAULT_OPENAI_LIVE_MODEL
 from tau2.data_model.message import AssistantMessage
 from tau2.data_model.simulation import AudioNativeConfig
+from tau2.voice.audio_native.adapter import create_adapter
 from tau2.voice.audio_native.audio_converter import StreamingTelephonyConverter
 from tau2.voice.audio_native.openai.discrete_time_adapter import (
     DiscreteTimeOpenAIAdapter,
@@ -107,6 +109,19 @@ def test_config_rejects_missing_or_misrouted_backend():
         AudioNativeConfig(provider="openai_live", model="test-live")
     with pytest.raises(ValueError, match="live_config is required"):
         AudioNativeConfig(provider="openai", live_config={"backend_model": "test"})
+
+
+def test_create_adapter_uses_default_live_frontend_model(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-only")
+
+    adapter, model = create_adapter(
+        "openai_live",
+        tick_duration_ms=200,
+        live_config=LiveConfig(backend_model="test-backend"),
+    )
+
+    assert model == DEFAULT_OPENAI_LIVE_MODEL == "gpt-live-submission"
+    assert adapter.model == DEFAULT_OPENAI_LIVE_MODEL
 
 
 def test_offer_advertises_audio_recovery_without_changing_other_providers(provider):

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -55,7 +55,7 @@ from typing import List, Optional
 
 import pytest
 
-from tau2.config import TELEPHONY_ULAW_SILENCE
+from tau2.config import DEFAULT_OPENAI_LIVE_MODEL, TELEPHONY_ULAW_SILENCE
 from tau2.environment.tool import Tool
 from tau2.voice.audio_native.adapter import DiscreteTimeAdapter, create_adapter
 from tau2.voice.audio_native.openai.live_config import LiveConfig
@@ -80,11 +80,10 @@ PROVIDERS = [
                 os.environ.get(key)
                 for key in (
                     "OPENAI_API_KEY",
-                    "OPENAI_LIVE_MODEL",
                     "OPENAI_LIVE_BACKEND_MODEL",
                 )
             ),
-            reason="OpenAI Live credentials and model names are required",
+            reason="OpenAI Live credentials and backend model are required",
         ),
     ),
     pytest.param(
@@ -358,7 +357,7 @@ def adapter(provider_name: str):
     model = None
 
     if provider_name == "openai_live":
-        model = os.environ["OPENAI_LIVE_MODEL"]
+        model = os.environ.get("OPENAI_LIVE_MODEL", DEFAULT_OPENAI_LIVE_MODEL)
         live_config = LiveConfig(backend_model=os.environ["OPENAI_LIVE_BACKEND_MODEL"])
 
     if provider_name in CASCADED_CONFIG_ALIASES:


### PR DESCRIPTION
Adds provider-owned frontend and backend prompt templates for OpenAI Live. Both templates slot in the audio-native tau system prompt, so standard runs only need the backend model and optional voice; explicit frontend_prompt/backend_prompt values remain supported for custom experiments. The rendered defaults match the downloaded standard GPT Live submission byte-for-byte for airline, retail, and telecom.

Adds `gpt-live-1-diamond-alpha` as the shared default OpenAI Live frontend model in `config.py`. The main CLI, adapter factory, provider conformance suite, and `run_multiple.py` now use that default when no frontend model is supplied. The delegated backend model remains required.

Also adds full `openai_live` support to `run_multiple.py` for sequential and worker modes via `--live-backend-model` and `--live-voice`, and adds `openai_live=40` to the default provider limits.

Validation:
- 34 focused tests passed for the feature, plus 3 targeted tests for the corrected model slug
- 300 broader offline voice/streaming/experiment tests passed (3 skipped, 102 deselected)
- Ruff check and format check passed