### PR TITLE
fix: construct dummy users without simulator arguments

### DIFF
--- a/src/tau2/runner/build.py
+++ b/src/tau2/runner/build.py
@@ -164,6 +164,8 @@ def build_user(
     # Validate DummyUser usage
     if issubclass(UserConstructor, DummyUser):
         assert solo_mode, "Dummy user can only be used with solo agent"
+        # Solo users have no model, tools, or persona to configure.
+        return UserConstructor()
 
     user_kwargs = {
         "tools": user_tools,

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,6 +1,9 @@
 import pytest
 
-from tau2.data_model.message import AssistantMessage, UserMessage
+from tau2.data_model.message import AssistantMessage, ToolCall, UserMessage
+from tau2.data_model.persona import PersonaConfig, Verbosity
+from tau2.data_model.simulation import TextRunConfig
+from tau2.runner.build import build_text_orchestrator, build_user
 from tau2.user.user_simulator import DummyUser, UserSimulator
 
 
@@ -64,3 +67,77 @@ def test_dummy_user_no_args():
     dummy = DummyUser()
     state = dummy.get_init_state()
     assert state.messages == []
+
+
+def test_build_dummy_user(get_environment, base_task):
+    user = build_user(
+        "dummy_user",
+        get_environment(solo_mode=True),
+        base_task,
+        llm="unused-user-model",
+        llm_args={"temperature": 0.7},
+        persona_config=PersonaConfig(verbosity=Verbosity.MINIMAL),
+        solo_mode=True,
+    )
+    assert isinstance(user, DummyUser)
+    assert user.llm == "dummy"
+    assert user.llm_args == {}
+    assert user.get_init_state().messages == []
+
+
+def test_build_dummy_user_requires_solo_mode(get_environment, base_task):
+    with pytest.raises(AssertionError, match="only be used with solo agent"):
+        build_user("dummy_user", get_environment(), base_task)
+
+
+def test_build_regular_user_preserves_configuration(
+    get_environment, task_with_user_tools
+):
+    environment = get_environment()
+    persona = PersonaConfig(verbosity=Verbosity.MINIMAL)
+    user = build_user(
+        "user_simulator",
+        environment,
+        task_with_user_tools,
+        llm="test-user-model",
+        llm_args={"temperature": 0.7},
+        persona_config=persona,
+    )
+    assert user.llm == "test-user-model"
+    assert user.llm_args == {"temperature": 0.7}
+    assert user.instructions == str(task_with_user_tools.user_scenario)
+    assert user.persona_config == persona
+    assert [tool.name for tool in user.tools] == [
+        tool.name
+        for tool in environment.get_user_tools(include=task_with_user_tools.user_tools)
+    ]
+
+
+def test_solo_runner_initializes_without_user_generation(base_task, monkeypatch):
+    first_message = AssistantMessage(
+        role="assistant",
+        tool_calls=[
+            ToolCall(
+                id="create-task",
+                name="create_task",
+                arguments={"user_id": "user_1", "title": "Important Meeting"},
+                requestor="assistant",
+            )
+        ],
+    )
+    monkeypatch.setattr("tau2.agent.llm_agent.generate", lambda **kwargs: first_message)
+    config = TextRunConfig(
+        domain="mock",
+        agent="llm_agent_solo",
+        user="dummy_user",
+        llm_agent="test-agent-model",
+        llm_user="unused-user-model",
+    )
+    orchestrator = build_text_orchestrator(config, base_task)
+    orchestrator.initialize()
+    assert orchestrator.solo_mode
+    assert isinstance(orchestrator.user, DummyUser)
+    assert orchestrator.step_count == 0
+    assert not orchestrator.done
+    assert orchestrator.user_state.messages == []
+    assert orchestrator.message.tool_calls[0].name == "create_task"


### PR DESCRIPTION
## Summary

Fixes #486, reported by @domdomdominic.

`build_user()` passes simulator configuration to `DummyUser`, whose constructor takes no arguments. A solo run therefore raises `TypeError` before the first episode. Construct the dummy user without arguments inside the existing solo-mode guard. Ordinary user simulators still receive their tools, instructions, model settings and persona configuration.

## Changes Made

- Keep the no-argument `DummyUser()` contract used by the gym path.
- Add builder regressions for solo construction, rejection outside solo mode, and ordinary user configuration forwarding.
- Exercise construction and initialization through `build_text_orchestrator`, using a mocked agent model response. No user generation or live model call is needed by the new tests.
- No scoring, task-data, dependency or persisted-format changes.

## Testing

- Against upstream `2174a603f6d014ef94473ffa95957f6ce27100db`, the two new solo-path regressions fail with the reported constructor error; three controls pass.
- Focused offline user/orchestrator selection: **14 passed**, six tests deselected (including the live-model cases).
- Full core suite with the new tests and unchanged upstream builder: **236 passed, 19 failed, 1 xfailed**. With this fix: **238 passed, 17 failed, 1 xfailed**. The two removed failures are the new regressions; there are no newly failing test IDs.
- The shared 17 failures are live-API tests without credentials, including a downstream empty-result assertion. Full-suite success is not claimed.
- `make check-all` and `git diff --check` pass.

Validation used Python 3.12.11 and the existing dev environment, with `PYTHONPATH=src` selecting this checkout. Voice integration and a complete live-model solo episode were not run. The unchanged direct-construction test covers the gym constructor contract; the gym integration suite was not run.

## Documentation

The change restores the existing runner/constructor contract; no user-facing option changes are introduced.

AI assistance: developed and checked with OpenAI Codex.
