### PR TITLE
fix: surface OpenAI Live interruption signals

### DIFF
--- a/src/tau2/voice/audio_native/openai/live_adapter.py
+++ b/src/tau2/voice/audio_native/openai/live_adapter.py
@@ -16,6 +16,7 @@ from tau2.voice.audio_native.openai.discrete_time_adapter import (
 from tau2.voice.audio_native.openai.events import AudioDeltaEvent
 from tau2.voice.audio_native.openai.live_config import LiveConfig
 from tau2.voice.audio_native.openai.live_provider import (
+    LiveInputTranscriptDelta,
     LiveTranscriptDelta,
     OpenAILiveProvider,
 )
@@ -90,6 +91,12 @@ class DiscreteTimeOpenAILiveAdapter(DiscreteTimeOpenAIAdapter):
         )
 
     async def _process_event(self, result: TickResult, event: object) -> None:
+        if isinstance(event, LiveInputTranscriptDelta):
+            # Live does not expose a separate VAD event. A timed input transcript
+            # delta is its structured indication that user speech was detected.
+            result.events.append(event)
+            result.vad_events.append("speech_started")
+            return
         if isinstance(event, LiveTranscriptDelta):
             result.events.append(event)
             self._transcript_deltas.append(event)

--- a/src/tau2/voice/audio_native/openai/live_provider.py
+++ b/src/tau2/voice/audio_native/openai/live_provider.py
@@ -8,7 +8,7 @@ import json
 import time
 from fractions import Fraction
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Literal
 
 import aiohttp
 import numpy as np
@@ -46,6 +46,15 @@ class LiveTranscriptDelta(AudioTranscriptDeltaEvent):
     """A native transcript delta located on the received PCM timeline."""
 
     audio_position_bytes: int
+    start_ms: int
+    end_ms: int
+
+
+class LiveInputTranscriptDelta(BaseRealtimeEvent):
+    """A timed input-transcript delta emitted by the Live frontend."""
+
+    type: Literal["session.input_transcript.delta"]
+    delta: str
     start_ms: int
     end_ms: int
 
@@ -400,6 +409,16 @@ class OpenAILiveProvider(OpenAIRealtimeProvider):
                     type="response.output_audio_transcript.delta",
                     delta=data["delta"],
                     audio_position_bytes=data["audio_position_bytes"],
+                    start_ms=data["start_ms"],
+                    end_ms=data["end_ms"],
+                )
+            ]
+        if event_type == "session.input_transcript.delta":
+            return [
+                LiveInputTranscriptDelta(
+                    type=event_type,
+                    event_id=data.get("event_id"),
+                    delta=data["delta"],
                     start_ms=data["start_ms"],
                     end_ms=data["end_ms"],
                 )

--- a/tests/test_voice/test_audio_native/test_live_provider.py
+++ b/tests/test_voice/test_audio_native/test_live_provider.py
@@ -26,6 +26,7 @@ from tau2.voice.audio_native.openai.events import (
 from tau2.voice.audio_native.openai.live_adapter import DiscreteTimeOpenAILiveAdapter
 from tau2.voice.audio_native.openai.live_config import LiveConfig
 from tau2.voice.audio_native.openai.live_provider import (
+    LiveInputTranscriptDelta,
     LiveTranscriptDelta,
     OpenAILiveProvider,
     _LiveInputAudioTrack,
@@ -151,6 +152,54 @@ def test_audio_arrives_without_any_turn_or_transcript_marker(provider):
     assert len(events) == 1
     assert isinstance(events[0], AudioDeltaEvent)
     assert base64.b64decode(events[0].delta) == pcm
+
+
+def test_input_transcript_delta_preserves_structured_speech_timing(provider):
+    events = provider._normalize_event(
+        {
+            "type": "session.input_transcript.delta",
+            "event_id": "event-1",
+            "delta": " hello",
+            "start_ms": 1200,
+            "end_ms": 1400,
+        }
+    )
+
+    assert events == [
+        LiveInputTranscriptDelta(
+            type="session.input_transcript.delta",
+            event_id="event-1",
+            delta=" hello",
+            start_ms=1200,
+            end_ms=1400,
+        )
+    ]
+
+
+def test_input_transcript_delta_surfaces_normalized_speech_event(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-only")
+    adapter = DiscreteTimeOpenAILiveAdapter(
+        tick_duration_ms=200,
+        model="test-live",
+        config=LiveConfig(backend_model="test-backend"),
+    )
+    event = LiveInputTranscriptDelta(
+        type="session.input_transcript.delta",
+        delta=" hello",
+        start_ms=1200,
+        end_ms=1400,
+    )
+    result = TickResult(
+        tick_number=1,
+        audio_sent_bytes=1600,
+        audio_sent_duration_ms=200,
+    )
+
+    asyncio.run(adapter._process_event(result, event))
+
+    assert result.events == [event]
+    assert result.vad_events == ["speech_started"]
+    assert result.was_truncated is False
 
 
 def response_event(provider, event):

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -202,6 +202,13 @@ def make_silence(tick_duration_ms: int = TICK_DURATION_MS) -> bytes:
     return TELEPHONY_ULAW_SILENCE * num_bytes
 
 
+def has_agent_speech(result: TickResult) -> bool:
+    """Use normalized activity when a continuous-media adapter provides it."""
+    if result.contains_speech is not None:
+        return result.contains_speech
+    return result.agent_audio_bytes > 0
+
+
 def _make_order_tool() -> Tool:
     """Create the get_order_status tool used in tool-call tests."""
 
@@ -324,7 +331,7 @@ def run_ticks_until(
         assert_audio_capping(result, adapter)
         assert_played_audio_length(result, adapter)
 
-        if stop_when == "agent_audio" and result.agent_audio_bytes > 0:
+        if stop_when == "agent_audio" and has_agent_speech(result):
             return results
         if stop_when == "tool_call" and result.tool_calls:
             return results
@@ -499,7 +506,7 @@ class TestSingleTurn:
             connected_adapter, chunks, timer, stop_when="agent_audio"
         )
 
-        got_audio = any(r.agent_audio_bytes > 0 for r in results)
+        got_audio = any(has_agent_speech(r) for r in results)
         assert got_audio, (
             f"Agent did not produce audio within {len(results)} ticks "
             f"({len(results) * TICK_DURATION_MS}ms) for {audio_file}"
@@ -538,7 +545,7 @@ class TestMultiTurn:
         results_t1 = run_ticks_until(
             connected_adapter, t1_chunks, timer, stop_when="agent_audio"
         )
-        got_audio_t1 = any(r.agent_audio_bytes > 0 for r in results_t1)
+        got_audio_t1 = any(has_agent_speech(r) for r in results_t1)
         assert got_audio_t1, "Turn 1: agent did not produce audio"
 
         # Let the agent finish responding (drain remaining audio)
@@ -564,10 +571,10 @@ class TestMultiTurn:
             results_t2.append(result)
             assert_audio_capping(result, connected_adapter)
             assert_played_audio_length(result, connected_adapter)
-            if result.agent_audio_bytes > 0:
+            if has_agent_speech(result):
                 break
 
-        got_audio_t2 = any(r.agent_audio_bytes > 0 for r in results_t2)
+        got_audio_t2 = any(has_agent_speech(r) for r in results_t2)
         assert got_audio_t2, "Turn 2: agent did not produce audio"
 
 
@@ -621,7 +628,7 @@ class TestToolCall:
             result = timer.run_tick(adapter, silence, tick_offset + tick + 1)
             assert_audio_capping(result, adapter)
             assert_played_audio_length(result, adapter)
-            if result.agent_audio_bytes > 0:
+            if has_agent_speech(result):
                 got_response_audio = True
                 break
 
@@ -658,7 +665,7 @@ class TestUsageReporting:
         results = run_ticks_until(
             connected_adapter, chunks, timer, stop_when="agent_audio"
         )
-        assert any(r.agent_audio_bytes > 0 for r in results), (
+        assert any(has_agent_speech(r) for r in results), (
             "Agent never produced audio; cannot check usage reporting"
         )
 
@@ -757,7 +764,7 @@ class TestBargeIn:
         results = run_ticks_until(
             adapter, trigger_chunks, timer, stop_when="agent_audio"
         )
-        assert any(r.agent_audio_bytes > 0 for r in results), (
+        assert any(has_agent_speech(r) for r in results), (
             f"Agent never started speaking for {audio_file}"
         )
 
@@ -808,9 +815,7 @@ class TestBargeIn:
         results = run_ticks_until(
             adapter, trigger_chunks, timer, stop_when="agent_audio"
         )
-        assert any(r.agent_audio_bytes > 0 for r in results), (
-            "Agent never started speaking"
-        )
+        assert any(has_agent_speech(r) for r in results), "Agent never started speaking"
 
         tick_num = len(results)
         silence = make_silence()
@@ -820,7 +825,7 @@ class TestBargeIn:
             tick_num += 1
             result = timer.run_tick(adapter, silence, tick_num)
             assert_audio_capping(result, adapter)
-            if result.agent_audio_bytes > 0:
+            if has_agent_speech(result):
                 agent_audio_ticks += 1
             if agent_audio_ticks >= MIN_AGENT_AUDIO_TICKS:
                 break
@@ -855,9 +860,7 @@ class TestBargeIn:
         results = run_ticks_until(
             adapter, trigger_chunks, timer, stop_when="agent_audio"
         )
-        assert any(r.agent_audio_bytes > 0 for r in results), (
-            "Agent never started speaking"
-        )
+        assert any(has_agent_speech(r) for r in results), "Agent never started speaking"
 
         # Phase 2: let agent speak for INTERRUPT_AFTER_TICKS (~1 second)
         tick_num = len(results)
@@ -868,7 +871,7 @@ class TestBargeIn:
             tick_num += 1
             result = timer.run_tick(adapter, silence, tick_num)
             assert_audio_capping(result, adapter)
-            if result.agent_audio_bytes > 0:
+            if has_agent_speech(result):
                 agent_audio_ticks += 1
             if agent_audio_ticks >= INTERRUPT_AFTER_TICKS:
                 break
@@ -903,7 +906,7 @@ class TestBargeIn:
 
             # After interruption, track silence
             if interruption_tick is not None:
-                if result.agent_audio_bytes > 0:
+                if has_agent_speech(result):
                     trailing_audio_ticks += 1
                     consecutive_silence = 0
                 else:


### PR DESCRIPTION
## Summary

- Parse the timed `session.input_transcript.delta` event emitted by the GPT Live frontend.
- Expose that structured speech activity as the normalized `speech_started` signal used by the provider conformance suite.
- Preserve the semantic distinction between detected speech and confirmed truncation: this does not set `was_truncated` because the Live endpoint does not emit an explicit truncation event.
- Make conformance assertions use `TickResult.contains_speech` when an adapter supplies it, with the existing audio-byte check as the fallback. This handles continuous WebRTC media that includes silence frames.

## Testing

- `make check-all`
- `python -m pytest tests/test_voice/test_audio_native/test_live_provider.py tests/test_voice/test_audio_native/test_openai_provider_config.py -q` — 18 passed
- Live GPT Live barge-in subset — 3 passed: short detection, medium detection, and agent yields

## Stack

Based on #527 (`codex/openai-live-prompt-templates`).