### PR TITLE
Add Cartesia speech for voice agents and customer simulation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ OPENROUTER_API_KEY=<your_key_here>
 # TAU2_VOICE_ID_WEI_LIN=<your_voice_id>
 # TAU2_VOICE_ID_MAMADOU_DIALLO=<your_voice_id>
 # TAU2_VOICE_ID_PRIYA_PATIL=<your_voice_id>
+
+# Optional Cartesia customer speech (--user-tts-config)
+CARTESIA_API_KEY=
+# TAU2_CARTESIA_VOICE_ID_MATT_DELANEY=
+# TAU2_CARTESIA_VOICE_ID_LISA_BRENNER=

--- a/examples/voice/cartesia-customer.json
+++ b/examples/voice/cartesia-customer.json
@@ -1,0 +1,8 @@
+{
+  "provider": "cartesia",
+  "provider_config": {
+    "model_id": "sonic-3.6-2026-08-27",
+    "voice_id": "16212f18-4955-4be9-a6cd-2196ce2c11d1",
+    "locale": "en"
+  }
+}

--- a/examples/voice/cartesia_customer_smoke.py
+++ b/examples/voice/cartesia_customer_smoke.py
@@ -1,0 +1,69 @@
+"""Exercise customer TTS and telephony conversion without running an agent/LLM.
+
+Run from the repository root:
+    uv run examples/voice/cartesia_customer_smoke.py
+Requires CARTESIA_API_KEY. Consumes one short TTS request.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from tau2.data_model.message import UserMessage
+from tau2.data_model.simulation import AudioNativeConfig
+from tau2.data_model.voice import SynthesisConfig, VoiceSettings
+from tau2.registry import registry
+from tau2.run import get_tasks
+from tau2.runner.build import build_voice_user
+
+
+def main():
+    """Save one real customer utterance plus its effective voice settings."""
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", default="examples/voice/cartesia-customer.json")
+    parser.add_argument("--output", default="data/simulations/cartesia-customer-smoke")
+    args = parser.parse_args()
+    output = Path(args.output)
+    synthesis = SynthesisConfig.model_validate_json(Path(args.config).read_text())
+    user = build_voice_user(
+        registry.get_env_constructor("retail")(),
+        get_tasks("retail", task_ids=["0"])[0],
+        AudioNativeConfig(),
+        domain="retail",
+        speech_complexity="control",
+        voice_settings=VoiceSettings(
+            transcription_config=None,
+            synthesis_config=synthesis,
+            output_dir=output,
+        ),
+    )
+    state = user.get_init_state()
+    message = user.synthesize_voice(
+        UserMessage(
+            role="user",
+            content="Hello. I would like to return my order. [pause] Can you help me?",
+        ),
+        state,
+    )
+    audio = message.get_audio_bytes()
+    assert audio and message.is_audio
+    assert message.audio_format.sample_rate == 8000
+    result = {
+        "bytes": len(audio),
+        "audio_format": message.audio_format.model_dump(mode="json"),
+        "audio_path": message.audio_path,
+        "voice_settings": user.voice_settings.model_dump(mode="json"),
+        "scope": "Live customer TTS and effects pipeline only; no agent or LLM call.",
+    }
+    output.mkdir(parents=True, exist_ok=True)
+    (output / "result.json").write_text(json.dumps(result, indent=2) + "\n")
+    print(
+        json.dumps({k: v for k, v in result.items() if k != "voice_settings"}, indent=2)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/voice/run_cartesia_customer_examples.py
+++ b/examples/voice/run_cartesia_customer_examples.py
@@ -1,0 +1,85 @@
+"""Run ten retail conversations with Haiku customers and Cartesia speech."""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def main():
+    """Load credentials, then run the benchmark with bounded example settings."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cartesia-env",
+        help="Optional existing dotenv file containing CARTESIA_API_KEY",
+    )
+    parser.add_argument(
+        "--auto-resume",
+        action="store_true",
+        help="Keep saved calls and retry infrastructure failures",
+    )
+    args = parser.parse_args()
+    load_dotenv()
+    if args.cartesia_env:
+        load_dotenv(args.cartesia_env, override=False)
+    missing = [
+        key for key in ("ANTHROPIC_API_KEY", "CARTESIA_API_KEY") if not os.getenv(key)
+    ]
+    if missing:
+        parser.error("Missing credentials: " + ", ".join(missing))
+    root = Path(__file__).resolve().parents[2]
+    os.chdir(root)
+    sys.argv = [
+        "tau2",
+        "run",
+        "--domain",
+        "retail",
+        "--audio-native",
+        "--audio-native-provider",
+        "livekit",
+        "--audio-native-model",
+        "claude-haiku-4-5-20251001",
+        "--cascaded-config",
+        "cartesia-haiku",
+        "--user-llm",
+        "anthropic/claude-haiku-4-5-20251001",
+        "--user-llm-args",
+        '{"temperature": 0}',
+        "--user-tts-config",
+        "examples/voice/cartesia-customer.json",
+        "--speech-complexity",
+        "control",
+        "--task-ids",
+        "0",
+        "2",
+        "5",
+        "10",
+        "12",
+        "15",
+        "16",
+        "17",
+        "18",
+        "21",
+        "--num-trials",
+        "1",
+        "--max-concurrency",
+        "2",
+        "--max-steps-seconds",
+        "300",
+        "--max-retries",
+        "1",
+        "--save-to",
+        "cartesia-haiku-both-10",
+        "--verbose-logs",
+    ]
+    if args.auto_resume:
+        sys.argv.append("--auto-resume")
+    from tau2.cli import main as run_cli
+
+    run_cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/voice/summarize_cartesia_examples.py
+++ b/examples/voice/summarize_cartesia_examples.py
@@ -1,0 +1,57 @@
+"""Export readable speech transcripts and an index for the Cartesia examples."""
+
+import json
+from pathlib import Path
+
+from tau2.data_model.simulation import SimulationRun
+from tau2.voice.synthesis.conversation_builder import _collect_speech_segments
+
+
+def main():
+    root = Path("data/simulations/cartesia-haiku-both-10")
+    rows = []
+    for path in sorted((root / "simulations").glob("*.json")):
+        sim = SimulationRun.model_validate_json(path.read_text())
+        segments = []
+        for role in ("user", "assistant"):
+            segments.extend(_collect_speech_segments(sim.ticks or [], role))
+        segments.sort(key=lambda segment: segment.start_tick)
+        transcript = root / f"task_{sim.task_id}_transcript.txt"
+        lines = [f"Task {sim.task_id} | {sim.termination_reason.value}", ""]
+        for segment in segments:
+            name = "Customer" if segment.role == "user" else "Agent"
+            lines.append(f"[{segment.start_tick * 0.2:.1f}s] {name}: {segment.text}")
+        lines += [
+            "",
+            "Tool calls and results (full structured data is in the simulation JSON):",
+        ]
+        for tick in sim.ticks or []:
+            for message in [*tick.agent_tool_calls, *tick.agent_tool_results]:
+                lines.append(
+                    f"[{tick.tick_id * 0.2:.1f}s] {message.model_dump_json(exclude_none=True)}"
+                )
+        transcript.write_text("\n\n".join(lines) + "\n")
+        audio = list(
+            (root / "artifacts" / f"task_{sim.task_id}").glob("*/audio/both.wav")
+        )
+        rows.append(
+            {
+                "task_id": sim.task_id,
+                "termination_reason": sim.termination_reason.value,
+                "reward": sim.reward_info.reward if sim.reward_info else None,
+                "wall_seconds": sim.duration,
+                "audio_seconds": len(sim.ticks or []) * 0.2,
+                "transcript": str(transcript.relative_to(root)),
+                "audio": [str(p.relative_to(root)) for p in audio],
+                "simulation": str(path.relative_to(root)),
+                "agent_cost": sim.agent_cost,
+                "user_llm_cost": sim.user_cost,
+            }
+        )
+    rows.sort(key=lambda row: int(row["task_id"]))
+    (root / "example-index.json").write_text(json.dumps(rows, indent=2) + "\n")
+    print(json.dumps(rows, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ voice = [
     "livekit-agents>=1.5.0",
     "livekit-plugins-deepgram>=1.5.0",
     "livekit-plugins-openai>=1.5.0",
+    "livekit-plugins-cartesia>=1.8.0",
+    "livekit-plugins-anthropic>=1.8.0",
+    "anthropic<1",  # LiveKit Anthropic plugin currently uses httpx, not httpx2.
 ]
 knowledge = [
     "rank-bm25>=0.2.2",

--- a/src/tau2/agent/base/voice.py
+++ b/src/tau2/agent/base/voice.py
@@ -10,7 +10,6 @@ from tau2.agent.base.streaming_utils import format_transcript_comparison
 from tau2.data_model.audio import AudioData, audio_bytes_to_string
 from tau2.data_model.message import Message
 from tau2.data_model.voice import VoiceSettings
-from tau2.data_model.voice_personas import get_elevenlabs_voice_id
 from tau2.voice.synthesis.audio_effects.noise_generator import (
     BackgroundNoiseGenerator,
 )
@@ -114,7 +113,9 @@ class VoiceMixin(
         speech_env = self.voice_settings.speech_environment
         synthesis_config = self.voice_settings.synthesis_config
         provider_config = deepcopy(synthesis_config.provider_config)
-        provider_config.voice_id = get_elevenlabs_voice_id(speech_env.persona_name)
+        provider_config.voice_id = synthesis_config.resolve_voice_id(
+            speech_env.persona_name
+        )
 
         # Generate per-turn effects (complexity overrides already merged into synthesis_config)
         speech_effects, source_effects, channel_effects = generate_turn_effects(

--- a/src/tau2/cli.py
+++ b/src/tau2/cli.py
@@ -39,6 +39,7 @@ from tau2.data_model.simulation import (
     TextRunConfig,
     VoiceRunConfig,
 )
+from tau2.data_model.voice import SynthesisConfig, VoiceSettings
 from tau2.domains.banking_knowledge.retrieval import get_all_variant_names
 from tau2.run import get_options, run_domain
 from tau2.runner.work import parse_provider_limits
@@ -266,7 +267,7 @@ def add_run_args(parser):
         type=str,
         default=None,
         help="Cascaded config preset name for livekit provider. "
-        "Available presets: 'default', 'openai-thinking'. "
+        "Available presets: 'default', 'openai-thinking', 'cartesia-haiku'. "
         "See tau2.voice.audio_native.livekit.config for details.",
     )
     parser.add_argument(
@@ -311,6 +312,12 @@ def add_run_args(parser):
         ],
         default=DEFAULT_SPEECH_COMPLEXITY,
         help=f"Speech complexity level for audio effects. Default is '{DEFAULT_SPEECH_COMPLEXITY}'.",
+    )
+
+    parser.add_argument(
+        "--user-tts-config",
+        type=str,
+        help="Path to a SynthesisConfig JSON file for customer speech (e.g. Cartesia).",
     )
 
     # Audio-native: Sample rates
@@ -681,11 +688,22 @@ def main():
             retrieval_config_kwargs=args.retrieval_config_kwargs,
         )
 
+        user_voice_settings = None
+        if args.user_tts_config:
+            if audio_native_config is None:
+                raise ValueError("--user-tts-config requires --audio-native")
+            with open(args.user_tts_config, encoding="utf-8") as f:
+                synthesis = SynthesisConfig.model_validate_json(f.read())
+            user_voice_settings = VoiceSettings(
+                transcription_config=None, synthesis_config=synthesis
+            )
+
         if audio_native_config is not None:
             config = VoiceRunConfig(
                 **shared_kwargs,
                 audio_native_config=audio_native_config,
                 speech_complexity=args.speech_complexity,
+                user_voice_settings=user_voice_settings,
                 audio_debug=getattr(args, "audio_debug", False),
                 audio_taps=getattr(args, "audio_taps", False),
             )

--- a/src/tau2/data_model/voice.py
+++ b/src/tau2/data_model/voice.py
@@ -1,10 +1,11 @@
 # Copyright Sierra
 """Voice data models for synthesis, transcription, and audio effects."""
 
+import os
 from pathlib import Path
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, model_validator
 
 from tau2.config import DEFAULT_SEED
 from tau2.data_model.audio import AudioEncoding, AudioFormat
@@ -17,6 +18,8 @@ from tau2.data_model.persona import PersonaConfig
 from tau2.data_model.voice_personas import DEFAULT_PERSONA_NAME, get_elevenlabs_voice_id
 from tau2.voice_config import (
     BURST_NOISE_EVENTS_PER_MINUTE,
+    DEFAULT_CARTESIA_API_VERSION,
+    DEFAULT_CARTESIA_TTS_MODEL,
     DEFAULT_TRANSCRIPTION_MODEL,
     DEFAULT_VOICE_SYNTHESIS_PROVIDER,
     ELEVENLABS_AUDIO_TAGS_PROBABILITY,
@@ -98,7 +101,21 @@ class ElevenLabsTTSConfig(BaseModel):
     seed: Optional[int] = Field(default=None)
 
 
-ProviderConfig = ElevenLabsTTSConfig
+class CartesiaTTSConfig(BaseModel):
+    """Cartesia customer speech; voice IDs are separate from ElevenLabs personas."""
+
+    model_id: str = DEFAULT_CARTESIA_TTS_MODEL
+    api_version: str = DEFAULT_CARTESIA_API_VERSION
+    voice_id: Optional[str] = None
+    persona_voice_ids: dict[str, str] = Field(default_factory=dict)
+    locale: str = "en"
+
+    @property
+    def output_audio_format(self) -> AudioFormat:
+        return AudioFormat(encoding=AudioEncoding.PCM_S16LE, sample_rate=16000)
+
+
+ProviderConfig = ElevenLabsTTSConfig | CartesiaTTSConfig
 
 
 # ============================================================================
@@ -120,6 +137,43 @@ class SynthesisConfig(BaseModel):
     speech_effects_config: SpeechEffectsConfig = Field(
         default_factory=SpeechEffectsConfig
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_provider_config(cls, value):
+        """Restore the correct config type when loading saved runs or CLI JSON."""
+        if isinstance(value, dict):
+            value = dict(value)
+            provider = value.get("provider", "elevenlabs")
+            config_type = {
+                "elevenlabs": ElevenLabsTTSConfig,
+                "cartesia": CartesiaTTSConfig,
+            }.get(provider)
+            if config_type is None:
+                raise ValueError(f"Unsupported synthesis provider: {provider}")
+            config = value.get("provider_config")
+            if config is None or isinstance(config, dict):
+                value["provider_config"] = config_type.model_validate(config or {})
+            elif not isinstance(config, config_type):
+                raise ValueError(f"Wrong provider_config type for {provider}")
+        return value
+
+    def resolve_voice_id(self, persona_name: str) -> str:
+        """Resolve a provider-specific voice, failing rather than using the wrong ID."""
+        config = self.provider_config
+        if self.provider == "cartesia":
+            key = f"TAU2_CARTESIA_VOICE_ID_{persona_name.upper()}"
+            voice_id = (
+                config.persona_voice_ids.get(persona_name)
+                or os.getenv(key)
+                or config.voice_id
+            )
+            if not voice_id or not voice_id.strip():
+                raise ValueError(
+                    f"Set {key}, persona_voice_ids[{persona_name!r}], or an explicit Cartesia voice_id"
+                )
+            return voice_id
+        return get_elevenlabs_voice_id(persona_name)
 
 
 class SynthesisResult(BaseModel):

--- a/src/tau2/runner/batch.py
+++ b/src/tau2/runner/batch.py
@@ -493,9 +493,12 @@ def make_voice_run_settings(
     from the config (so a worker process re-derives the same values)."""
     if not isinstance(config, VoiceRunConfig):
         return None, None
-    user_voice_settings = VoiceSettings(
-        transcription_config=None,
-        synthesis_config=SynthesisConfig(),
+    user_voice_settings = (
+        config.user_voice_settings.model_copy(deep=True)
+        if config.user_voice_settings is not None
+        else VoiceSettings(
+            transcription_config=None, synthesis_config=SynthesisConfig()
+        )
     )
     complexity_config = COMPLEXITY_CONFIGS[config.speech_complexity]
     user_persona_config = PersonaConfig(

--- a/src/tau2/runner/build.py
+++ b/src/tau2/runner/build.py
@@ -246,6 +246,15 @@ def build_voice_user(
         synthesis_config=task_voice_settings.synthesis_config,
     )
 
+    # Apply provider limitations after loading presets, including pre-sampled files.
+    if task_voice_settings.synthesis_config.provider == "cartesia":
+        sampled_voice_config = sampled_voice_config.model_copy(deep=True)
+        if sampled_voice_config.speech_effects_config.enable_vocal_tics:
+            logger.warning(
+                "Cartesia customer simulation disables ElevenLabs-only vocal tics; this is a modified speech condition."
+            )
+        sampled_voice_config.speech_effects_config.enable_vocal_tics = False
+
     # Update synthesis_config with merged effect configs
     task_voice_settings.synthesis_config.channel_effects_config = (
         sampled_voice_config.channel_effects_config
@@ -259,6 +268,14 @@ def build_voice_user(
 
     # Set speech environment
     speech_environment = sampled_voice_config.to_speech_environment(task_seed)
+    speech_environment.voice_id = task_voice_settings.synthesis_config.resolve_voice_id(
+        speech_environment.persona_name
+    )
+    # Persist the resolved voice so a saved task need not depend on environment overrides.
+    if task_voice_settings.synthesis_config.provider == "cartesia":
+        task_voice_settings.synthesis_config.provider_config.persona_voice_ids[
+            speech_environment.persona_name
+        ] = speech_environment.voice_id
     task_voice_settings.speech_environment = speech_environment
 
     # Use provided persona config or fall back to sampled config

--- a/src/tau2/utils/llm_utils.py
+++ b/src/tau2/utils/llm_utils.py
@@ -386,6 +386,13 @@ def generate(
         os.environ["VERTEXAI_LOCATION"] = "global"
 
     litellm_messages = to_litellm_messages(messages)
+    if model.startswith(("anthropic/", "claude-")):
+        conversation = [m for m in litellm_messages if m["role"] != "system"]
+        # The voice customer may be prompted after silence, with no initial
+        # user turn or with its own previous reply last. Avoid Anthropic
+        # treating that reply as an assistant prefill and returning no text.
+        if not conversation or conversation[-1]["role"] == "assistant":
+            litellm_messages.append({"role": "user", "content": "Please continue."})
     tools_schema = [tool.openai_schema for tool in tools] if tools else None
     if tools_schema and tool_choice is None:
         tool_choice = "auto"

--- a/src/tau2/utils/retry.py
+++ b/src/tau2/utils/retry.py
@@ -75,6 +75,8 @@ def _is_retryable_tts_error(e: Exception) -> bool:
     exc_name = type(e).__name__.lower()
     if "timeout" in exc_name or "readtimeout" in exc_name:
         return True
+    if isinstance(e, httpx.HTTPStatusError):
+        return e.response.status_code in (409, 429) or e.response.status_code >= 500
     # HTTP status code based retries
     if hasattr(e, "status_code") and e.status_code is not None:
         # Retry on rate limiting (429), conflict (409), and server errors (5xx)

--- a/src/tau2/voice/README.md
+++ b/src/tau2/voice/README.md
@@ -136,3 +136,90 @@ See the [Voice Persona Setup Guide](../../docs/voice-personas.md) for step-by-st
 | `ELEVENLABS_API_KEY` | User simulator TTS (synthesis) |
 | `DEEPGRAM_API_KEY` | Transcription (Deepgram nova-2, nova-3) |
 | `TAU2_VOICE_ID_*` | Custom voice ID overrides (see [Voice Persona Setup](../../docs/voice-personas.md)) |
+
+## Cartesia customer speech
+
+The customer simulator can use Cartesia TTS independently of the agent provider.
+Install the voice dependencies and set `CARTESIA_API_KEY`, then run:
+
+```bash
+tau2 run --domain retail --audio-native --num-tasks 1 --num-trials 1 \
+  --speech-complexity control --verbose-logs \
+  --user-tts-config examples/voice/cartesia-customer.json
+```
+
+This example uses the single Hao stock voice for **all** customer personas and
+pins `sonic-3.6-2026-08-27`. It is a smoke-test configuration, not a reproduction
+of the standard customer accents. The command retains the default OpenAI agent
+and therefore also needs OpenAI access. It does not configure the agent's ASR or
+TTS; customer synthesis and the evaluated agent are independent.
+
+For persona-specific voices, remove the example's `voice_id` and supply
+`provider_config.persona_voice_ids`, mapping persona names such as `matt_delaney`
+and `lisa_brenner` to Cartesia voice IDs. Alternatively set
+`TAU2_CARTESIA_VOICE_ID_MATT_DELANEY`, `TAU2_CARTESIA_VOICE_ID_LISA_BRENNER`, etc.
+Resolution order is JSON persona mapping, persona environment variable, then an
+explicit shared `voice_id`. Missing voices fail instead of falling back to an
+ElevenLabs ID. Choose and audition voices matching the intended personas before
+comparing configurations. The standard `TAU2_VOICE_ID_*` variables remain
+ElevenLabs-only.
+
+The customer text LLM, policies, task definitions, and scoring are unchanged.
+Speech uses 16 kHz mono PCM before the existing noise, muffling, telephony, and
+frame-loss processing. Normal utterances, backchannels, and non-directed phrases
+all use the selected Cartesia voice. `[pause]` becomes a 500 ms Cartesia break.
+ElevenLabs-only cough/sneeze/sniffle inserts are disabled **after** task presets
+are loaded, including for `regular`; this is recorded in the task's effective
+speech settings. Those tags are rejected if they reach the Cartesia API helper.
+Other speech conditions and their timing settings remain in place.
+
+These are **modified customer-simulator conditions**, not directly comparable
+with the standard ElevenLabs results. Saved settings include the provider,
+model snapshot, API version, resolved task voice IDs, and effective effects.
+Credentials are read from the environment and are not part of the Cartesia
+configuration. No ElevenLabs API key is needed for Cartesia customer synthesis.
+
+Programmatically, pass `VoiceSettings(transcription_config=None,
+synthesis_config=SynthesisConfig(provider="cartesia",
+provider_config=CartesiaTTSConfig(...)))` as `VoiceRunConfig.user_voice_settings`.
+
+To check only the customer side (one short Cartesia request; no agent/LLM API):
+
+```bash
+uv run examples/voice/cartesia_customer_smoke.py
+```
+
+It saves a WAV and effective configuration under
+`data/simulations/cartesia-customer-smoke/` after passing through the real
+customer simulator's synthesis and telephony conversion.
+
+### Ten conversations with Cartesia on both sides
+
+With `ANTHROPIC_API_KEY` and `CARTESIA_API_KEY` in the environment or `.env`:
+
+```bash
+uv run examples/voice/run_cartesia_customer_examples.py
+```
+
+This runs retail tasks 0, 2, 5, 10, 12, 15, 16, 17, 18, and 21 once,
+with two conversations at a time and a 300-second conversation limit.
+The evaluated agent uses LiveKit's Cartesia Ink 2 ASR, Claude Haiku 4.5
+(`claude-haiku-4-5-20251001`), and Cartesia Sonic 3.6 with the Hao voice.
+The customer uses Haiku 4.5 for dialogue and the same Cartesia TTS snapshot.
+The `control` speech setting uses clean audio. This is an example run of a
+cascaded agent, not a test of Cartesia Managed Agents orchestration.
+Anthropic requests receive a "Please continue." user cue when initializing
+the customer or prompting it again after silence; this avoids assistant prefill.
+
+Results and audio are saved under `data/simulations/cartesia-haiku-both-10/`.
+Cartesia usage quantities are recorded, but total dollar cost is unavailable
+because the pricing table does not encode Cartesia's plan-dependent credits.
+To run live adapter validation, set `CARTESIA_TEST_ENABLED=1` and run
+`uv run tests/test_voice/test_audio_native/run_provider_suite.py`; its dollar-cost
+coverage assertion currently fails for Cartesia for that reason.
+
+If a batch is interrupted or blocked by API billing, rerun the example script
+with `--auto-resume` after resolving the issue. Completed calls are retained;
+infrastructure failures are retried. Use
+`uv run examples/voice/summarize_cartesia_examples.py` to export readable
+transcripts, tool calls, and `example-index.json` alongside the recordings.

--- a/src/tau2/voice/audio_native/livekit/__init__.py
+++ b/src/tau2/voice/audio_native/livekit/__init__.py
@@ -70,24 +70,15 @@ def preregister_livekit_plugins() -> None:
 
     Must be called from the main thread before any workers are created.
     """
+    from importlib import import_module
+
     from loguru import logger
 
-    try:
-        # Import the plugins - this triggers their registration
-        from livekit.plugins import (  # noqa: F401
-            anthropic,
-            deepgram,
-            elevenlabs,
-            openai,
-        )
-
-        logger.debug("LiveKit plugins pre-registered on main thread")
-    except ImportError as e:
-        logger.warning(
-            f"Failed to pre-register LiveKit plugins: {e}. "
-            "Install with: pip install livekit-plugins-openai livekit-plugins-deepgram "
-            "livekit-plugins-anthropic livekit-plugins-elevenlabs"
-        )
+    for plugin in ("anthropic", "cartesia", "deepgram", "elevenlabs", "openai"):
+        try:
+            import_module(f"livekit.plugins.{plugin}")
+        except ImportError:
+            logger.debug(f"Optional LiveKit plugin {plugin} is not installed")
 
 
 __all__ = [

--- a/src/tau2/voice/audio_native/livekit/config.py
+++ b/src/tau2/voice/audio_native/livekit/config.py
@@ -12,6 +12,8 @@ from typing import Dict, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
+from tau2.voice_config import DEFAULT_CARTESIA_TTS_MODEL
+
 # =============================================================================
 # STT Configurations
 # =============================================================================
@@ -50,7 +52,16 @@ class DeepgramSTTConfig(BaseModel):
 
 
 # Type alias for STT configs (extensible for future providers)
-STTConfig = DeepgramSTTConfig
+class CartesiaSTTConfig(BaseModel):
+    """Streaming Cartesia ASR with model-provided speech boundaries."""
+
+    provider: Literal["cartesia"] = "cartesia"
+    model: str = "ink-2"
+    language: str = "en"
+    utterance_end_ms: int = 2000
+
+
+STTConfig = Union[DeepgramSTTConfig, CartesiaSTTConfig]
 
 
 # =============================================================================
@@ -154,7 +165,17 @@ class ElevenLabsTTSConfig(BaseModel):
 
 
 # Type alias for TTS configs
-TTSConfig = Union[DeepgramTTSConfig, ElevenLabsTTSConfig]
+class CartesiaTTSConfig(BaseModel):
+    """Cartesia agent voice and PCM sample rate."""
+
+    provider: Literal["cartesia"] = "cartesia"
+    model: str = DEFAULT_CARTESIA_TTS_MODEL
+    voice_id: str = "16212f18-4955-4be9-a6cd-2196ce2c11d1"
+    language: str = "en"
+    sample_rate: int = 24000
+
+
+TTSConfig = Union[DeepgramTTSConfig, ElevenLabsTTSConfig, CartesiaTTSConfig]
 
 
 # =============================================================================
@@ -188,6 +209,11 @@ class CascadedConfig(BaseModel):
 # =============================================================================
 
 CASCADED_CONFIGS: Dict[str, CascadedConfig] = {
+    "cartesia-haiku": CascadedConfig(
+        stt=CartesiaSTTConfig(),
+        llm=AnthropicLLMConfig(model="claude-haiku-4-5-20251001", temperature=0.0),
+        tts=CartesiaTTSConfig(),
+    ),
     # Default: Balanced speed and quality
     "default": CascadedConfig(
         stt=DeepgramSTTConfig(model="nova-3"),

--- a/src/tau2/voice/audio_native/livekit/discrete_time_adapter.py
+++ b/src/tau2/voice/audio_native/livekit/discrete_time_adapter.py
@@ -49,7 +49,11 @@ from tau2.data_model.usage import UsageRecord
 from tau2.environment.tool import Tool
 from tau2.voice.audio_native.adapter import DiscreteTimeAdapter
 from tau2.voice.audio_native.audio_converter import StreamingTelephonyConverter
-from tau2.voice.audio_native.livekit.config import CascadedConfig, DeepgramTTSConfig
+from tau2.voice.audio_native.livekit.config import (
+    CartesiaTTSConfig,
+    CascadedConfig,
+    DeepgramTTSConfig,
+)
 from tau2.voice.audio_native.livekit.provider import (
     CascadedEvent,
     CascadedEventType,
@@ -125,6 +129,8 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
         # Event queue for non-blocking tick processing.
         # Background tasks push events here; ticks drain within their time budget.
         self._event_queue: asyncio.Queue[CascadedEvent] = asyncio.Queue()
+        self._response_task: Optional[asyncio.Task] = None
+        self._suppress_response_audio = False
 
         # Audio buffering for tick alignment
         # Excess audio from one tick is carried over to the next
@@ -143,7 +149,7 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
         # Audio format conversion (telephony ↔ internal formats)
         # TTS sample rate depends on config (Deepgram=24kHz, ElevenLabs varies)
         tts_sample_rate = 24000  # default
-        if isinstance(self.cascaded_config.tts, DeepgramTTSConfig):
+        if isinstance(self.cascaded_config.tts, (DeepgramTTSConfig, CartesiaTTSConfig)):
             tts_sample_rate = self.cascaded_config.tts.sample_rate
         self._audio_converter = StreamingTelephonyConverter(
             input_sample_rate=16000,
@@ -206,6 +212,8 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
             self._tick_count = 0
             self._utterance_transcripts.clear()
             self._current_utterance_id = None
+            self._response_task = None
+            self._suppress_response_audio = False
             logger.info(
                 f"LiveKitCascadedAdapter connected "
                 f"(tick={self.tick_duration_ms}ms, bytes_per_tick={self.bytes_per_tick})"
@@ -255,7 +263,7 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
 
         if self._loop is not None and self._provider is not None:
             future = asyncio.run_coroutine_threadsafe(
-                self._provider.disconnect(),
+                self._disconnect_provider(),
                 self._loop,
             )
             try:
@@ -271,6 +279,15 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
         self._audio_converter.reset()
         logger.info("LiveKitCascadedAdapter disconnected")
 
+    async def _disconnect_provider(self) -> None:
+        """Finish pipeline tasks before closing their HTTP sessions and event loop."""
+        current = asyncio.current_task()
+        pending = [task for task in asyncio.all_tasks() if task is not current]
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        await self._provider.disconnect()
+
     def _start_background_loop(self) -> None:
         """Start the background thread with async event loop."""
         if self._loop is not None:
@@ -280,6 +297,8 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
             self._loop = asyncio.new_event_loop()
             asyncio.set_event_loop(self._loop)
             self._loop.run_forever()
+            self._loop.run_until_complete(self._loop.shutdown_asyncgens())
+            self._loop.close()
 
         self._thread = threading.Thread(target=run_loop, daemon=True)
         self._thread.start()
@@ -352,6 +371,11 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
         """
         try:
             async for event in async_gen:
+                if event.type in (
+                    CascadedEventType.LLM_STARTED,
+                    CascadedEventType.TTS_STARTED,
+                ):
+                    self._response_task = asyncio.current_task()
                 await self._event_queue.put(event)
         except Exception as e:
             logger.error(f"Background pipeline error: {e}")
@@ -538,7 +562,16 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
             vad_events: List to append VAD event names to.
             tool_calls: List to append tool calls to.
         """
-        if event.type == CascadedEventType.LLM_COMPLETED:
+        if event.type == CascadedEventType.ERROR:
+            raise RuntimeError(
+                f"LiveKit {event.data.get('stage', 'provider')} error: "
+                f"{event.data.get('error', 'unknown provider error')}"
+            )
+
+        elif event.type == CascadedEventType.LLM_STARTED:
+            self._suppress_response_audio = False
+
+        elif event.type == CascadedEventType.LLM_COMPLETED:
             # Store transcript for the current utterance for proportional
             # distribution across ticks as audio plays back.
             text = event.text or ""
@@ -553,7 +586,7 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
 
         elif event.type == CascadedEventType.TTS_AUDIO:
             audio = event.audio
-            if audio:
+            if audio and not self._suppress_response_audio:
                 # Convert TTS audio from internal format to telephony (8kHz μ-law)
                 telephony_audio = self._audio_converter.convert_output(audio)
                 utterance_id = f"utt_{self._utterance_counter}"
@@ -637,7 +670,12 @@ class LiveKitCascadedAdapter(DiscreteTimeAdapter):
         if has_agent_audio:
             vad_events.append("interrupted")
             self._clear_agent_audio(agent_audio_chunks)
-            logger.debug("Barge-in: cleared buffered agent audio")
+            self._suppress_response_audio = True
+            if self._response_task is not None and not self._response_task.done():
+                self._response_task.cancel()
+            logger.debug(
+                "Barge-in: cancelled response and cleared buffered agent audio"
+            )
 
     def _clear_agent_audio(
         self,

--- a/src/tau2/voice/audio_native/livekit/provider.py
+++ b/src/tau2/voice/audio_native/livekit/provider.py
@@ -30,6 +30,8 @@ from tau2.data_model.message import ToolCall
 from tau2.environment.tool import Tool
 from tau2.voice.audio_native.livekit.config import (
     AnthropicLLMConfig,
+    CartesiaSTTConfig,
+    CartesiaTTSConfig,
     CascadedConfig,
     DeepgramSTTConfig,
     DeepgramTTSConfig,
@@ -356,7 +358,10 @@ class CascadedVoiceProvider:
         # Stop STT stream
         await self._stop_stt_stream()
 
-        # Cleanup clients
+        # Close plugin resources before discarding clients.
+        for client in (self._stt_client, self._llm_client, self._tts_client):
+            if client is not None:
+                await client.aclose()
         self._stt_client = None
         self._llm_client = None
         self._tts_client = None
@@ -399,6 +404,15 @@ class CascadedVoiceProvider:
             except ImportError as e:
                 logger.error(f"Failed to import livekit-plugins-deepgram: {e}")
                 raise
+        elif isinstance(config, CartesiaSTTConfig):
+            from livekit.plugins import cartesia
+
+            self._stt_client = cartesia.STT(
+                model=config.model,
+                language=config.language,
+                sample_rate=DEFAULT_PCM_SAMPLE_RATE,
+                http_session=self._http_session,
+            )
         else:
             raise ValueError(f"Unknown STT config type: {type(config)}")
 
@@ -475,6 +489,16 @@ class CascadedVoiceProvider:
             except ImportError as e:
                 logger.error(f"Failed to import livekit-plugins-elevenlabs: {e}")
                 raise
+        elif isinstance(config, CartesiaTTSConfig):
+            from livekit.plugins import cartesia
+
+            self._tts_client = cartesia.TTS(
+                model=config.model,
+                voice=config.voice_id,
+                language=config.language,
+                sample_rate=config.sample_rate,
+                http_session=self._http_session,
+            )
         else:
             raise ValueError(f"Unknown TTS config type: {type(config)}")
 

--- a/src/tau2/voice/synthesis/audio_effects/speech_generator.py
+++ b/src/tau2/voice/synthesis/audio_effects/speech_generator.py
@@ -13,7 +13,6 @@ from tau2.config import DEFAULT_TELEPHONY_RATE
 from tau2.data_model.audio import AudioData
 from tau2.data_model.audio_effects import UserSpeechInsert
 from tau2.data_model.voice import SynthesisConfig
-from tau2.data_model.voice_personas import get_elevenlabs_voice_id
 from tau2.voice.synthesis.audio_effects.effects import apply_constant_muffling
 from tau2.voice.synthesis.synthesize import synthesize_voice
 from tau2.voice.utils.audio_preprocessing import resample_audio
@@ -124,7 +123,7 @@ def create_streaming_audio_generators(
     out_of_turn_items = speech_config.get_out_of_turn_speech_inserts()
 
     if out_of_turn_items:
-        voice_id = get_elevenlabs_voice_id(persona_name)
+        voice_id = synthesis_config.resolve_voice_id(persona_name)
         provider_config_with_voice = deepcopy(synthesis_config.provider_config)
         provider_config_with_voice.voice_id = voice_id
         out_of_turn_speech_generator = OutOfTurnSpeechGenerator(

--- a/src/tau2/voice/synthesis/synthesize.py
+++ b/src/tau2/voice/synthesis/synthesize.py
@@ -3,13 +3,12 @@
 from dotenv import load_dotenv
 
 from tau2.data_model.audio import AudioData
-from tau2.data_model.voice import ElevenLabsTTSConfig
+from tau2.data_model.voice import ProviderConfig
 from tau2.utils.retry import tts_retry
+from tau2.voice.utils.cartesia_utils import tts_cartesia
 from tau2.voice.utils.elevenlabs_utils import tts_elevenlabs
 
 load_dotenv()
-
-ProviderConfig = ElevenLabsTTSConfig
 
 
 @tts_retry
@@ -21,6 +20,8 @@ def synthesize_voice(
     """Synthesize voice from text using the specified configuration."""
     if provider == "elevenlabs":
         audio_data = tts_elevenlabs(text=text, config=provider_config)
+    elif provider == "cartesia":
+        audio_data = tts_cartesia(text=text, config=provider_config)
     else:
         raise ValueError(f"Unsupported synthesis provider: {provider}")
 

--- a/src/tau2/voice/utils/cartesia_utils.py
+++ b/src/tau2/voice/utils/cartesia_utils.py
@@ -1,0 +1,49 @@
+"""Cartesia customer TTS, using the same PCM format as the effects pipeline."""
+
+import os
+import re
+
+import httpx
+
+from tau2.data_model.audio import AudioData
+from tau2.data_model.voice import CartesiaTTSConfig
+
+
+def tts_cartesia(text: str, config: CartesiaTTSConfig) -> AudioData:
+    """Synthesize 16 kHz mono PCM without sending ElevenLabs-only vocal tags."""
+    api_key = os.getenv("CARTESIA_API_KEY")
+    if not api_key:
+        raise ValueError("CARTESIA_API_KEY is not set")
+    if not config.voice_id:
+        raise ValueError("Cartesia voice_id is required")
+    if re.search(r"\[(?:cough|sneeze|sniffle)\]", text, re.IGNORECASE):
+        raise ValueError(
+            "Cartesia synthesis does not support ElevenLabs vocal-tic tags"
+        )
+    transcript = re.sub(
+        r"\[pause\]", '<break time="500ms"/>', text, flags=re.IGNORECASE
+    )
+    response = httpx.post(
+        "https://api.cartesia.ai/tts/bytes",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Cartesia-Version": config.api_version,
+        },
+        json={
+            "model_id": config.model_id,
+            "voice": config.voice_id,
+            "transcript": transcript,
+            "locale": config.locale,
+            "output_format": {
+                "container": "raw",
+                "encoding": "pcm_s16le",
+                "sample_rate": config.output_audio_format.sample_rate,
+            },
+        },
+        timeout=60.0,
+    )
+    response.raise_for_status()
+    audio = response.content
+    if not audio or len(audio) % 2:
+        raise ValueError("Cartesia returned empty or incomplete PCM16 audio")
+    return AudioData(data=audio, format=config.output_audio_format)

--- a/src/tau2/voice_config.py
+++ b/src/tau2/voice_config.py
@@ -124,3 +124,7 @@ MIN_WORDS_FOR_VOCAL_TICS = 3
 
 # Backchannel
 BACKCHANNEL_PHRASES = ["uh-huh", "mm-hmm"]
+
+# Cartesia customer synthesis (pin model snapshots for reproducible runs).
+DEFAULT_CARTESIA_TTS_MODEL = "sonic-3.6-2026-08-27"
+DEFAULT_CARTESIA_API_VERSION = "2026-08-14"

--- a/tests/test_anthropic_voice_prompt.py
+++ b/tests/test_anthropic_voice_prompt.py
@@ -1,0 +1,35 @@
+"""Anthropic must start a new reply when the voice simulator resumes after silence."""
+
+import pytest
+from litellm import ModelResponse
+
+from tau2.data_model.message import AssistantMessage, SystemMessage, UserMessage
+from tau2.utils import llm_utils
+
+
+@pytest.mark.parametrize("after_reply", [False, True])
+def test_customer_start_and_silence_are_not_assistant_prefills(
+    monkeypatch, after_reply
+):
+    messages = [SystemMessage(role="system", content="You are the customer.")]
+    if after_reply:
+        messages += [
+            UserMessage(role="user", content="One moment."),
+            AssistantMessage(role="assistant", content="Okay."),
+            SystemMessage(role="system", content="Both parties silent for 5 seconds."),
+        ]
+    captured = {}
+
+    def complete(**kwargs):
+        captured.update(kwargs)
+        return ModelResponse(
+            choices=[{"message": {"role": "assistant", "content": "Hello?"}}]
+        )
+
+    monkeypatch.setattr(llm_utils, "completion", complete)
+    monkeypatch.setattr(llm_utils, "get_response_cost", lambda response: 0.0)
+    monkeypatch.setattr(llm_utils, "get_response_usage", lambda response: {})
+    result = llm_utils.generate("anthropic/claude-haiku-4-5-20251001", messages)
+    assert result.content == "Hello?"
+    assert captured["messages"][-1] == {"role": "user", "content": "Please continue."}
+    assert messages[-1].role == "system"

--- a/tests/test_voice/test_audio_native/test_livekit_errors.py
+++ b/tests/test_voice/test_audio_native/test_livekit_errors.py
@@ -1,0 +1,16 @@
+"""Provider failures must not silently turn into benchmark task failures."""
+
+import pytest
+
+from tau2.voice.audio_native.livekit.discrete_time_adapter import LiveKitCascadedAdapter
+from tau2.voice.audio_native.livekit.provider import CascadedEvent, CascadedEventType
+
+
+def test_payment_error_aborts_tick():
+    adapter = LiveKitCascadedAdapter(tick_duration_ms=200)
+    event = CascadedEvent(
+        type=CascadedEventType.ERROR,
+        data={"stage": "tts", "error": "402 Payment Required"},
+    )
+    with pytest.raises(RuntimeError, match="402 Payment Required"):
+        adapter._handle_event(event, [], [], [])

--- a/tests/test_voice/test_audio_native/test_provider_suite.py
+++ b/tests/test_voice/test_audio_native/test_provider_suite.py
@@ -73,6 +73,13 @@ TESTDATA_DIR = Path(__file__).parent / "testdata"
 # have credentials for.
 PROVIDERS = [
     pytest.param(
+        "livekit-cartesia",
+        marks=pytest.mark.skipif(
+            not os.environ.get("CARTESIA_TEST_ENABLED"),
+            reason="CARTESIA_TEST_ENABLED not set",
+        ),
+    ),
+    pytest.param(
         "gemini",
         marks=pytest.mark.skipif(
             not (
@@ -330,6 +337,7 @@ def provider_name(request) -> str:
 
 
 CASCADED_CONFIG_ALIASES = {
+    "livekit-cartesia": ("livekit", "cartesia-haiku"),
     "livekit-thinking": ("livekit", "openai-thinking"),
 }
 

--- a/tests/test_voice/test_cartesia_customer.py
+++ b/tests/test_voice/test_cartesia_customer.py
@@ -1,0 +1,162 @@
+"""Offline tests for Cartesia customer synthesis and run wiring."""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tau2.data_model.audio import AudioEncoding
+from tau2.data_model.simulation import AudioNativeConfig, VoiceRunConfig
+from tau2.data_model.voice import (
+    CartesiaTTSConfig,
+    ElevenLabsTTSConfig,
+    SynthesisConfig,
+    VoiceSettings,
+)
+from tau2.runner.batch import make_voice_run_settings
+from tau2.runner.build import build_voice_user
+from tau2.user_simulation_voice_presets import sample_voice_config
+from tau2.utils.retry import _is_retryable_tts_error
+from tau2.voice.synthesis.synthesize import synthesize_voice
+from tau2.voice.utils.cartesia_utils import tts_cartesia
+
+
+def test_config_roundtrip_and_provider_isolation(monkeypatch):
+    monkeypatch.setenv("TAU2_CARTESIA_VOICE_ID_MATT_DELANEY", "cartesia-matt")
+    config = SynthesisConfig(provider="cartesia")
+    restored = SynthesisConfig.model_validate_json(config.model_dump_json())
+    assert isinstance(restored.provider_config, CartesiaTTSConfig)
+    assert restored.resolve_voice_id("matt_delaney") == "cartesia-matt"
+    with pytest.raises(ValueError, match="TAU2_CARTESIA_VOICE_ID_LISA_BRENNER"):
+        restored.resolve_voice_id("lisa_brenner")
+    restored.provider_config.persona_voice_ids["matt_delaney"] = "saved-matt"
+    assert restored.resolve_voice_id("matt_delaney") == "saved-matt"
+    assert isinstance(SynthesisConfig().provider_config, ElevenLabsTTSConfig)
+    with pytest.raises(ValueError, match="Wrong provider_config"):
+        SynthesisConfig(provider="cartesia", provider_config=ElevenLabsTTSConfig())
+
+
+def test_http_audio_contract(monkeypatch):
+    monkeypatch.setenv("CARTESIA_API_KEY", "test-only")
+    seen = {}
+
+    def post(url, **kwargs):
+        seen.update(kwargs)
+        return httpx.Response(
+            200, content=b"\x00\x00\x01\x00", request=httpx.Request("POST", url)
+        )
+
+    monkeypatch.setattr("tau2.voice.utils.cartesia_utils.httpx.post", post)
+    audio = synthesize_voice(
+        "Hi [pause] there", "cartesia", CartesiaTTSConfig(voice_id="hao")
+    )
+    assert audio.format.encoding == AudioEncoding.PCM_S16LE
+    assert audio.format.sample_rate == 16000
+    assert audio.data == b"\x00\x00\x01\x00"
+    assert seen["json"]["voice"] == "hao"
+    assert seen["json"]["transcript"] == 'Hi <break time="500ms"/> there'
+    assert seen["json"]["output_format"]["container"] == "raw"
+    with pytest.raises(ValueError, match="vocal-tic"):
+        tts_cartesia("[cough]", CartesiaTTSConfig(voice_id="hao"))
+
+
+@pytest.mark.parametrize("body", [b"", b"\x00"])
+def test_invalid_audio_rejected(monkeypatch, body):
+    monkeypatch.setenv("CARTESIA_API_KEY", "test-only")
+    monkeypatch.setattr(
+        "tau2.voice.utils.cartesia_utils.httpx.post",
+        lambda *a, **k: httpx.Response(
+            200, content=body, request=httpx.Request("POST", a[0])
+        ),
+    )
+    with pytest.raises(ValueError, match="PCM16"):
+        tts_cartesia("hello", CartesiaTTSConfig(voice_id="hao"))
+
+
+@pytest.mark.parametrize(
+    "status,retry", [(401, False), (422, False), (429, True), (503, True)]
+)
+def test_http_retry_policy(status, retry):
+    response = httpx.Response(
+        status, request=httpx.Request("POST", "https://api.cartesia.ai/tts/bytes")
+    )
+    with pytest.raises(httpx.HTTPStatusError) as error:
+        response.raise_for_status()
+    assert _is_retryable_tts_error(error.value) is retry
+
+
+def test_batch_and_task_settings_preserve_cartesia(monkeypatch):
+    synthesis = SynthesisConfig(
+        provider="cartesia", provider_config=CartesiaTTSConfig(voice_id="hao")
+    )
+    config = VoiceRunConfig(
+        domain="mock",
+        audio_native_config=AudioNativeConfig(),
+        user_voice_settings=VoiceSettings(
+            transcription_config=None, synthesis_config=synthesis
+        ),
+    )
+    restored = VoiceRunConfig.model_validate_json(config.model_dump_json())
+    settings, _ = make_voice_run_settings(restored)
+    assert settings.synthesis_config.provider == "cartesia"
+    assert settings is not restored.user_voice_settings
+    sampled = sample_voice_config(
+        seed=300, synthesis_config=synthesis, complexity="regular"
+    )
+    assert sampled.speech_effects_config.enable_vocal_tics
+    monkeypatch.setattr(
+        "tau2.runner.build.get_or_load_task_voice_config", lambda **kwargs: sampled
+    )
+    monkeypatch.setattr(
+        "tau2.user.user_simulator_streaming.VoiceStreamingUserSimulator",
+        lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    user = build_voice_user(
+        SimpleNamespace(get_user_tools=lambda **kwargs: []),
+        SimpleNamespace(id="0", user_tools=None, user_scenario="Return my order"),
+        AudioNativeConfig(),
+        domain="mock",
+        voice_settings=settings,
+    )
+    actual = user.voice_settings
+    assert actual.speech_environment.voice_id == "hao"
+    assert not actual.synthesis_config.speech_effects_config.enable_vocal_tics
+    assert not actual.speech_environment.speech_effects_config.enable_vocal_tics
+    assert actual.synthesis_config.speech_effects_config.enable_non_directed_phrases
+    assert (
+        actual.synthesis_config.source_effects_config == sampled.source_effects_config
+    )
+    assert (
+        actual.synthesis_config.channel_effects_config == sampled.channel_effects_config
+    )
+    assert sampled.speech_effects_config.enable_vocal_tics  # original preset unmodified
+    persona = actual.speech_environment.persona_name
+    assert actual.synthesis_config.provider_config.persona_voice_ids[persona] == "hao"
+
+
+def test_out_of_turn_uses_cartesia_voice(monkeypatch):
+    from tau2.voice.synthesis.audio_effects.speech_generator import (
+        create_streaming_audio_generators,
+    )
+
+    seen = {}
+    monkeypatch.setattr(
+        "tau2.voice.synthesis.audio_effects.speech_generator.create_background_noise_generator",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "tau2.voice.synthesis.audio_effects.speech_generator.OutOfTurnSpeechGenerator.generate_all",
+        lambda self, items: seen.update(
+            provider=self.provider, voice=self.provider_config.voice_id
+        ),
+    )
+    config = SynthesisConfig(
+        provider="cartesia",
+        provider_config=CartesiaTTSConfig(
+            persona_voice_ids={"matt_delaney": "cartesia-matt"}
+        ),
+    )
+    config.speech_effects_config.enable_vocal_tics = False
+    config.speech_effects_config.enable_non_directed_phrases = True
+    create_streaming_audio_generators(config, "matt_delaney", 16000)
+    assert seen == {"provider": "cartesia", "voice": "cartesia-matt"}

--- a/uv.lock
+++ b/uv.lock
@@ -116,6 +116,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.125.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/f8/6f0560884b5363848347bd640b6c1d04abc25e7aa61787a232f790c6b60a/anthropic-0.125.0.tar.gz", hash = "sha256:e0cdd336580cb7411c1cdab69f80973e9bf4bff7f8e08141811d46307d45c682", size = 1112593, upload-time = "2026-08-19T22:00:42.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/1a/b1bd30cda3790557e8791bec5922a6ec8fabb6fa8b008c76a39cf7be6152/anthropic-0.125.0-py3-none-any.whl", hash = "sha256:3486013602eca76d8b12540764e53654f02cf4951110bca86cf06e67428a9f21", size = 1184067, upload-time = "2026-08-19T22:00:44.596Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1165,6 +1184,15 @@ wheels = [
 ]
 
 [[package]]
+name = "json-repair"
+version = "0.60.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a6/d69888cb4ffde30e80db1e6c32caaadd2f984a80067d5ea72c2cb3f61c3f/json_repair-0.60.1.tar.gz", hash = "sha256:841661cdd2df507c9a4e189097f38ca6bc372e06d4b4e36d72e590f68176c290", size = 49451, upload-time = "2026-06-03T17:28:44.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/1f/2a2b5eea8ef5762a86ad3f8fddddaaba2c0d76dd44e644b9158900868bec/json_repair-0.60.1-py3-none-any.whl", hash = "sha256:ba6ff974f2a8bef2f7768144a7f03f870a816443f03da27a49cdd0ec31a78049", size = 48045, upload-time = "2026-06-03T17:28:43.038Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1262,7 +1290,7 @@ wheels = [
 
 [[package]]
 name = "livekit"
-version = "1.1.3"
+version = "1.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1270,18 +1298,18 @@ dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/28/293ae58c752ed40ae3e266130d787fe6270f123808fbbfca033038b736e5/livekit-1.1.3.tar.gz", hash = "sha256:68825cf74225c3d4af93187953240fbfeb56227d4e11369c9c5b7d8202714d1b", size = 320483, upload-time = "2026-03-23T22:42:09.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/e20f97969cf21959061cdc6e1c89e3ad88e23693030398df283c236430fc/livekit-1.1.17.tar.gz", hash = "sha256:0553bfc9041dc8430029597a2278b43e4bb75594a72cb9dcc42bf3ee8e1689a0", size = 378467, upload-time = "2026-09-01T05:03:19.976Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/8d/5d3a399904f6cbde1bc23e5fac87a4f056a8e76c8b3ac995ed677f3ac7ec/livekit-1.1.3-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:db7bfb25141c2f665054044f8b3ef2c93c5ee633c8f5a9f9f43bd0f9c1e6f035", size = 9890232, upload-time = "2026-03-23T22:41:59.521Z" },
-    { url = "https://files.pythonhosted.org/packages/85/37/4a6d2aff39bbe2daa965c6f71498059338878e98d632e8b1a14dd0d863ff/livekit-1.1.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2ef963a9731215c542e142df94c4d6ba385490a058d01328a66161340b181bf4", size = 8691926, upload-time = "2026-03-23T22:42:01.937Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/93/bbee45bd3e5ea46a9683716a7aebd5b2e3e4c2d82ebc537abbc11b87671f/livekit-1.1.3-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:97e47e0723127a0a98775634334dac799fb2cb72894b743e0c78b6961f710092", size = 9712001, upload-time = "2026-03-23T22:42:04.021Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c9/47da7ae46ab666a7151044627e75621e4a77fb8275edace915294d837565/livekit-1.1.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b268998a06d57b32335b017f859566e7548aeebf9c64deea3a1add2fbb3baa05", size = 11085841, upload-time = "2026-03-23T22:42:05.898Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/a8/68a7cf4b710b0eb80e3657098e50bebfca5b5b4e19d8ac0e3efb19ed5393/livekit-1.1.3-py3-none-win_amd64.whl", hash = "sha256:87647d68c5b64a024098d167a503ee5e69061fe4b16e431f7a011aa4c73dd4d9", size = 10413627, upload-time = "2026-03-23T22:42:08.006Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/74/d93c5dd19ff2139c070eacb634e075cd2aff239a9cf692002afaa529a630/livekit-1.1.17-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:39188ac6c805643c8ef952cccb96b2e81e430600e626dea9c6aa1faca7013fdb", size = 10468167, upload-time = "2026-09-01T05:03:06.001Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/9f4f5e3f0c325d0d5d19c5dc1ae345f4bf1353369db3b42e265a1ee4dbc5/livekit-1.1.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:078d249974aed5e845b60f840802e36dc9d2c9c1dd606341fb95ee018749169e", size = 9289118, upload-time = "2026-09-01T05:03:09.011Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d5/89293b55b7a719c7f7b7929d995c009bee7ce9f4d29876c77ee878fd9bf9/livekit-1.1.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:984c7c0efa3e1f917e973ce412a141ff8244baf98ff24587aa82c206b621054f", size = 10580945, upload-time = "2026-09-01T05:03:11.743Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/4e/aad025688f8aceeecb4ec97aaae3541d64302e03454c84dc57e02bbaf5b9/livekit-1.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:100f2ddd8e433ea906ecf45f1d37063e43e72c7c2cff0b65ddddc11181bc8dd7", size = 11805780, upload-time = "2026-09-01T05:03:14.614Z" },
+    { url = "https://files.pythonhosted.org/packages/97/7a/5447238155494f2a2fd55ff0f7705b9769fe67e787b52150a5d269eeaa61/livekit-1.1.17-py3-none-win_amd64.whl", hash = "sha256:7a7b1bdb646775d8042ec97baec6c6b615c5828d6f9b6dd2adaa167841d6f6c2", size = 10968316, upload-time = "2026-09-01T05:03:17.671Z" },
 ]
 
 [[package]]
 name = "livekit-agents"
-version = "1.5.1"
+version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1292,9 +1320,11 @@ dependencies = [
     { name = "colorama" },
     { name = "docstring-parser" },
     { name = "eval-type-backport" },
+    { name = "json-repair" },
     { name = "livekit" },
     { name = "livekit-api" },
     { name = "livekit-blingfire" },
+    { name = "livekit-local-inference" },
     { name = "livekit-protocol" },
     { name = "nest-asyncio" },
     { name = "numpy" },
@@ -1307,15 +1337,16 @@ dependencies = [
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pyjwt" },
+    { name = "pyyaml" },
     { name = "sounddevice" },
     { name = "typer" },
     { name = "types-protobuf" },
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/3e/fbf49f6fa2b771d71135f9cbea00ab07c498e00e5ea639a9026a4ba3c5a5/livekit_agents-1.5.1.tar.gz", hash = "sha256:3bc3faa2ac588b0f5f7e698f614eb7163bd3e0f548d10fff62a94f162ac33af8", size = 2455210, upload-time = "2026-03-23T22:50:44.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/88/ace06ebd95b8cc45e25430a2a10ec7ccfb6b386b67907192ad421493858f/livekit_agents-1.8.0.tar.gz", hash = "sha256:132029af152a585770b58623a1a2ac7c8b1b9241b045e8cd220b30415fbcf2ad", size = 2688509, upload-time = "2026-09-05T00:10:03.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/59/8a58348e778c0921fa2eaf338fcca82ef826f2e79c881ed48c2455880a0e/livekit_agents-1.5.1-py3-none-any.whl", hash = "sha256:51da84d1c1571b8ba9bdfa8c3f55b3296d0db0df6c306945b915747d18a13491", size = 2547860, upload-time = "2026-03-23T22:50:42.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/79/a1dce13ad49ab5b3248727b808ef265b2a535928c53161440d049a0b747d/livekit_agents-1.8.0-py3-none-any.whl", hash = "sha256:0da6c79c71eb7620af14d5c18adba1da796d6743338630813c341e9ce72f45c8", size = 2806075, upload-time = "2026-09-05T00:10:01.23Z" },
 ]
 
 [package.optional-dependencies]
@@ -1328,7 +1359,7 @@ images = [
 
 [[package]]
 name = "livekit-api"
-version = "1.1.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1337,9 +1368,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/0a/ad3cce124e608c056d6390244ec4dd18c8a4b5f055693a95831da2119af7/livekit_api-1.1.0.tar.gz", hash = "sha256:f94c000534d3a9b506e6aed2f35eb88db1b23bdea33bb322f0144c4e9f73934e", size = 16649, upload-time = "2025-12-02T19:37:11.452Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/0d/ff9502faa5e9785563e9648313a030fab65ed7f6ff8cf52d7bc6c9e01c97/livekit_api-1.2.1.tar.gz", hash = "sha256:eee78dba493b736bc8422660debc7cf89340f1b80c63890a36a18d99c938045c", size = 21780, upload-time = "2026-08-27T14:06:57.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/b9/8d8515e3e0e629ab07d399cf858b8fc7e0a02bbf6384a6592b285264b4b9/livekit_api-1.1.0-py3-none-any.whl", hash = "sha256:bfc1c2c65392eb3f580a2c28108269f0e79873f053578a677eee7bb1de8aa8fb", size = 19620, upload-time = "2025-12-02T19:37:10.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c8/bc29cf16427fc446aa4487c552503cef42eebfcb920902bb54b7180e40d3/livekit_api-1.2.1-py3-none-any.whl", hash = "sha256:aa15b0a194c9e8167d4261bc61381682df23f98bc6d77760fcded93d2ce4b4ca", size = 27586, upload-time = "2026-08-27T14:06:56.286Z" },
 ]
 
 [[package]]
@@ -1357,6 +1388,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/d2/ad95d195ed6dccb6527ed3c1e753f211c3e9509050af5cddf007608bb104/livekit_blingfire-1.1.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3aac3207cdd88c62323e0b07c33a69aac79c544122a2ddfbecc6c721ca760c", size = 167886, upload-time = "2025-12-16T00:48:19.858Z" },
     { url = "https://files.pythonhosted.org/packages/c5/67/fc4af1bbbed319d8edc319051bce720b51fa544f5d2ebb3201240779f135/livekit_blingfire-1.1.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:839feefa2910f99d794d3f3d696f95193ee8188cc6688a8d712bade2cede7951", size = 175858, upload-time = "2025-12-16T00:48:21.144Z" },
     { url = "https://files.pythonhosted.org/packages/76/6c/9e14763826476925767b511531318a83f95f3bf9e4dbc7dc611400af6e9e/livekit_blingfire-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:1409d4c297260b60a37bfe6ba21e4fb59dd53cd929632c0a78a28d41fe424302", size = 131048, upload-time = "2025-12-16T00:48:22.17Z" },
+]
+
+[[package]]
+name = "livekit-local-inference"
+version = "0.2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/59/4a120c700508179d01af5525911acc044e2996d5fc86619896020b4fc41d/livekit_local_inference-0.2.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:86b64885254d554ca35483059e295bcf0281d7470b58301862e0367568633615", size = 34838988, upload-time = "2026-08-18T09:46:36.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/1a/0384f23dae195dca39fec32fb77fa5bf68bb022ca1648e9c1908b1228667/livekit_local_inference-0.2.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d66a509223e6e1f2ae77c52081969cafb49bd63d7bf4d50153f5bcdf52172865", size = 35096362, upload-time = "2026-08-18T09:46:38.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/29/18d7c360642e519124c8e5ae422dac36e22d74696a476edcc48fc6217d36/livekit_local_inference-0.2.7-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8fc1803a65654cc5061274a1aee067c584e2f0fd4ead85659f8f26ec06880f8", size = 34835065, upload-time = "2026-08-18T09:46:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/37/61/0b073e893274e461019516f8610029ceab74c06b9f6496b34be9ed704039/livekit_local_inference-0.2.7-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:449411e6cf01057e761588d6c19f1978d0ff652235d43de1780aa0b866b1435d", size = 34876716, upload-time = "2026-08-18T09:46:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/230770d450305c53cad880445d046c7f84c26507b61c50fe185ea15a29ca/livekit_local_inference-0.2.7-cp312-cp312-win_amd64.whl", hash = "sha256:5a497ed9dc7f11666b2226cf195c85bd12f511ad7d57dbd7857bec4c573b9031", size = 34877098, upload-time = "2026-08-18T09:46:47.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ff/01233367f526c67df021d5ee5ad0e7d229553ad7e90d5ae02d5afbdc7abb/livekit_local_inference-0.2.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5b23b2fca99fbf05d349b8c1c1e499d9154997214db15b6784a999783f63169a", size = 34839008, upload-time = "2026-08-18T09:46:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/45/9c70db9dc4581d9f2eecc04386bba3c8e74b6f438d2d6acb11aeaf66f96e/livekit_local_inference-0.2.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:866036cf42fce282404ecdad90bb2b814bc78aab245bc7be740e3cff528a36e8", size = 35096385, upload-time = "2026-08-18T09:46:53.359Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/7d/0a981a4c7504fc4323a277d04705799fa48fbc036d368e47d5780c737341/livekit_local_inference-0.2.7-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f304cca187033b257cc8baf67f8799f5f467fa5f5984cdc3948591eb2027761b", size = 34835081, upload-time = "2026-08-18T09:46:55.883Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/cc/858e2792eba28aa3baae1939488319f3bbef38c911cc0640f020bb0fe708/livekit_local_inference-0.2.7-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:454c451a4df153f5a9c8c7ba20e842dd5c77993103fd1c03194856d351be87dd", size = 34876656, upload-time = "2026-08-18T09:46:58.567Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/07/b85d8f18fd46f335a559f6d39f8acf07663510d1add19d1f31814ef7daf0/livekit_local_inference-0.2.7-cp313-cp313-win_amd64.whl", hash = "sha256:c16e86495346d8c349910ac8530de1e3532a6d1bac95ece0bc416c88f2a5c20f", size = 34877068, upload-time = "2026-08-18T09:47:01.317Z" },
+]
+
+[[package]]
+name = "livekit-plugins-anthropic"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "httpx" },
+    { name = "livekit-agents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/e3/d7bb1699d562895432a7d2e482f22506d987f86c9510b4d63b3afa6947fe/livekit_plugins_anthropic-1.8.0.tar.gz", hash = "sha256:9ad57e1ce2137c361cd4453f39aefe90751490d3b9138493c2ae065ee6ad0d64", size = 9368, upload-time = "2026-09-05T00:10:03.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/bd/8b7a9c919ef5f15fce8e4a55acf25d31f61e47078e7b030467b7074df9d6/livekit_plugins_anthropic-1.8.0-py3-none-any.whl", hash = "sha256:d91d1db6fd617ad5c14d6156438349b0721db5844d87fd53c74bf0e7796c4085", size = 11130, upload-time = "2026-09-05T00:10:02.321Z" },
+]
+
+[[package]]
+name = "livekit-plugins-cartesia"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "livekit-agents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/aa/e3436e288b224d47e64e2d869ef674badaaa636e3678957ea69a82e7147f/livekit_plugins_cartesia-1.8.0.tar.gz", hash = "sha256:76657b07993d32c2bd83045703ace878db09ace87ccfee228b852b04205ce043", size = 19566, upload-time = "2026-09-05T00:10:30.569Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/0c/1f0da816879b4cc118a0ed560e29b3f37f8ba1c005ce1e7b3336f243e4c3/livekit_plugins_cartesia-1.8.0-py3-none-any.whl", hash = "sha256:43c269434f60fc7262943961ec84a7cf0ed4dc5ffefb32da3b390d30bb8fdf02", size = 27115, upload-time = "2026-09-05T00:10:29.307Z" },
 ]
 
 [[package]]
@@ -1387,15 +1461,15 @@ wheels = [
 
 [[package]]
 name = "livekit-protocol"
-version = "1.1.3"
+version = "1.1.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ca/d15e2a2cc8c8aa4ba621fe5f9ffd1806d88ac91c7b8fa4c09a3c0304dd92/livekit_protocol-1.1.3.tar.gz", hash = "sha256:cb4948d2513e81d91583f4a795bf80faa9026cedda509c5714999c7e33564287", size = 88746, upload-time = "2026-03-18T05:25:43.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/49/733f3655717bd1bdccfbb4ab958ac7f51d7e17d37e61b98de2f6b2e0c107/livekit_protocol-1.1.26.tar.gz", hash = "sha256:de8d291abb2efd026fbe23394ee4c05358195f09102d3c13335978ba04d7bdb8", size = 123833, upload-time = "2026-08-28T17:15:50.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/0e/f3d3e48628294df4559cffd0f8e1adf030127029e5a8da9beff9979090a0/livekit_protocol-1.1.3-py3-none-any.whl", hash = "sha256:fdae5640e064ab6549ec3d62d8bac75a3ef44d7ea73716069b419cbe8b360a5c", size = 107498, upload-time = "2026-03-18T05:25:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/b9a9a04b921b1aaef9312c3a16523cd4ddb508dcc4be18ca0e300b750b7e/livekit_protocol-1.1.26-py3-none-any.whl", hash = "sha256:37db1272487518df2ce3e13624a5217d1e158c6832fe01166bb3fb1875a8ddd9", size = 150535, upload-time = "2026-08-28T17:15:48.535Z" },
 ]
 
 [[package]]
@@ -2741,7 +2815,7 @@ wheels = [
 
 [[package]]
 name = "tau2"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },
@@ -2768,6 +2842,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "aiohttp" },
+    { name = "anthropic" },
     { name = "aws-sdk-bedrock-runtime" },
     { name = "boto3" },
     { name = "deepgram-sdk" },
@@ -2778,6 +2853,8 @@ all = [
     { name = "gymnasium" },
     { name = "jiwer" },
     { name = "livekit-agents" },
+    { name = "livekit-plugins-anthropic" },
+    { name = "livekit-plugins-cartesia" },
     { name = "livekit-plugins-deepgram" },
     { name = "livekit-plugins-openai" },
     { name = "matplotlib" },
@@ -2817,6 +2894,7 @@ knowledge = [
 ]
 voice = [
     { name = "aiohttp" },
+    { name = "anthropic" },
     { name = "aws-sdk-bedrock-runtime" },
     { name = "boto3" },
     { name = "deepgram-sdk" },
@@ -2826,6 +2904,8 @@ voice = [
     { name = "google-genai" },
     { name = "jiwer" },
     { name = "livekit-agents" },
+    { name = "livekit-plugins-anthropic" },
+    { name = "livekit-plugins-cartesia" },
     { name = "livekit-plugins-deepgram" },
     { name = "livekit-plugins-openai" },
     { name = "pyaudio" },
@@ -2839,6 +2919,7 @@ voice = [
 requires-dist = [
     { name = "addict", specifier = ">=2.4.0" },
     { name = "aiohttp", marker = "extra == 'voice'", specifier = ">=3.0" },
+    { name = "anthropic", marker = "extra == 'voice'", specifier = "<1" },
     { name = "aws-sdk-bedrock-runtime", marker = "extra == 'voice'", specifier = ">=0.3.0" },
     { name = "boto3", marker = "extra == 'voice'", specifier = ">=1.35.0" },
     { name = "deepdiff", specifier = ">=8.4.2" },
@@ -2854,6 +2935,8 @@ requires-dist = [
     { name = "jiwer", marker = "extra == 'voice'", specifier = ">=3.0.0" },
     { name = "litellm", specifier = ">=1.80.15,<1.82.7" },
     { name = "livekit-agents", marker = "extra == 'voice'", specifier = ">=1.5.0" },
+    { name = "livekit-plugins-anthropic", marker = "extra == 'voice'", specifier = ">=1.8.0" },
+    { name = "livekit-plugins-cartesia", marker = "extra == 'voice'", specifier = ">=1.8.0" },
     { name = "livekit-plugins-deepgram", marker = "extra == 'voice'", specifier = ">=1.5.0" },
     { name = "livekit-plugins-openai", marker = "extra == 'voice'", specifier = ">=1.5.0" },
     { name = "loguru", specifier = ">=0.7.3" },


### PR DESCRIPTION
This adds Cartesia speech on both sides of voice evaluations: customer TTS through `--user-tts-config`, and an evaluated LiveKit agent using Cartesia Ink 2 ASR → Claude Haiku 4.5 → Cartesia Sonic 3.6 TTS. Customer and agent speech providers can be selected independently.

- Add provider-specific customer voice resolution, saved configuration round trips, and Cartesia PCM synthesis through the existing audio-effects pipeline.
- Add the `cartesia-haiku` cascade preset and example scripts for a resumable ten-task retail run and transcript export.
- Handle Anthropic customer initialization and silence prompts, cancel agent responses on interruption, close plugin resources, and propagate provider errors as infrastructure failures.
- Document modified customer conditions: the example uses the Hao voice for every persona, and ElevenLabs-only vocal tics are disabled for Cartesia.

Validation:
- `UV_NO_SYNC=1 make check-all`: passed.
- Targeted customer, Anthropic prompt, provider-error, audio-effects, and runner tests: 66 passed.
- Live Cartesia provider suite before the final error-propagation/reconnect-reset changes: 11 passed, 1 failed, 84 skipped. The remaining failure is dollar-cost coverage: usage quantities are recorded, but Cartesia pricing is not in the benchmark's pricing table. Final error propagation is covered offline; live validation could not be repeated after billing became unavailable.
- The ten-task example run saved two 300-second conversations, both ending at the duration limit with reward 0. Subsequent Cartesia ASR and TTS requests returned HTTP 402 Payment Required. The batch was stopped; the remaining eight tasks require restored billing access. These are integration examples, not a completed benchmark result.

Draft pending complete live validation and a decision on Cartesia plan-dependent cost reporting. This evaluates a LiveKit cascade, not Cartesia Managed Agents orchestration. Credentials and local simulation artifacts are excluded.
