### PR TITLE
leaderboard: add GPT Live standard and custom voice results

### DIFF
--- a/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha-user-sim-gpt-5-5_openai_2026-09-09/submission.json
+++ b/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha-user-sim-gpt-5-5_openai_2026-09-09/submission.json
@@ -1,0 +1,174 @@
+{
+  "model_name": "gpt-live-1-diamond-alpha",
+  "model_organization": "OpenAI",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-09-09",
+  "submission_type": "custom",
+  "modality": "voice",
+  "contact_info": {
+    "email": "keshav@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 84.21052631578947
+    },
+    "airline": {
+      "pass_1": 78.0
+    },
+    "telecom": {
+      "pass_1": 96.49122807017544
+    },
+    "banking_knowledge": {
+      "pass_1": 31.958762886597935,
+      "retrieval_config": "alltools"
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_regular_openai_live__medium",
+    "banking_knowledge": "banking_knowledge_regular_openai_live__medium",
+    "retail": "retail_regular_openai_live__medium",
+    "telecom": "telecom_regular_openai_live__medium"
+  },
+  "references": [
+    {
+      "title": "OpenAI Live provider integration",
+      "url": "https://github.com/sierra-research/tau2-bench/pull/523",
+      "type": "github"
+    },
+    {
+      "title": "OpenAI Live prompt templates and evaluation runner",
+      "url": "https://github.com/sierra-research/tau2-bench/pull/527",
+      "type": "github"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-09-09",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "gpt-5.5-2026-04-23 (xhigh)",
+    "notes": "Custom GPT Live evaluation using the same agent, tools, prompts, policies, regular speech complexity, realtime generation, marin voice, seed 300, alltools banking retrieval, and default Anthropic hallucination reviewer as the standard submission; only the benchmark user-simulator LLM changes from GPT-4.1 temperature 0 to gpt-5.5-2026-04-23 at xhigh reasoning effort.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "openai_live",
+    "model": "gpt-live-1-diamond-alpha",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "interaction_metrics": {
+    "version": "1.0",
+    "config": {
+      "tick_duration_sec": 0.2,
+      "no_yield_window_sec": 2.0,
+      "backchannel_yield_window_sec": 1.0,
+      "vocal_tic_yield_window_sec": 1.0,
+      "non_directed_yield_window_sec": 1.0,
+      "vocal_tic_response_window_sec": 2.0,
+      "non_directed_response_window_sec": 2.0
+    },
+    "domains": {
+      "airline": {
+        "response_latency_mean": 2.543046357615894,
+        "yield_latency_mean": 1.069135802469136,
+        "response_rate": 0.9457202505219207,
+        "yield_rate": 0.36818181818181817,
+        "agent_interruption_rate": 0.21294363256784968,
+        "selectivity_backchannel": null,
+        "selectivity_vocal_tic": 0.6301369863013699,
+        "selectivity_non_directed": 0.5,
+        "counts": {
+          "n_simulations": 50,
+          "response_total": 479,
+          "yield_total": 220,
+          "backchannel_total": 0,
+          "vocal_tic_total": 73,
+          "non_directed_total": 42,
+          "agent_interrupts_count": 102
+        }
+      },
+      "banking_knowledge": {
+        "response_latency_mean": 2.85496688741722,
+        "yield_latency_mean": 1.0623655913978496,
+        "response_rate": 0.8564946114577425,
+        "yield_rate": 0.28054298642533937,
+        "agent_interruption_rate": 0.20930232558139536,
+        "selectivity_backchannel": 0.8,
+        "selectivity_vocal_tic": 0.6502057613168724,
+        "selectivity_non_directed": 0.6235955056179776,
+        "counts": {
+          "n_simulations": 97,
+          "response_total": 1763,
+          "yield_total": 663,
+          "backchannel_total": 20,
+          "vocal_tic_total": 243,
+          "non_directed_total": 178,
+          "agent_interrupts_count": 369
+        }
+      },
+      "retail": {
+        "response_latency_mean": 2.3781312127236576,
+        "yield_latency_mean": 1.0246753246753249,
+        "response_rate": 0.9748062015503876,
+        "yield_rate": 0.3235294117647059,
+        "agent_interruption_rate": 0.2189922480620155,
+        "selectivity_backchannel": 0.8571428571428572,
+        "selectivity_vocal_tic": 0.5984848484848485,
+        "selectivity_non_directed": 0.5643564356435644,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 1032,
+          "yield_total": 476,
+          "backchannel_total": 14,
+          "vocal_tic_total": 132,
+          "non_directed_total": 101,
+          "agent_interrupts_count": 226
+        }
+      },
+      "telecom": {
+        "response_latency_mean": 2.334981684981685,
+        "yield_latency_mean": 1.0254545454545454,
+        "response_rate": 0.9081081081081082,
+        "yield_rate": 0.383008356545961,
+        "agent_interruption_rate": 0.1446985446985447,
+        "selectivity_backchannel": 1.0,
+        "selectivity_vocal_tic": 0.5860805860805861,
+        "selectivity_non_directed": 0.5954545454545455,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 2405,
+          "yield_total": 718,
+          "backchannel_total": 5,
+          "vocal_tic_total": 273,
+          "non_directed_total": 220,
+          "agent_interrupts_count": 348
+        }
+      }
+    },
+    "overall": {
+      "response_latency_mean": 2.527781535684614,
+      "yield_latency_mean": 1.045407815999214,
+      "response_rate": 0.9212822929095397,
+      "yield_rate": 0.3388156432294561,
+      "agent_interruption_rate": 0.1964841877274513,
+      "selectivity_backchannel": 0.8857142857142858,
+      "selectivity_vocal_tic": 0.6162270455459192,
+      "selectivity_non_directed": 0.5708516216790218,
+      "counts": {
+        "agent_interrupts_count": 1045,
+        "backchannel_total": 39,
+        "n_simulations": 375,
+        "non_directed_total": 541,
+        "response_total": 5679,
+        "vocal_tic_total": 721,
+        "yield_total": 2077
+      }
+    }
+  },
+  "reasoning_effort": "medium"
+}

--- a/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha-user-sim-gpt-5-5_openai_2026-09-09/submission.json
+++ b/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha-user-sim-gpt-5-5_openai_2026-09-09/submission.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "gpt-live-1-diamond-alpha",
+  "model_name": "gpt-live-1",
   "model_organization": "OpenAI",
   "submitting_organization": "Sierra",
   "submission_date": "2026-09-09",
@@ -55,7 +55,7 @@
     }
   },
   "voice_config": {
-    "provider": "openai_live",
+    "provider": "OpenAI",
     "model": "gpt-live-1-diamond-alpha",
     "tick_duration_seconds": 0.2,
     "max_steps_seconds": 1200.0,
@@ -170,5 +170,8 @@
       }
     }
   },
-  "reasoning_effort": "medium"
+  "reasoning_effort": "medium",
+  "model_release": {
+    "release_date": "2026-09-10"
+  }
 }

--- a/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha_openai_2026-09-09/submission.json
+++ b/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha_openai_2026-09-09/submission.json
@@ -1,0 +1,174 @@
+{
+  "model_name": "gpt-live-1-diamond-alpha",
+  "model_organization": "OpenAI",
+  "submitting_organization": "Sierra",
+  "submission_date": "2026-09-09",
+  "submission_type": "standard",
+  "modality": "voice",
+  "contact_info": {
+    "email": "keshav@sierra.ai",
+    "name": "Sierra Research Team"
+  },
+  "results": {
+    "retail": {
+      "pass_1": 78.94736842105263
+    },
+    "airline": {
+      "pass_1": 82.0
+    },
+    "telecom": {
+      "pass_1": 84.21052631578947
+    },
+    "banking_knowledge": {
+      "pass_1": 25.263157894736842,
+      "retrieval_config": "alltools"
+    }
+  },
+  "is_new": true,
+  "trajectories_available": true,
+  "trajectory_files": {
+    "airline": "airline_regular_openai_live__medium",
+    "banking_knowledge": "banking_knowledge_regular_openai_live__medium",
+    "retail": "retail_regular_openai_live__medium",
+    "telecom": "telecom_regular_openai_live__medium"
+  },
+  "references": [
+    {
+      "title": "OpenAI Live provider integration",
+      "url": "https://github.com/sierra-research/tau2-bench/pull/523",
+      "type": "github"
+    },
+    {
+      "title": "OpenAI Live prompt templates and evaluation runner",
+      "url": "https://github.com/sierra-research/tau2-bench/pull/527",
+      "type": "github"
+    }
+  ],
+  "methodology": {
+    "evaluation_date": "2026-09-09",
+    "tau2_bench_version": "1.0.1",
+    "user_simulator": "v1.0",
+    "notes": "Standard GPT Live evaluation using the provider-owned frontend/backend prompt templates, gpt-live-1-diamond-alpha frontend, gpt-6-astra backend at medium reasoning effort, marin agent voice, regular speech complexity, realtime user generation, seed 300, alltools retrieval for banking, and the default Anthropic hallucination reviewer. One trial was scheduled for every task: airline 50, retail 114, telecom 114, and banking_knowledge 97. Two banking infrastructure-error trajectories have null rewards and are excluded by the standard tau2 metrics implementation, so the reported banking score is 24/95.",
+    "verification": {
+      "modified_prompts": false,
+      "omitted_questions": false
+    }
+  },
+  "voice_config": {
+    "provider": "openai_live",
+    "model": "gpt-live-1-diamond-alpha",
+    "tick_duration_seconds": 0.2,
+    "max_steps_seconds": 1200.0,
+    "user_tts_provider": "elevenlabs/eleven_v3"
+  },
+  "interaction_metrics": {
+    "version": "1.0",
+    "config": {
+      "tick_duration_sec": 0.2,
+      "no_yield_window_sec": 2.0,
+      "backchannel_yield_window_sec": 1.0,
+      "vocal_tic_yield_window_sec": 1.0,
+      "non_directed_yield_window_sec": 1.0,
+      "vocal_tic_response_window_sec": 2.0,
+      "non_directed_response_window_sec": 2.0
+    },
+    "domains": {
+      "airline": {
+        "response_latency_mean": 2.670232558139535,
+        "yield_latency_mean": 1.077777777777778,
+        "response_rate": 0.9188034188034188,
+        "yield_rate": 0.3643724696356275,
+        "agent_interruption_rate": 0.23504273504273504,
+        "selectivity_backchannel": 1.0,
+        "selectivity_vocal_tic": 0.6851851851851851,
+        "selectivity_non_directed": 0.5714285714285714,
+        "counts": {
+          "n_simulations": 50,
+          "response_total": 468,
+          "yield_total": 247,
+          "backchannel_total": 14,
+          "vocal_tic_total": 54,
+          "non_directed_total": 42,
+          "agent_interrupts_count": 110
+        }
+      },
+      "banking_knowledge": {
+        "response_latency_mean": 2.899556868537668,
+        "yield_latency_mean": 1.0037914691943128,
+        "response_rate": 0.8451935081148564,
+        "yield_rate": 0.33706070287539935,
+        "agent_interruption_rate": 0.28714107365792757,
+        "selectivity_backchannel": 0.8285714285714285,
+        "selectivity_vocal_tic": 0.6405529953917051,
+        "selectivity_non_directed": 0.6213017751479291,
+        "counts": {
+          "n_simulations": 95,
+          "response_total": 1602,
+          "yield_total": 626,
+          "backchannel_total": 35,
+          "vocal_tic_total": 217,
+          "non_directed_total": 169,
+          "agent_interrupts_count": 460
+        }
+      },
+      "retail": {
+        "response_latency_mean": 2.682307692307692,
+        "yield_latency_mean": 1.0439306358381504,
+        "response_rate": 0.9567617295308187,
+        "yield_rate": 0.27724358974358976,
+        "agent_interruption_rate": 0.250229990800368,
+        "selectivity_backchannel": 0.967741935483871,
+        "selectivity_vocal_tic": 0.6164383561643836,
+        "selectivity_non_directed": 0.4591836734693877,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 1087,
+          "yield_total": 624,
+          "backchannel_total": 31,
+          "vocal_tic_total": 146,
+          "non_directed_total": 98,
+          "agent_interrupts_count": 272
+        }
+      },
+      "telecom": {
+        "response_latency_mean": 2.2615626638699524,
+        "yield_latency_mean": 1.1204545454545454,
+        "response_rate": 0.9896211728074727,
+        "yield_rate": 0.43636363636363634,
+        "agent_interruption_rate": 0.17384535547483135,
+        "selectivity_backchannel": 1.0,
+        "selectivity_vocal_tic": 0.463302752293578,
+        "selectivity_non_directed": 0.34013605442176875,
+        "counts": {
+          "n_simulations": 114,
+          "response_total": 1927,
+          "yield_total": 605,
+          "backchannel_total": 2,
+          "vocal_tic_total": 218,
+          "non_directed_total": 147,
+          "agent_interrupts_count": 335
+        }
+      }
+    },
+    "overall": {
+      "response_latency_mean": 2.628414945713712,
+      "yield_latency_mean": 1.0614886070661966,
+      "response_rate": 0.9275949573141417,
+      "yield_rate": 0.35376009965456323,
+      "agent_interruption_rate": 0.2365647887439655,
+      "selectivity_backchannel": 0.9490783410138248,
+      "selectivity_vocal_tic": 0.6013698222587129,
+      "selectivity_non_directed": 0.4980125186169142,
+      "counts": {
+        "agent_interrupts_count": 1177,
+        "backchannel_total": 82,
+        "n_simulations": 373,
+        "non_directed_total": 456,
+        "response_total": 5084,
+        "vocal_tic_total": 635,
+        "yield_total": 2102
+      }
+    }
+  },
+  "reasoning_effort": "medium"
+}

--- a/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha_openai_2026-09-09/submission.json
+++ b/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha_openai_2026-09-09/submission.json
@@ -18,17 +18,12 @@
     },
     "telecom": {
       "pass_1": 84.21052631578947
-    },
-    "banking_knowledge": {
-      "pass_1": 25.263157894736842,
-      "retrieval_config": "alltools"
     }
   },
   "is_new": true,
   "trajectories_available": true,
   "trajectory_files": {
     "airline": "airline_regular_openai_live__medium",
-    "banking_knowledge": "banking_knowledge_regular_openai_live__medium",
     "retail": "retail_regular_openai_live__medium",
     "telecom": "telecom_regular_openai_live__medium"
   },
@@ -48,7 +43,7 @@
     "evaluation_date": "2026-09-09",
     "tau2_bench_version": "1.0.1",
     "user_simulator": "v1.0",
-    "notes": "Standard GPT Live evaluation using the provider-owned frontend/backend prompt templates, gpt-live-1-diamond-alpha frontend, gpt-6-astra backend at medium reasoning effort, marin agent voice, regular speech complexity, realtime user generation, seed 300, alltools retrieval for banking, and the default Anthropic hallucination reviewer. One trial was scheduled for every task: airline 50, retail 114, telecom 114, and banking_knowledge 97. Two banking infrastructure-error trajectories have null rewards and are excluded by the standard tau2 metrics implementation, so the reported banking score is 24/95.",
+    "notes": "Standard GPT Live evaluation using the provider-owned frontend/backend prompt templates, gpt-live-1-diamond-alpha frontend, gpt-6-astra backend at medium reasoning effort, marin agent voice, regular speech complexity, realtime user generation, seed 300, and the default Anthropic hallucination reviewer. One trial was scheduled for every task: airline 50, retail 114, and telecom 114.",
     "verification": {
       "modified_prompts": false,
       "omitted_questions": false
@@ -92,25 +87,6 @@
           "agent_interrupts_count": 110
         }
       },
-      "banking_knowledge": {
-        "response_latency_mean": 2.899556868537668,
-        "yield_latency_mean": 1.0037914691943128,
-        "response_rate": 0.8451935081148564,
-        "yield_rate": 0.33706070287539935,
-        "agent_interruption_rate": 0.28714107365792757,
-        "selectivity_backchannel": 0.8285714285714285,
-        "selectivity_vocal_tic": 0.6405529953917051,
-        "selectivity_non_directed": 0.6213017751479291,
-        "counts": {
-          "n_simulations": 95,
-          "response_total": 1602,
-          "yield_total": 626,
-          "backchannel_total": 35,
-          "vocal_tic_total": 217,
-          "non_directed_total": 169,
-          "agent_interrupts_count": 460
-        }
-      },
       "retail": {
         "response_latency_mean": 2.682307692307692,
         "yield_latency_mean": 1.0439306358381504,
@@ -151,22 +127,22 @@
       }
     },
     "overall": {
-      "response_latency_mean": 2.628414945713712,
-      "yield_latency_mean": 1.0614886070661966,
-      "response_rate": 0.9275949573141417,
-      "yield_rate": 0.35376009965456323,
-      "agent_interruption_rate": 0.2365647887439655,
-      "selectivity_backchannel": 0.9490783410138248,
-      "selectivity_vocal_tic": 0.6013698222587129,
-      "selectivity_non_directed": 0.4980125186169142,
+      "response_latency_mean": 2.5380343047723932,
+      "yield_latency_mean": 1.0807209863568246,
+      "response_rate": 0.9550621070472367,
+      "yield_rate": 0.35932656524761786,
+      "agent_interruption_rate": 0.2197060271059781,
+      "selectivity_backchannel": 0.989247311827957,
+      "selectivity_vocal_tic": 0.5883087645477155,
+      "selectivity_non_directed": 0.45691609977324266,
       "counts": {
-        "agent_interrupts_count": 1177,
-        "backchannel_total": 82,
-        "n_simulations": 373,
-        "non_directed_total": 456,
-        "response_total": 5084,
-        "vocal_tic_total": 635,
-        "yield_total": 2102
+        "agent_interrupts_count": 717,
+        "backchannel_total": 47,
+        "n_simulations": 278,
+        "non_directed_total": 287,
+        "response_total": 3482,
+        "vocal_tic_total": 418,
+        "yield_total": 1476
       }
     }
   },

--- a/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha_openai_2026-09-09/submission.json
+++ b/web/leaderboard/public/submissions/gpt-live-1-diamond-alpha_openai_2026-09-09/submission.json
@@ -1,5 +1,5 @@
 {
-  "model_name": "gpt-live-1-diamond-alpha",
+  "model_name": "gpt-live-1",
   "model_organization": "OpenAI",
   "submitting_organization": "Sierra",
   "submission_date": "2026-09-09",
@@ -50,7 +50,7 @@
     }
   },
   "voice_config": {
-    "provider": "openai_live",
+    "provider": "OpenAI",
     "model": "gpt-live-1-diamond-alpha",
     "tick_duration_seconds": 0.2,
     "max_steps_seconds": 1200.0,
@@ -146,5 +146,8 @@
       }
     }
   },
-  "reasoning_effort": "medium"
+  "reasoning_effort": "medium",
+  "model_release": {
+    "release_date": "2026-09-10"
+  }
 }

--- a/web/leaderboard/public/submissions/manifest.json
+++ b/web/leaderboard/public/submissions/manifest.json
@@ -49,7 +49,9 @@
     "qwen3-5-omni-plus-realtime_qwen_2026-08-06",
     "grok-voice-think-fast-2-0_xai_2026-08-06",
     "pine-voice-preview-user-sim-v1-0_pineai_2026-08-17",
-    "pine-voice-preview-user-sim-gpt-5-5_pineai_2026-08-17"
+    "pine-voice-preview-user-sim-gpt-5-5_pineai_2026-08-17",
+    "gpt-live-1-diamond-alpha_openai_2026-09-09",
+    "gpt-live-1-diamond-alpha-user-sim-gpt-5-5_openai_2026-09-09"
   ],
   "legacy_submissions": [
     "claude-3-7-sonnet_anthropic_2024-06-20",


### PR DESCRIPTION
## Summary

Adds two GPT Live voice leaderboard submissions covering airline, retail, telecom, and banking_knowledge:

| Submission | Airline | Retail | Telecom | Banking |
|---|---:|---:|---:|---:|
| Standard user simulator | 82.00% | 78.95% | 84.21% | 25.26% |
| GPT-5.5 xhigh user simulator | 78.00% | 84.21% | 96.49% | 31.96% |

Both submissions use the gpt-live-1-diamond-alpha frontend, gpt-6-astra backend at medium reasoning effort, marin voice, regular speech complexity, realtime user generation, seed 300, the default Anthropic hallucination reviewer, and alltools retrieval for banking.

## Trajectories

The complete selected trajectory bundles, including audio artifacts and per-simulation JSON, are uploaded under the public leaderboard prefixes:

- Standard: https://tau-bench-public.s3.us-west-2.amazonaws.com/submissions/gpt-live-1-diamond-alpha_openai_2026-09-09/
- Custom: https://tau-bench-public.s3.us-west-2.amazonaws.com/submissions/gpt-live-1-diamond-alpha-user-sim-gpt-5-5_openai_2026-09-09/

The committed trajectory_files mappings point the website viewer to each uploaded domain directory.

## Validation

- Maintainer review_submission validation passed for all eight domain/result combinations.
- Voice interaction metrics were recomputed from the selected trajectories.
- S3 upload verification passed for both submissions and all public results.json URLs.
- Pydantic schema validation passed for both submission.json files.
- Leaderboard schema freshness check passed.
- Ruff lint and formatting checks passed.

Two null-reward banking infrastructure errors in the standard run are excluded by the repository metrics policy, producing 24/95 (25.26%). The custom banking run has 31/97 (31.96%).