### PR TITLE
fix: preserve checkpoint when replacement trajectory write fails

### DIFF
--- a/src/tau2/runner/checkpoint.py
+++ b/src/tau2/runner/checkpoint.py
@@ -321,12 +321,6 @@ def create_checkpoint_fns(
         ):
             with lock:
                 old_sim_id = _key_to_sim_id.get(key)
-                if old_sim_id:
-                    old_path = sims_dir / f"{old_sim_id}.json"
-                    if old_path.exists():
-                        old_path.unlink()
-                    _index_by_id.pop(old_sim_id, None)
-
                 sim_path = sims_dir / f"{simulation.id}.json"
                 fd, tmp_path = tempfile.mkstemp(
                     suffix=".json", prefix=".sim_", dir=sims_dir
@@ -339,6 +333,15 @@ def create_checkpoint_fns(
                     if os.path.exists(tmp_path):
                         os.unlink(tmp_path)
                     raise
+                # Keep the previous trajectory and index until the new file has
+                # been written successfully. The retry may reuse the same id,
+                # in which case os.replace has already replaced the old file.
+                if old_sim_id:
+                    if old_sim_id != simulation.id:
+                        old_path = sims_dir / f"{old_sim_id}.json"
+                        if old_path.exists():
+                            old_path.unlink()
+                    _index_by_id.pop(old_sim_id, None)
                 _key_to_sim_id[key] = simulation.id
                 _saved_keys.discard(key)
                 _saved_keys.add(key)

--- a/tests/test_results_format.py
+++ b/tests/test_results_format.py
@@ -359,6 +359,53 @@ class TestCheckpointDirFormat:
         assert len(sim_files) == 1
         assert sim_files[0].name == "sim-replacement.json"
 
+    @pytest.mark.parametrize("failure_stage", ["mkstemp", "serialize", "replace"])
+    @pytest.mark.parametrize("reuse_id", [False, True])
+    def test_failed_replacement_preserves_checkpoint(
+        self, tmp_path, monkeypatch, failure_stage, reuse_id
+    ):
+        """A failed trajectory write must preserve the previous checkpoint."""
+        save_path = tmp_path / "results.json"
+        results = Results(info=_make_info(), tasks=[_make_task("t0")], simulations=[])
+        results.save(save_path, format="dir")
+        save_fn, replace_fn = create_checkpoint_fns(save_path, multiprocessing.Lock())
+        original = _make_sim("t0")
+        save_fn(original)
+        replacement = original.model_copy(
+            update={"id": original.id if reuse_id else "replacement", "duration": 120.0}
+        )
+        original_metadata = save_path.read_bytes()
+        sims_dir = tmp_path / SIMULATIONS_DIR
+        original_path = sims_dir / f"{original.id}.json"
+        original_bytes = original_path.read_bytes()
+
+        def fail(*args, **kwargs):
+            raise OSError("injected checkpoint write failure")
+
+        targets = {
+            "mkstemp": "tau2.runner.checkpoint.tempfile.mkstemp",
+            "serialize": "tau2.data_model.simulation.SimulationRun.model_dump_json",
+            "replace": "tau2.runner.checkpoint.os.replace",
+        }
+        with monkeypatch.context() as patch:
+            patch.setattr(targets[failure_stage], fail)
+            with pytest.raises(OSError, match="injected checkpoint write failure"):
+                replace_fn((0, "t0", 42), replacement)
+
+        assert original_path.read_bytes() == original_bytes
+        assert save_path.read_bytes() == original_metadata
+        assert list(sims_dir.iterdir()) == [original_path]
+        assert Results.load(save_path).simulations == [original]
+
+        # A later retry must still replace the original, without duplicate files.
+        replace_fn((0, "t0", 42), replacement)
+        assert Results.load(save_path).simulations == [replacement]
+        assert len(list(sims_dir.iterdir())) == 1
+        metadata = json.loads(save_path.read_text())
+        assert [entry["id"] for entry in metadata["simulation_index"]] == [
+            replacement.id
+        ]
+
     def test_try_resume_dir_format_removes_infra_errors(self, tmp_path):
         save_path = tmp_path / "results.json"
         tasks = [_make_task("t0"), _make_task("t1")]


### PR DESCRIPTION
## Summary
Directory-format checkpoint replacement currently unlinks the previous trajectory before creating or writing the replacement. If temporary-file creation, serialization, or the final rename fails, the previous result is lost while metadata still points to it.

Defer removing the previous trajectory and index entry until the replacement file has been written successfully. A replacement reusing the same simulation ID keeps the file already installed by `os.replace`.

## Changes Made
- Preserve the old trajectory and index on replacement-file write failures.
- Add six failure-injection regression cases (temporary-file creation, serialization, rename; each with a new or reused simulation ID).
- Check unchanged checkpoint bytes, temporary-file cleanup, reloadability, and successful retry without duplicate trajectories/index entries.
- No scoring, task, or persisted-schema changes; no new dependencies.

## Testing
- New regressions against upstream `2174a60`: **6 failed** because the original trajectory had been deleted.
- `pytest tests/test_results_format.py tests/test_checkpoint.py -q`: **55 passed**.
- `make check-all`: passed.
- `make test`: **240 passed, 17 failed, 1 xfailed**. The failing tests call live LLM APIs without configured credentials (one batch test subsequently asserts that messages are nonempty).
- Environment: Python 3.12.11, `uv sync --extra dev`, plus local `websockets`, `scipy`, and `soundfile` for upstream unconditional voice imports. Full voice extra installation hit missing local PortAudio headers; voice integration tests were not run.

## Documentation
The change is limited to recoverability when writing the replacement trajectory fails. It does not make the multi-file trajectory/metadata update crash-atomic.

## Checklist
- [x] Regression tests pass
- [ ] Full core suite passes (live-API tests require credentials)
- [x] Code follows style guidelines (`make check-all`)
- [x] No breaking changes or documentation changes required

## Reproducible evidence
A separate [pinned checkpoint-failure experiment](https://github.com/justavibedev/tau2-bench/tree/ec199b93253cd17e0e457751c8f7aed607770522/src/experiments/checkpoint_failure_recovery) includes the runner, raw results, dependency pins and limitations. It tests six selected I/O failure cases; these are not production failure rates or agent-score measurements.

AI assistance: developed and checked with OpenAI Codex.
